### PR TITLE
docs: prepare Pro authority audit context

### DIFF
--- a/docs/audit/LIFEOS_AUTHORITY_AUDIT_MANIFEST.md
+++ b/docs/audit/LIFEOS_AUTHORITY_AUDIT_MANIFEST.md
@@ -1,0 +1,156 @@
+# LifeOS Authority Audit Manifest
+
+Status: Pro-level audit context manifest
+Owner: CEO / active COO stewardship
+Audit target commit: `d94e51afd1c076393a32d7d7e94e893a33e82185`
+Prepared for: cross-project authority, approval, delegation, pushback, evidence, and state-machine audit
+
+This manifest is a launch surface for a scarce Pro-level Thinking audit. It is not a new canonical architecture decision and does not modify authority semantics by itself.
+
+---
+
+## 1. Audit target
+
+| Field | Value |
+| --- | --- |
+| Repo | `marcusglee11/LifeOS` |
+| Branch | `main` |
+| Commit SHA | `d94e51afd1c076393a32d7d7e94e893a33e82185` |
+| Manifest path | `docs/audit/LIFEOS_AUTHORITY_AUDIT_MANIFEST.md` |
+| Scope | Authority, approval, proxy approval, StepGate, Council Runtime, OpenClaw/Hermes authority, work item lifecycle, receipts/evidence, state transitions |
+
+## 2. Canonicality rule for the auditor
+
+Treat artefacts in this priority order:
+
+1. Constitution and governance rulings
+2. Architecture Source of Truth and ratified ADRs
+3. COO Operating Contract
+4. Canonical operational architecture
+5. Current protocol specs
+6. Current schemas/tests
+7. Current runtime state and backlog trackers
+8. Current wiki only when mechanically derived and up to date
+9. Proposal/draft docs only where explicitly marked non-canonical
+10. Archived docs and conversation memory — never canonical by themselves
+
+Draft/proposal documents are not binding unless ratified. If a draft conflicts with a canonical document, the canonical document wins and the draft should be treated as evidence of unresolved or rejected design pressure, not operative policy.
+
+## 3. Required artefacts
+
+### A. Canonical architecture truth
+
+| Artefact | Path | Canonical? | Notes |
+| --- | --- | --- | --- |
+| Architecture Source of Truth | `docs/10_meta/ARCHITECTURE_SOURCE_OF_TRUTH.md` | Orientation/control surface | Current canon/proposal/stale map; says it is not itself the deepest authority |
+| Architecture Changelog | `docs/10_meta/ARCHITECTURE_CHANGELOG.md` | Control log | Architecture deltas and normalization amendments |
+| ADR / decision index | `docs/10_meta/architecture_decisions/INDEX.md` | Active register | Ratified decisions only; ADR-001 through ADR-004 |
+| Docs index | `docs/INDEX.md` | Navigation/control index | Current repo navigation and authority chain |
+| Strategic corpus | `docs/LifeOS_Strategic_Corpus.md` | Derived context | Use as orientation only; canonical docs win on conflict |
+| Wiki schema | `.context/wiki/SCHEMA.md` | Derived-surface schema | Use only to understand derived wiki constraints |
+| Wiki home | `.context/wiki/home.md` | Derived surface | Use only if source_commit/source freshness is valid |
+
+### B. COO authority and operating contract
+
+| Artefact | Path | Canonical? | Notes |
+| --- | --- | --- | --- |
+| COO Operating Contract | `docs/01_governance/COO_Operating_Contract_v1.0.md` | Canonical governance contract | Main authority surface for CEO/COO/agent boundaries |
+| ADR-001 Active/standby + sole-writer | `docs/10_meta/architecture_decisions/INDEX.md` | Ratified | See ADR-001 section |
+| ADR-002 Inter-agent directionality | `docs/10_meta/architecture_decisions/INDEX.md` | Ratified | See ADR-002 section |
+| ADR-003 Human approval capture | `docs/10_meta/architecture_decisions/INDEX.md` | Ratified | See ADR-003 section |
+| ADR-004 Drive/Workspace role | `docs/10_meta/architecture_decisions/INDEX.md` | Ratified | See ADR-004 section |
+| Agent roles reference | `docs/00_foundations/Agent_Roles_Reference_v1.0.md` | Non-authoritative orientation | Loses to canonical governance docs on conflict |
+
+### C. StepGate and approval semantics
+
+| Artefact | Path | Canonical? | Notes |
+| --- | --- | --- | --- |
+| StepGate protocol | `docs/09_prompts/v1.0/protocols/stepgate_protocol_v1.0.md` | Protocol surface | Explicit gate sequencing and approval semantics |
+| Human approval capture contract | `docs/01_governance/COO_Operating_Contract_v1.0.md` | Canonical | §9, including binding tuple and ambiguity fails closed |
+| Approval capture ADR | `docs/10_meta/architecture_decisions/INDEX.md` | Ratified | ADR-003 |
+| G-CBS standard | `docs/02_protocols/G-CBS_Standard_v1.1.md` | Protocol | Include if audit needs governance/build-control semantics |
+| Deterministic artefact protocol | `docs/02_protocols/Deterministic_Artefact_Protocol_v2.0.md` | Protocol | Include if audit needs artefact/receipt semantics |
+
+### D. Council Runtime / governance protocol
+
+| Artefact | Path | Canonical? | Notes |
+| --- | --- | --- | --- |
+| Council Protocol | `docs/02_protocols/Council_Protocol_v1.3.md` | Canonical | Current council review procedure |
+| Council Procedural Specification | `docs/02_protocols/AI_Council_Procedural_Spec_v1.1.md` | Runbook | Executes council procedure |
+| Council invocation binding | `docs/01_governance/Council_Invocation_Runtime_Binding_Spec_v1.1.md` | Governance spec | Invocation/runtime binding rules |
+| Intent routing | `docs/02_protocols/Intent_Routing_Rule_v1.1.md` | Protocol | CEO/CSO/Council/runtime routing |
+| Council context pack schema | `docs/02_protocols/Council_Context_Pack_Schema_v0.3.md` | Schema | Council context pack structure |
+| Reviewer prompts | `docs/09_prompts/v1.2/` | Current prompts | Use as role-prompt reference, not higher authority than protocol |
+
+### E. Work item lifecycle and task schemas
+
+| Artefact | Path | Canonical? | Notes |
+| --- | --- | --- | --- |
+| Runtime state ledger | `docs/11_admin/LIFEOS_STATE.md` | Canonical tracker | Current operational state |
+| Runtime work tracker | `docs/11_admin/BACKLOG.md` | Canonical tracker | Actionable work tracker |
+| COO schemas | `artifacts/coo/schemas.md` | Schema/reference | Contains `task_proposal.v1`, `execution_order.v1`, `escalation_packet.v1` |
+| COO parser | `runtime/orchestration/coo/parser.py` | Runtime implementation | Use for actual schema parsing/enforcement reality |
+| Runtime spec | `docs/03_runtime/COO_Runtime_Spec_v1.0.md` | Runtime spec | Mechanical execution contract/FSM/determinism |
+| Runtime core spec | `docs/03_runtime/COO_Runtime_Core_Spec_v1.0.md` | Runtime spec | Extended core specification |
+| Build handoff protocol | `docs/02_protocols/Build_Handoff_Protocol_v1.1.md` | Protocol | Handoff architecture for agent coordination |
+| Project planning protocol | `docs/02_protocols/Project_Planning_Protocol_v1.0.md` | Protocol | Mission plan requirements and lifecycle |
+
+### F. OpenClaw / Hermes / agent runtime operations
+
+| Artefact | Path | Canonical? | Notes |
+| --- | --- | --- | --- |
+| OpenClaw COO integration | `docs/02_protocols/OpenClaw_COO_Integration_v1.0.md` | Protocol | Gateway invocation, CLI wrappers, known constraints |
+| OpenClaw integration wiki | `.context/wiki/openclaw-integration.md` | Derived surface | Use only if fresh against source commits |
+| Multi-agent communication architecture | `docs/00_foundations/ARCH_Multi_Agent_Communication_Architecture.md` | Proposal-only / non-canonical | Important contradiction-pressure source; loses to COO contract and ADRs |
+| Agent roles reference | `docs/00_foundations/Agent_Roles_Reference_v1.0.md` | Non-authoritative orientation | Actor taxonomy and autonomy levels |
+| Build loop architecture | `docs/03_runtime/LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` | Canonical per docs index | Use for autonomous build-loop semantics |
+| Runtime hardening / clean build | `docs/03_runtime/COO_Runtime_Clean_Build_Spec_v1.1.md` | Spec | Use for runtime build constraints where relevant |
+| OpenClaw OAuth recovery guide | `docs/02_protocols/guides/OpenClaw_Codex_OAuth_Recovery_v1.0.md` | Operational guide | Include only for current OpenClaw operational constraints |
+
+### G. Representative examples
+
+| Example | Path / PR / issue | Notes |
+| --- | --- | --- |
+| Architecture normalization reset | PR #28 | Adds architecture control surfaces and review packet |
+| COO authority amendment | PR #36 | Ratifies active/standby sole-writer and Hermes/OpenClaw directionality |
+| Human approval capture | PR #38 and main squashed lineage | PR body captures §9 contract and validation; final main content is authoritative |
+| Drive/Workspace role | PR #39 and main squashed lineage | PR closed unmerged, but content later landed in main lineage; final main content is authoritative |
+| Architecture maintenance rule | PR #40 | Event-triggered pre-merge architecture impact rule |
+| Review packet: architecture normalization | `artifacts/review_packets/Review_Packet_Architecture_Normalization_Reset_v1.0.md` | Representative review artefact |
+| Review packet: A1/A2 StepGate | `artifacts/review_packets/Review_Packet_A1_A2_StepGate_v1.0.md` | Representative StepGate review artefact |
+| Closure process review | `artifacts/review_packets/Review_Packet_Closure_Process_20260216_v1.0.md` | Representative closure evidence process |
+
+## 4. Known stale / non-canonical / caution surfaces
+
+| Artefact | Path | Classification | Replacement / caution |
+| --- | --- | --- | --- |
+| Multi-agent communication architecture | `docs/00_foundations/ARCH_Multi_Agent_Communication_Architecture.md` | Proposal-only, non-canonical | Loses to COO contract §§7–9 and ADR-001 through ADR-004 |
+| Architecture skeleton | `docs/00_foundations/Architecture_Skeleton_v1.0.md` | Stale conceptual explainer | Use canonical target architecture instead |
+| Legacy changelog | `docs/10_meta/CHANGELOG.md` | Stale repository changelog | Use `docs/10_meta/ARCHITECTURE_CHANGELOG.md` |
+| Autonomy status | `docs/11_admin/AUTONOMY_STATUS.md` | Derived/stale orientation | Use canonical state/backlog and COO contract |
+| Archive docs | `docs/99_archive/**` | Historical only | Not canonical unless explicitly referenced by a current canonical doc |
+| PR #26/#27 claims | GitHub PRs #26/#27 | Superseded/unsafe | Use later normalization decisions and source-of-truth page |
+
+## 5. Known open decisions / pressure points
+
+| ID | Decision needed | Why it matters | Candidate owner |
+| --- | --- | --- | --- |
+| OD-001 | Whether advisory lifecycle / receipt model should be promoted from draft to canon | Current draft contains useful semantics but remains non-canonical | CEO / active COO / council if invoked |
+| OD-002 | Whether work item lifecycle states need formal schema-level enforcement beyond current tracker/parser surfaces | Recent reviews identified possible review-return and closure-evidence gaps | Active COO |
+| OD-003 | Whether Hermes/OpenClaw authority language should be represented as machine-checkable policy | ADR-002 is canonical prose; runtime enforcement may lag | Active COO / runtime owner |
+| OD-004 | Whether approval receipts should become a dedicated typed schema rather than fields embedded in operational state | COO contract §9 defines tuple; enforcement surface may need hardening | Active COO / runtime owner |
+
+## 6. Out of scope for the Pro audit
+
+- Broad web research
+- Tool/vendor comparison
+- Generic multi-agent framework design
+- New feature design not required by authority/evidence reconciliation
+- Quant/trading strategy design
+- Productisation strategy
+
+## 7. Context sufficiency expectation
+
+Categories A–F are populated for a valid audit. Category G has representative examples but should be checked for whether PR bodies, merged commits, and current main-line files agree.
+
+The audit should proceed only after verifying that all listed paths exist at the pinned commit and that proposal-only surfaces are not accidentally treated as canonical.

