### PR TITLE
docs: stewardship index entries for Multi-Agent Communication Architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ artifacts/store/
 # Stale runtime artifacts (WSL/Windows filesystem side-effects)
 /nul
 /test_budget_concurrency.db
+artifacts/replay_cache/

--- a/docs/01_governance/ARTEFACT_INDEX.json
+++ b/docs/01_governance/ARTEFACT_INDEX.json
@@ -17,6 +17,7 @@
     "constitution": "docs/00_foundations/LifeOS_Constitution_v2.0.md",
     "anti_failure": "docs/00_foundations/Anti_Failure_Operational_Packet_v0.1.md",
     "architecture_skeleton": "docs/00_foundations/Architecture_Skeleton_v1.0.md",
+    "multi_agent_comm_arch": "docs/00_foundations/ARCH_Multi_Agent_Communication_Architecture.md",
     "_comment_governance": "=== 01_governance: Governance Contracts ===",
     "coo_contract": "docs/01_governance/COO_Operating_Contract_v1.0.md",
     "agent_constitution": "docs/01_governance/AgentConstitution_GEMINI_Template_v1.0.md",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,6 @@
 # LifeOS Strategic Corpus [P26-02-28 (rev12)]
 
-Last Updated: 2026-03-10
+Last Updated: 2026-04-20
 
 **Authority**: [LifeOS Constitution v2.0](./00_foundations/LifeOS_Constitution_v2.0.md)
 
@@ -76,6 +76,7 @@ LifeOS Constitution v2.0 (Supreme)
 | [Architecture_Skeleton_v1.0.md](./00_foundations/Architecture_Skeleton_v1.0.md) | High-level conceptual architecture (CEO/COO/Worker layers) |
 | [Tier_Definition_Spec_v1.1.md](./00_foundations/Tier_Definition_Spec_v1.1.md) | **Canonical** — Tier progression model, definitions, and capabilities |
 | [ARCH_Future_Build_Automation_Operating_Model_v0.2.md](./00_foundations/ARCH_Future_Build_Automation_Operating_Model_v0.2.md) | **Architecture Proposal** — Future Build Automation Operating Model v0.2 |
+| [ARCH_Multi_Agent_Communication_Architecture.md](./00_foundations/ARCH_Multi_Agent_Communication_Architecture.md) | **Architecture** — Multi-agent communication bus, authority boundaries, promotion flow, briefing projection |
 | [lifeos-agent-architecture.md](./00_foundations/lifeos-agent-architecture.md) | **Architecture** — Non-canonical agent architecture |
 | [lifeos-maximum-vision.md](./00_foundations/lifeos-maximum-vision.md) | **Vision** — Non-canonical maximum vision architecture |
 


### PR DESCRIPTION
## Summary

Registers the Multi-Agent Communication Architecture doc in the canonical index and navigation index.

The doc itself (`docs/00_foundations/ARCH_Multi_Agent_Communication_Architecture.md`) already landed on `origin/main` via direct commit `17fe8ad2`. This PR adds the missing stewardship entries only.

## Changes

- `docs/INDEX.md` — added entry under `00_foundations`
- `docs/01_governance/ARTEFACT_INDEX.json` — added `multi_agent_comm_arch` entry under FOUNDATIONAL section
- `.gitignore` — excluded `artifacts/replay_cache/` (transient cache)

## Source

- Google Doc: https://docs.google.com/document/d/1DdGKOxR3KXnMuUYR4wNK7htL_CTjopnyPmesVCvC38Y
- Work order: https://github.com/marcusglee11/lifeos-operational-bus/issues/8

🤖 Generated with Claude Code