--- a/docs/audit/LIFEOS_AUTHORITY_AUDIT_PREFLIGHT_PROMPT.md
+++ b/docs/audit/LIFEOS_AUTHORITY_AUDIT_PREFLIGHT_PROMPT.md
@@ -1,0 +1,55 @@
+# LifeOS Authority Audit — Preflight Prompt
+
+Use this prompt with a normal agent/model before spending a Pro-level Thinking query.
+
+```text
+You are preparing context for a later Pro-level Thinking audit.
+
+Repository context:
+- Repo: marcusglee11/LifeOS
+- Branch: main
+- Pinned audit commit: d94e51afd1c076393a32d7d7e94e893a33e82185
+- Manifest: docs/audit/LIFEOS_AUTHORITY_AUDIT_MANIFEST.md
+
+Task:
+Inspect the manifest and the connected GitHub repo at the pinned commit.
+
+Do not perform the architecture audit.
+Do not propose architecture fixes.
+Do not broaden into web research.
+Do not use memory from other chats.
+
+Verify:
+1. Whether categories A–F are sufficiently populated.
+2. Whether every listed path exists at the pinned commit.
+3. Whether proposal-only, stale, superseded, or archive docs are clearly marked.
+4. Whether representative examples in category G are adequate.
+5. Whether any missing artefacts would invalidate the later Pro audit.
+
+Output only:
+
+A. CONTEXT SUFFICIENCY VERDICT
+- SUFFICIENT / PARTIAL / INSUFFICIENT
+
+B. MISSING OR WEAK CONTEXT
+- category
+- missing/weak artefact
+- why required
+
+C. PATH VALIDATION
+- found
+- missing
+- ambiguous
+
+D. CANONICALITY VALIDATION
+- canonical surfaces confirmed
+- proposal/stale/archive surfaces confirmed
+- unresolved canonicality risks
+
+E. DO NOT SPEND PRO QUERY YET?
+- yes/no
+- reason
+
+Acceptance rule:
+Only answer NO under section E if categories A–F are populated, paths resolve, and canonicality/draft distinctions are clear enough for the later audit.
+```

--- a/docs/audit/LIFEOS_AUTHORITY_AUDIT_PRO_PROMPT.md
+++ b/docs/audit/LIFEOS_AUTHORITY_AUDIT_PRO_PROMPT.md
@@ -1,0 +1,349 @@
+# LifeOS Authority Audit — Pro-Level Launch Prompt
+
+Use this only after `docs/audit/LIFEOS_AUTHORITY_AUDIT_PREFLIGHT_PROMPT.md` returns `SUFFICIENT` or `PARTIAL` with no blocking context gaps.
+
+```text
+You are acting as a formal architecture auditor for my LifeOS / COO Operating Console project.
+
+Source context:
+Use the connected GitHub repo as the source of truth.
+
+Audit target:
+- Repo: marcusglee11/LifeOS
+- Branch: main
+- Commit SHA: d94e51afd1c076393a32d7d7e94e893a33e82185
+- Manifest: docs/audit/LIFEOS_AUTHORITY_AUDIT_MANIFEST.md
+
+Before auditing, inspect the manifest and confirm context sufficiency.
+
+Mission:
+Derive the smallest coherent authority, approval, evidence, delegation, pushback, and execution-state model that can govern the whole system without ambiguity, circular authority, silent bypasses, or false agency.
+
+This is not a literature review.
+Do not perform broad web research.
+Do not give generic governance or agent-framework advice.
+Use only the connected repo context and the manifest.
+Do not rely on prior memory.
+Where artefacts conflict, identify the conflict explicitly.
+Where required artefacts are missing, mark the issue as UNKNOWN rather than inventing a rule.
+
+If categories A–F in the manifest are not sufficiently provided, stop and return:
+
+CONTEXT INSUFFICIENT FOR 10/10 AUDIT
+
+Then list the missing artefacts required to make the audit valid.
+
+If representative examples are weak or missing, proceed only if A–F are sufficient, and mark the practical-example coverage as weak.
+
+Project context:
+I am building LifeOS / COO Operating Console: a governance-aware COO/Chief-of-Staff interface that converts intent into bounded, auditable, fail-closed actions. The system uses deterministic execution loops, StepGate approval semantics, typed workflows, receipt-based evidence, state transitions, agent delegation, and multi-agent review.
+
+Major streams:
+
+1. LifeOS / COO Operating Console
+- Governance-aware COO/Chief-of-Staff interface
+- Deterministic execution loops
+- StepGate approval semantics
+- Receipts-first CI/CD
+- Fail-closed governance
+- Typed workflows such as execution_order.v1, task_proposal.v1, escalation_packet.v1
+- Auditability, evidence gates, deterministic state transitions
+
+2. Council Runtime / Governance Architecture
+- Multi-agent review protocol
+- Policy packs
+- FSM orchestration
+- Independence constraints
+- Schema enforcement
+- Contradiction ledgers
+- Canonical hashes / RFC 8785-style signing
+- Proportional tiering T0–T3
+
+3. OpenClaw / Hermes / Agent Runtime Operations
+- COO/ingress/router/status rendering
+- External execution harnesses
+- Agent authority
+- Proxy approval
+- Pushback rights
+- Bus/communication architecture
+- Low-friction ops via Windows Terminal, WSL2, GCP, GitHub, Codex/Claude/Copilot agents
+
+Core audit question:
+What is the single canonical model of authority, approval, delegation, pushback, evidence, and execution-state advancement that should govern this whole system?
+
+Audit tasks:
+
+1. Authority taxonomy
+
+Define the precise difference between:
+- user intent
+- CEO approval
+- delegated/proxy approval
+- COO direction
+- agent recommendation
+- agent execution order
+- reviewer finding
+- reviewer veto
+- escalation
+- pushback
+- advisory comment
+- runtime status report
+- evidence receipt
+
+For each term, specify:
+- whether it is binding
+- who or what may issue it
+- what evidence is required
+- what state transition, if any, it can authorize
+
+2. Authority hierarchy
+
+Determine who or what can bind whom:
+- user / CEO
+- COO layer
+- Council reviewers
+- OpenClaw
+- Hermes
+- execution agents
+- coding agents
+- CI/runtime validators
+- schemas/policy packs
+- receipts and state machines
+
+Identify where authority is:
+- human
+- delegated
+- mechanical
+- advisory
+- evidentiary
+- invalid
+
+3. Approval semantics
+
+Define exactly when human approval is required, when it can be proxied, when it cannot be proxied, and what evidence must exist for approval to be valid.
+
+Resolve:
+- Can COO approve on behalf of the CEO?
+- Can OpenClaw or Hermes relay an approval?
+- Can an agent infer approval from prior context?
+- Can a Council recommendation become binding?
+- Can a validator block a human-approved action?
+- Can an agent push back against a CEO-approved task?
+- What makes a StepGate transition valid?
+- What makes approval invalid, stale, ambiguous, or non-transferable?
+
+4. Pushback rights
+
+Define when an agent or reviewer:
+- must comply
+- may recommend changes
+- must push back
+- must refuse
+- must escalate
+- may block execution
+- may only record a warning
+
+Separate:
+- safety pushback
+- governance pushback
+- correctness pushback
+- scope pushback
+- preference pushback
+- cost/efficiency pushback
+
+5. Evidence and receipt semantics
+
+Define the minimum evidence required for:
+- task creation
+- triage
+- dispatch
+- execution start
+- review return
+- fixes requested
+- approval
+- closure
+- rejection
+- escalation
+- deployment
+- post-run reconciliation
+
+Distinguish:
+- claim
+- observation
+- receipt
+- proof
+- validator result
+- audit record
+
+6. State-machine implications
+
+Audit the work item lifecycle and StepGate model for:
+- missing transitions
+- overloaded states
+- ambiguous states
+- invalid shortcuts
+- review-return gaps
+- closure-evidence weakness
+- dispatch/in-progress ambiguity
+- blocked/awaiting-agent ambiguity
+- bypass paths
+
+Propose a corrected minimal transition model.
+
+7. Contradiction ledger
+
+Produce a ledger of contradictions, tensions, or unresolved ambiguities across the artefacts.
+
+For each item include:
+- ID
+- source artefacts / sections
+- conflicting claims
+- why it matters
+- severity: BLOCKING / MAJOR / MINOR
+- proposed resolution
+- invariant or schema/test that would prevent recurrence
+
+8. Canonical invariant set
+
+Derive the smallest set of non-negotiable invariants needed to make the system fail-closed and auditable.
+
+Each invariant must be:
+- short
+- testable
+- enforceable by schema, state machine, CI, receipt check, or explicit human gate
+- mapped to the failure mode it prevents
+
+9. Minimal schema amendments
+
+Recommend minimal amendments to:
+- execution_order.v1
+- task_proposal.v1
+- escalation_packet.v1
+- review packet structures
+- receipt structures
+- lifecycle state records
+- approval records
+
+Do not over-design.
+Only include fields required to remove ambiguity or enforce invariants.
+
+10. Acceptance tests / proof cases
+
+Design concrete proof cases for:
+- valid human approval
+- invalid inferred approval
+- proxy approval attempt
+- relayed approval
+- stale approval
+- ambiguous approval
+- reviewer requests fixes
+- reviewer veto
+- agent pushback against unsafe task
+- agent pushback against merely suboptimal task
+- CI validator blocks an approved task
+- closure without sufficient receipt
+- OpenClaw/Hermes authority conflict
+- StepGate advancement without explicit “go”
+
+Output format:
+
+A. Context sufficiency verdict
+- CONTEXT SUFFICIENT FOR 10/10 AUDIT
+- CONTEXT PARTIAL — AUDIT VALID BUT LIMITED
+- CONTEXT INSUFFICIENT FOR 10/10 AUDIT
+
+B. Executive verdict
+- Is the current authority/evidence model coherent?
+- If not, what is the main architectural defect?
+
+C. Canonical authority model
+- taxonomy
+- hierarchy
+- binding/non-binding distinction
+- invalid authority forms
+
+D. Approval and proxy-approval model
+- allowed cases
+- prohibited cases
+- required evidence
+- invalid approval patterns
+
+E. Pushback and escalation model
+- comply
+- warn
+- recommend
+- push back
+- refuse
+- escalate
+- block
+
+F. Evidence and receipt model
+- claim vs observation vs receipt vs proof
+- minimum evidence by lifecycle stage
+- evidence insufficient for closure
+
+G. Corrected lifecycle/state-machine model
+- states
+- transitions
+- guards
+- required fields
+- terminal states
+- prohibited shortcuts
+
+H. Contradiction ledger
+Table columns:
+- ID
+- source artefact / section
+- conflict
+- severity
+- why it matters
+- proposed fix
+- invariant/test
+
+I. Minimal invariant set
+For each invariant:
+- invariant ID
+- statement
+- enforcement mechanism
+- failure mode prevented
+
+J. Minimal schema amendments
+For each amendment:
+- target artefact/schema
+- exact field/enum/rule change
+- reason
+- enforcement mechanism
+
+K. Acceptance test suite
+For each test:
+- test name
+- scenario
+- expected result
+- enforcement layer
+
+L. Implementation sequence
+- surgical amendment order
+- what to change first
+- what to defer
+- what not to build yet
+
+Constraints:
+Be blunt.
+
+Prefer a smaller coherent model over a comprehensive but unwieldy model.
+
+Do not preserve existing terminology if it causes ambiguity; rename it.
+
+Do not invent authority where no artefact supports it.
+
+Do not let convenience override fail-closed governance.
+
+Any proposed rule must be enforceable or explicitly marked as advisory.
+
+Any unresolved issue must be listed as an open decision, not buried in prose.
+
+When citing evidence, cite artefact names and section headings or line references where available.
+
+The success condition is not “more architecture.”
+The success condition is a smaller, stricter, enforceable authority and evidence model that prevents ambiguity, bypass, false agency, and invalid state advancement.
+```


### PR DESCRIPTION
## Summary

- Adds `docs/audit/LIFEOS_AUTHORITY_AUDIT_MANIFEST.md` as the pinned context manifest for a Pro-level authority/evidence audit.
- Adds `docs/audit/LIFEOS_AUTHORITY_AUDIT_PREFLIGHT_PROMPT.md` for cheap context sufficiency verification before spending the Pro query.
- Adds `docs/audit/LIFEOS_AUTHORITY_AUDIT_PRO_PROMPT.md` as the final launch prompt once preflight passes.

## Architecture impact

Architecture impact: none

Reason: this PR adds audit-preparation launch surfaces only. It does not change canon, authority semantics, approval capture, writer boundaries, state-machine semantics, receipt models, or operational behavior.

## Audit target

- Repo: `marcusglee11/LifeOS`
- Branch: `main`
- Commit SHA: `d94e51afd1c076393a32d7d7e94e893a33e82185`
- Manifest: `docs/audit/LIFEOS_AUTHORITY_AUDIT_MANIFEST.md`

## Test plan

- Path existence checked for key manifest anchors via GitHub connector:
  - `docs/10_meta/ARCHITECTURE_SOURCE_OF_TRUTH.md`
  - `docs/10_meta/architecture_decisions/INDEX.md`
  - `docs/01_governance/COO_Operating_Contract_v1.0.md`
  - `docs/INDEX.md`
  - `docs/09_prompts/v1.0/protocols/stepgate_protocol_v1.0.md`
  - `docs/02_protocols/Council_Protocol_v1.3.md`
  - `artifacts/coo/schemas.md`
- Full repo tests not run; docs-only preparation PR.

## Use

1. Run the preflight prompt with a normal model/agent.
2. Spend the Pro-level query only if preflight returns `SUFFICIENT` or `PARTIAL` with no blocking context gaps.
3. Use the Pro prompt as the launch packet.