### PR TITLE
docs: ratify WP2 CEO decision planning

### DIFF
--- a/artifacts/plans/WP2_CEO_DECISION_PACKET_2026-04-27.md
+++ b/artifacts/plans/WP2_CEO_DECISION_PACKET_2026-04-27.md
@@ -1,141 +1,118 @@
 # WP2 — CEO Decision Packet: Authority Audit Follow-Up
 
-**Status:** Proposal — decision packet for CEO review
+**Status:** RATIFIED — CEO decisions incorporated
+**Ruling date:** 2026-04-27
+**Ruling source:** CEO ruling (this session)
+**Branch:** `wp2/ratify-ceo-decisions`
 **Owner:** Active COO
 **Source:** `docs/audit/LIFEOS_AUTHORITY_AUDIT_RESULT_2026-04-27.md` §H (C-003, C-008, C-009, C-010), §Open Decisions (OD-AUDIT-003, OD-AUDIT-004, OD-AUDIT-006)
-**Date:** 2026-04-27
-**Branch:** none — decision packet only; no binding changes implemented
 
 ---
 
-## Decision 1: G-CBS — ratify, demote, or replace (OD-AUDIT-003, C-008)
+## CEO Ruling
 
-### Problem
-
-G-CBS Standard (`docs/02_protocols/G-CBS_Standard_v1.1.md`) is listed as "Protocol" in the audit manifest but has `Draft` status markers. The Council Protocol v1.3 treats the G-CBS closure bundle as gating, but the standard itself says draft/CT-2. This creates a circular dependency: closure requirements reference an unratified standard.
-
-### Options
-
-| Option | Effect | Risk |
-|---|---|---|
-| **A: Ratify G-CBS** — Promote through required governance process, list in authoritative index, update version to ratified | Removes closure dependency uncertainty; G-CBS becomes fully canonical | Requires Council/CEO process; may expose additional design gaps |
-| **B: Demote to draft** — Remove binding G-CBS references from Council Protocol; make G-CBS advisory only | Unblocks closure without ratification; G-CBS stays as reference | Loss of closure-evidence standardisation guidance |
-| **C: Replace with minimal closure standard** — Define a lightweight closure-evidence schema in the audit's AL1 sequence (see WP4); retire G-CBS dependency | Cleanest path if G-CBS scope exceeds what closure actually needs | Adds schema work; may duplicate effort |
-
-### Recommendation
-
-**Option A (ratify)** if the CEO wants G-CBS as the canonical closure-evidence standard.
-**Option B (demote)** if the CEO wants closure unblocked now and is willing to defer G-CBS ratification.
-
-The audit's AL1 implementation sequence (§L1) already defers full G-CBS resolution to step 8. This is consistent with Option B allowing WP4 to proceed.
-
-### CEO decision needed
-
-Choose A, B, or C. If A, specify ratification route (Council ruling, CEO decree, or PR). If B or C, specify whether `Council_Protocol_v1.3.md` should be patched to remove binding G-CBS references.
+The following five decisions are final and binding for WP2 planning and future implementation. They do not authorize runtime parser/FSM changes, G-CBS ratification, lifecycle migration, or exhaustive artefact-path audit.
 
 ---
 
-## Decision 2: Council Protocol reference alignment (C-003, OD-AUDIT-006)
+## D1 — G-CBS (OD-AUDIT-003, C-008)
 
-### Problem
+**Decision:** Do not ratify G-CBS now.
 
-The current Council Protocol is v1.3, but binding/procedural docs reference older versions:
+**Ruling:**
+- Demote G-CBS as binding for current closure enforcement.
+- Remove or patch binding G-CBS dependencies where they block closure.
+- `WP4/closure_receipt.v1` is to become the minimal canonical closure-evidence standard for current lifecycle closure, once WP4 is approved.
+- G-CBS may remain draft/advisory pending later ratification or retirement.
 
-| Doc | Reference | Issue |
-|---|---|---|
-| `Council_Invocation_Runtime_Binding_Spec_v1.1.md` | Binds to unspecified council protocol version | Version gap not auditable |
-| `AI_Council_Procedural_Spec_v1.1.md` | References procedural steps that may differ from v1.3 | Stale procedure risk |
-| `Council_Context_Pack_Schema_v0.3.md` | Schema version may not match v1.3 protocol | Schema drift |
-| `Intent_Routing_Rule_v1.1.md` | References older intent routing that may conflict | Routing authority confusion |
+**Rationale preserved from proposal:** G-CBS standard is draft/CT-2 while the Council Protocol v1.3 treats it as gating — a circular dependency. Demotion unblocks closure without requiring full ratification process. WP4's lightweight closure standard is the cleaner path for current needs.
 
-### Options
-
-| Option | Effect | Effort |
-|---|---|---|
-| **A: Version-bump all binding docs** — Update each doc's protocol version reference to v1.3; verify procedural/context mappings | Clean authority; stale docs become current | Medium: 4-6 doc edits + review |
-| **B: Pin to a version table** — Create a single `docs/01_governance/PROTOCOL_VERSION_REGISTER.md` that maps protocol surfaces to current versions; update register instead of each doc | Single source of truth for version binding | Low: one new doc + edit existing docs to reference register |
-| **C: Defer** — Mark as known stale; audit C-003 documents the gap; fix when Council Protocol next receives a material revision | Zero immediate effort; gap documented | Gap persists |
-
-### Recommendation
-
-**Option B (version register)** — lowest long-term maintenance cost. The register can be a simple YAML/table and be referenced by docs, CI lints, and version-check tests.
-
-### CEO decision needed
-
-Approve approach and timeline (immediate vs deferred to next Council Protocol revision).
+**Effect on docs:** Any binding G-CBS reference in `Council_Protocol_v1.3.md` or related governance docs must be patched or annotated as advisory in the implementation pass.
 
 ---
 
-## Decision 3: DAP path/status consistency (C-009)
+## D2 — Council Protocol reference alignment (C-003, OD-AUDIT-006)
 
-### Problem
+**Decision:** Approve Option B — create `PROTOCOL_VERSION_REGISTER.md`.
 
-The Deterministic Artefact Protocol (DAP) claims canonical placement/status and mandatory Gate 3 for artefacts, but path/status references appear inconsistent with actual repo usage and protocol workflows.
+**Ruling:**
+- Create `docs/01_governance/PROTOCOL_VERSION_REGISTER.md` as the source of truth for current Council/protocol version bindings.
+- Do not mass-bump dependent docs merely to say v1.3 unless semantic compatibility is verified.
+- Mark stale dependent references through the register (i.e. the register notes which docs are verified-compatible vs. stale).
 
-### Options
+**Rationale preserved from proposal:** Single source of truth for version binding; lowest long-term maintenance cost; referenced by docs, CI lints, and version-check tests.
 
-| Option | Effect | Effort |
-|---|---|---|
-| **A: Normalise DAP to current practice** — Update DAP path/status to reflect actual repo usage; add explicit artefact-type exceptions | Honest canonical doc; artefact creation not over-blocked | Low: 1 doc edit |
-| **B: Demote DAP to advisory** — Mark DAP as guidance rather than binding protocol for audit/result artefacts | Simplest path; removes Gate 3 constraint for non-standard artefacts | Low: classification change |
-| **C: Audit all artefact paths** — Exhaustive cross-reference of DAP vs all artefact paths in repo | Most thorough; highest effort | High |
-
-### Recommendation
-
-**Option A** — the audit's C-009 is MINOR severity, suggesting a lightweight normalisation is appropriate. Define in DAP that AWK/audit/result artefacts are exempt from Gate 3.
-
-### CEO decision needed
-
-Approve approach. If A, approve the specific exemption language for audit/result artefacts.
+**Effect on docs:** Version register to be authored in implementation pass. Binding doc edits to reference register are out of scope unless semantic compatibility is verified.
 
 ---
 
-## Decision 4: Build Loop canonicality status (C-010, OD-AUDIT-004)
+## D3 — DAP path/status consistency (C-009)
 
-### Problem
+**Decision:** Keep DAP canonical; normalise to current repo practice.
 
-`LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` is listed as "Canonical per docs index" in the audit manifest (section F), but its draft/status-mixed markers and the manifest's own canonicality priority create ambiguity. Additionally, the active COO registry source is unresolved (OD-AUDIT-004).
+**Ruling:**
+- DAP remains the canonical Deterministic Artefact Protocol.
+- Normalise DAP path/status to reflect actual repo usage.
+- Add bounded exceptions for the following artefact types so DAP Gate 3 does not incorrectly block them:
+  - Authority-audit packets
+  - Reconciliation receipts
+  - Closure receipts
+  - Generated evidence bundles
 
-### Options for canonicality:
+**Excluded from this work:** Exhaustive artefact-path audit. Do not run one in this WP.
 
-| Option | Effect |
-|---|---|
-| **A: Add canonicality header** — Add explicit "Status: Canonical" or "Status: Working architecture — may diverge from deployed state" header | Clarity without demotion |
-| **B: Demote to working architecture** — Mark as active reference that may diverge from deployed runtime | Safer; autonomous loop semantics not over-trusted |
-
-### Recommendation
-
-**Option A** — the Build Loop doc is actively referenced and functionally canonical for build semantics. A header clarifies status without breaking references.
-
-### Options for active COO registry source (OD-AUDIT-004):
-
-The audit asks which substrate is the active COO registry source for machine-checkable sole-writer enforcement. Candidates:
-
-| Option | Effect |
-|---|---|
-| **A: GitHub issue label/state** — Use issue body state block or a label convention | Low ceremony; already in use implicitly |
-| **B: Config file** — `config/governance/active_coo.yaml` | Machine-checkable; explicit |
-| **C: GitHub Actions variable** — Repo-level variable | Branch/infra-independent |
-
-### Recommendation
-
-**Option B** — `config/governance/active_coo.yaml` is the cheapest machine-checkable path. The sole-writer guard reads it at dispatch time. The active COO updates it on switchover.
-
-### CEO decision needed
-
-1. Approve Build Loop canonicality status approach (A or B).
-2. Approve active COO registry source approach (A, B, or C).
+**Rationale preserved from proposal:** C-009 is MINOR severity — lightweight normalisation appropriate. Exemptions are bounded and specific; DAP authority is preserved for canonical artefact types.
 
 ---
 
-## Summary of CEO decisions required
+## D4a — Build Loop canonicality (C-010, OD-AUDIT-004)
 
-| # | Decision | Options | Recommended |
-|---|---|---|---|
-| D1 | G-CBS ratify/demote/replace | A / B / C | B (demote) to unblock closure; ratify later |
-| D2 | Council Protocol reference alignment | A / B / C | B (version register) |
-| D3 | DAP path/status consistency | A / B / C | A (normalise with artefact-type exceptions) |
-| D4a | Build Loop canonicality | A / B | A (canonicality header) |
-| D4b | Active COO registry source | A / B / C | B (config/governance/active_coo.yaml) |
+**Decision:** Add a scoped canonicality header to `LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md`.
 
-All five decisions are independent. The CEO may answer a subset now and defer the rest.
+**Ruling:**
+- The document is canonical for build-loop design semantics and work-order flow only.
+- It is **not** canonical evidence of deployed runtime behaviour.
+- Runtime truth remains: receipts, tests, CI, current main, and operational state.
+
+**Rationale preserved from proposal:** The doc is actively referenced and functionally canonical for build semantics. A header clarifies scope without breaking references.
+
+---
+
+## D4b — Active COO registry source (OD-AUDIT-004)
+
+**Decision:** Use `config/governance/active_coo.yaml` as the authoritative active COO registry.
+
+**Ruling:**
+- `config/governance/active_coo.yaml` is the authoritative source for the active COO identity.
+- GitHub issue state and GitHub Actions variables may mirror or cache the registry but are **not authoritative**.
+- WP3 parser guards must fail closed if `active_coo_id` is missing or inconsistent with the registry.
+
+**Note:** The file itself is not to be created in this work package — it is authorized for future creation in WP2 implementation pass.
+
+**Rationale preserved from proposal:** Machine-checkable; explicit; cheapest path for sole-writer guard to read at dispatch time.
+
+---
+
+## Original Decision Options (preserved for audit trail)
+
+| # | Decision | Options | Recommended | Final ruling |
+|---|---|---|---|---|
+| D1 | G-CBS ratify/demote/replace | A / B / C | B (demote) | **B — demote to advisory; WP4 closure_receipt.v1 becomes minimal standard** |
+| D2 | Council Protocol reference alignment | A / B / C | B (version register) | **B — create PROTOCOL_VERSION_REGISTER.md; do not mass-bump unless semantic compatibility verified** |
+| D3 | DAP path/status consistency | A / B / C | A (normalise) | **A — keep canonical; normalise with bounded Gate 3 exceptions for audit/result/proposal/receipt/evidence artefacts** |
+| D4a | Build Loop canonicality | A / B | A (canonicality header) | **A — scoped canonicality header; canonical for design semantics/work-order flow only, not runtime truth** |
+| D4b | Active COO registry source | A / B / C | B (config file) | **B — config/governance/active_coo.yaml authoritative; GitHub issue/Actions variables mirror only** |
+
+---
+
+## Implementation Boundary
+
+These rulings authorize **planning and future implementation of WP2 only**, triggered by an explicit execution instruction.
+
+They do **NOT** authorize:
+- WP3 or WP4 implementation
+- Runtime parser/FSM changes
+- G-CBS ratification
+- Lifecycle migration
+- Exhaustive artefact-path audit
+- Creation of `config/governance/active_coo.yaml` or `PROTOCOL_VERSION_REGISTER.md` in this pass (planning artifacts only)

--- a/artifacts/plans/WP2_CEO_DECISION_PACKET_2026-04-27.md
+++ b/artifacts/plans/WP2_CEO_DECISION_PACKET_2026-04-27.md
@@ -3,7 +3,7 @@
 **Status:** RATIFIED — CEO decisions incorporated
 **Ruling date:** 2026-04-27
 **Ruling source:** CEO ruling (this session)
-**Branch:** `wp2/ratify-ceo-decisions`
+**Recording branch:** `wp2/ratify-ceo-decisions`
 **Owner:** Active COO
 **Source:** `docs/audit/LIFEOS_AUTHORITY_AUDIT_RESULT_2026-04-27.md` §H (C-003, C-008, C-009, C-010), §Open Decisions (OD-AUDIT-003, OD-AUDIT-004, OD-AUDIT-006)
 
@@ -54,10 +54,11 @@ The following five decisions are final and binding for WP2 planning and future i
 - DAP remains the canonical Deterministic Artefact Protocol.
 - Normalise DAP path/status to reflect actual repo usage.
 - Add bounded exceptions for the following artefact types so DAP Gate 3 does not incorrectly block them:
-  - Authority-audit packets
-  - Reconciliation receipts
-  - Closure receipts
-  - Generated evidence bundles
+  - audit artefacts
+  - result artefacts
+  - proposal artefacts
+  - receipt artefacts
+  - evidence artefacts / evidence bundles
 
 **Excluded from this work:** Exhaustive artefact-path audit. Do not run one in this WP.
 

--- a/artifacts/plans/WP2_IMPLEMENTATION_PLAN_2026-04-27.md
+++ b/artifacts/plans/WP2_IMPLEMENTATION_PLAN_2026-04-27.md
@@ -1,0 +1,149 @@
+# WP2 — Implementation Plan: Authority Audit Decisions
+
+**Status:** Planning artifact — awaiting execution instruction
+**Ruling:** `artifacts/plans/WP2_CEO_DECISION_PACKET_2026-04-27.md` (ratified 2026-04-27)
+**Branch:** `wp2/ratify-ceo-decisions`
+**Owner:** Active COO
+**Audit baseline:** `043c3f1d6b98f3cf713d3a29783e23383851dfa0`
+
+---
+
+## Goal
+
+Capture planning artifacts for WP2 authority-audit decisions D1–D4b. Planning only — no runtime code, no parser changes, no lifecycle migration.
+
+---
+
+## Task Map
+
+### D1 — G-CBS Demotion
+
+| # | Task | Files touched |
+|---|---|---|
+| D1.1 | Audit `Council_Protocol_v1.3.md` for binding G-CBS references | `docs/01_governance/Council_Protocol_v1.3.md` |
+| D1.2 | Patch or annotate binding G-CBS references as advisory | `docs/01_governance/Council_Protocol_v1.3.md` (and others as found) |
+| D1.3 | Verify WP4 `closure_receipt.v1` schema exists and is referenced as the minimal closure-evidence standard (deferred until WP4 approval) | `artifacts/plans/WP4_LIFECYCLE_CLOSURE_DESIGN_2026-04-27.md` (reference only) |
+| D1.4 | Mark G-CBS status as `Draft / Advisory` in any authoritative index if not already | `docs/02_protocols/G-CBS_Standard_v1.1.md` (annotation only) |
+
+**Constraint:** Do not ratify G-CBS. Do not retire it. Keep as draft/advisory.
+
+---
+
+### D2 — Council Protocol Version Register
+
+| # | Task | Files touched |
+|---|---|---|
+| D2.1 | Author `PROTOCOL_VERSION_REGISTER.md` | `docs/01_governance/PROTOCOL_VERSION_REGISTER.md` (new) |
+| D2.2 | Catalogue stale protocol references (C-003 docs: binding spec, procedural spec, context pack schema, intent routing rule) | register entries only; no doc edits unless semantic compatibility verified |
+| D2.3 | Add register reference to affected C-003 docs (annotation/stub, not version-bump) | `docs/02_protocols/Council_Invocation_Runtime_Binding_Spec_v1.1.md`, `docs/02_protocols/AI_Council_Procedural_Spec_v1.1.md`, `docs/02_protocols/Council_Context_Pack_Schema_v0.3.md`, `docs/02_protocols/Intent_Routing_Rule_v1.1.md` |
+
+**Constraint:** Do not mass-bump docs to v1.3 unless semantic compatibility is verified per-document. Stale references are marked through the register, not silenced by bulk edits.
+
+---
+
+### D3 — DAP Normalisation
+
+| # | Task | Files touched |
+|---|---|---|
+| D3.1 | Read current DAP (expect `docs/02_protocols/Deterministic_Artefact_Protocol_v1.0.md` or similar) | `docs/02_protocols/DAP_*.md` |
+| D3.2 | Add bounded Gate 3 exceptions for: authority-audit packets, reconciliation receipts, closure receipts, generated evidence bundles | same DAP doc |
+| D3.3 | Normalise path/status references to reflect actual repo usage | same DAP doc |
+
+**Constraint:** No exhaustive artefact-path audit. Scope is bounded to adding the listed exceptions and correcting any immediately observable inconsistencies.
+
+---
+
+### D4a — Build Loop Canonicality Header
+
+| # | Task | Files touched |
+|---|---|---|
+| D4a.1 | Read `LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` | `docs/architecture/LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` |
+| D4a.2 | Add canonicality header: canonical for build-loop design semantics and work-order flow; not canonical evidence of deployed runtime behaviour | same doc |
+| D4a.3 | Runtime truth remains: receipts, tests, CI, current main, operational state — make this explicit in header or a footnote | same doc |
+
+---
+
+### D4b — Active COO Registry Source
+
+| # | Task | Files touched |
+|---|---|---|
+| D4b.1 | Author `config/governance/active_coo.yaml` stub (empty or with current COO placeholder) | `config/governance/active_coo.yaml` (new) |
+| D4b.2 | Document in the register (or a governance note) that GitHub issue state and GitHub Actions variables are mirrors only, not authoritative | `docs/01_governance/PROTOCOL_VERSION_REGISTER.md` or separate governance note |
+| D4b.3 | Note that WP3 parser guards must fail closed if `active_coo_id` is missing or inconsistent with registry | Implementation note in plan; guard code is WP3 scope |
+
+**Constraint:** `active_coo.yaml` is authorized for creation. WP3 parser guard implementation is out of scope.
+
+---
+
+## Files Expected to Be Created
+
+| File | Purpose |
+|---|---|
+| `docs/01_governance/PROTOCOL_VERSION_REGISTER.md` | Source of truth for protocol version bindings |
+| `config/governance/active_coo.yaml` | Authoritative active COO registry |
+
+---
+
+## Files Expected to Be Modified
+
+| File | Decision | Change |
+|---|---|---|
+| `artifacts/plans/WP2_CEO_DECISION_PACKET_2026-04-27.md` | (this plan) | Updated to ratified status (done in this branch) |
+| `docs/01_governance/Council_Protocol_v1.3.md` | D1 | Patch binding G-CBS references as advisory |
+| `docs/02_protocols/G-CBS_Standard_v1.1.md` | D1 | Annotate status as Draft/Advisory |
+| `docs/02_protocols/DAP_*.md` | D3 | Add Gate 3 bounded exceptions; normalise path/status |
+| `docs/architecture/LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` | D4a | Add scoped canonicality header |
+| `docs/02_protocols/Council_Invocation_Runtime_Binding_Spec_v1.1.md` | D2 | Add register reference (annotation, not version-bump) |
+| `docs/02_protocols/AI_Council_Procedural_Spec_v1.1.md` | D2 | Add register reference |
+| `docs/02_protocols/Council_Context_Pack_Schema_v0.3.md` | D2 | Add register reference |
+| `docs/02_protocols/Intent_Routing_Rule_v1.1.md` | D2 | Add register reference |
+
+---
+
+## Explicit Non-Goals
+
+The following are **not** in scope for WP2:
+
+- WP3 approval enforcement implementation (schema, parser guards, execution_order authority fields)
+- WP4 lifecycle/closure semantics implementation (closure_receipt.v1 schema, lifecycle_state.v1 FSM, disposition definitions)
+- Runtime parser or FSM changes
+- G-CBS ratification
+- Lifecycle migration
+- Exhaustive artefact-path audit
+- Changes to `runtime/orchestration/coo/*` or `runtime/tests/orchestration/coo/*`
+- Changes to `artifacts/coo/schemas.md` except as reference in this plan
+
+---
+
+## Acceptance Checklist
+
+- [ ] `PROTOCOL_VERSION_REGISTER.md` created in `docs/01_governance/`
+- [ ] `config/governance/active_coo.yaml` created (stub or initial value)
+- [ ] `Council_Protocol_v1.3.md` binding G-CBS references patched or annotated
+- [ ] G-CBS Standard annotated as Draft/Advisory
+- [ ] DAP doc has bounded Gate 3 exceptions for audit/result/proposal/receipt/evidence artefacts
+- [ ] Build Loop doc has scoped canonicality header
+- [ ] No WP3/WP4 runtime code, parser changes, or FSM changes made
+- [ ] No exhaustive artefact-path audit run
+- [ ] Branch pushed; PR ready for review
+
+---
+
+## Tests and Checks Expected
+
+**For this plan-only work package (artifacts/plans/*.md edits):**
+- No repo-wide pytest required — plan-only close-build gate applies
+- `git status` clean before commit
+
+**For future WP2 execution pass (implementation):**
+- `pytest runtime/tests -q` must pass before commit (no regressions)
+- Quality gate (`python3 scripts/workflow/quality_gate.py check --scope changed --json`) on any modified code files
+- Markdown lint on any new or modified `.md` files
+
+---
+
+## Dependency Notes
+
+- D1.3 (WP4 `closure_receipt.v1` verification) is deferred until WP4 is independently approved.
+- D4b parser guard failure-mode is documented for WP3 implementation; guard code itself is out of scope.
+- WP3 implementation remains blocked on D1 (G-CBS demotion) and D4b (active COO registry) being resolved in a prior pass.

--- a/artifacts/plans/WP2_IMPLEMENTATION_PLAN_2026-04-27.md
+++ b/artifacts/plans/WP2_IMPLEMENTATION_PLAN_2026-04-27.md
@@ -20,8 +20,8 @@ Capture planning artifacts for WP2 authority-audit decisions D1–D4b. Planning 
 
 | # | Task | Files touched |
 |---|---|---|
-| D1.1 | Audit `Council_Protocol_v1.3.md` for binding G-CBS references | `docs/01_governance/Council_Protocol_v1.3.md` |
-| D1.2 | Patch or annotate binding G-CBS references as advisory | `docs/01_governance/Council_Protocol_v1.3.md` (and others as found) |
+| D1.1 | Audit `Council_Protocol_v1.3.md` for binding G-CBS references | `docs/02_protocols/Council_Protocol_v1.3.md` |
+| D1.2 | Patch or annotate binding G-CBS references as advisory | `docs/02_protocols/Council_Protocol_v1.3.md` (and others as found) |
 | D1.3 | Verify WP4 `closure_receipt.v1` schema exists and is referenced as the minimal closure-evidence standard (deferred until WP4 approval) | `artifacts/plans/WP4_LIFECYCLE_CLOSURE_DESIGN_2026-04-27.md` (reference only) |
 | D1.4 | Mark G-CBS status as `Draft / Advisory` in any authoritative index if not already | `docs/02_protocols/G-CBS_Standard_v1.1.md` (annotation only) |
 
@@ -45,8 +45,8 @@ Capture planning artifacts for WP2 authority-audit decisions D1–D4b. Planning 
 
 | # | Task | Files touched |
 |---|---|---|
-| D3.1 | Read current DAP (expect `docs/02_protocols/Deterministic_Artefact_Protocol_v1.0.md` or similar) | `docs/02_protocols/DAP_*.md` |
-| D3.2 | Add bounded Gate 3 exceptions for: authority-audit packets, reconciliation receipts, closure receipts, generated evidence bundles | same DAP doc |
+| D3.1 | Read current DAP | `docs/02_protocols/Deterministic_Artefact_Protocol_v2.0.md` |
+| D3.2 | Add bounded Gate 3 exceptions for: audit artefacts, result artefacts, proposal artefacts, receipt artefacts, evidence artefacts / evidence bundles | same DAP doc |
 | D3.3 | Normalise path/status references to reflect actual repo usage | same DAP doc |
 
 **Constraint:** No exhaustive artefact-path audit. Scope is bounded to adding the listed exceptions and correcting any immediately observable inconsistencies.
@@ -57,7 +57,7 @@ Capture planning artifacts for WP2 authority-audit decisions D1–D4b. Planning 
 
 | # | Task | Files touched |
 |---|---|---|
-| D4a.1 | Read `LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` | `docs/architecture/LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` |
+| D4a.1 | Read `LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` | `docs/03_runtime/LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` |
 | D4a.2 | Add canonicality header: canonical for build-loop design semantics and work-order flow; not canonical evidence of deployed runtime behaviour | same doc |
 | D4a.3 | Runtime truth remains: receipts, tests, CI, current main, operational state — make this explicit in header or a footnote | same doc |
 
@@ -89,10 +89,10 @@ Capture planning artifacts for WP2 authority-audit decisions D1–D4b. Planning 
 | File | Decision | Change |
 |---|---|---|
 | `artifacts/plans/WP2_CEO_DECISION_PACKET_2026-04-27.md` | (this plan) | Updated to ratified status (done in this branch) |
-| `docs/01_governance/Council_Protocol_v1.3.md` | D1 | Patch binding G-CBS references as advisory |
+| `docs/02_protocols/Council_Protocol_v1.3.md` | D1 | Patch binding G-CBS references as advisory |
 | `docs/02_protocols/G-CBS_Standard_v1.1.md` | D1 | Annotate status as Draft/Advisory |
-| `docs/02_protocols/DAP_*.md` | D3 | Add Gate 3 bounded exceptions; normalise path/status |
-| `docs/architecture/LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` | D4a | Add scoped canonicality header |
+| `docs/02_protocols/Deterministic_Artefact_Protocol_v2.0.md` | D3 | Add Gate 3 bounded exceptions; normalise path/status |
+| `docs/03_runtime/LifeOS_Autonomous_Build_Loop_Architecture_v0.3.md` | D4a | Add scoped canonicality header |
 | `docs/02_protocols/Council_Invocation_Runtime_Binding_Spec_v1.1.md` | D2 | Add register reference (annotation, not version-bump) |
 | `docs/02_protocols/AI_Council_Procedural_Spec_v1.1.md` | D2 | Add register reference |
 | `docs/02_protocols/Council_Context_Pack_Schema_v0.3.md` | D2 | Add register reference |
@@ -119,7 +119,7 @@ The following are **not** in scope for WP2:
 
 - [ ] `PROTOCOL_VERSION_REGISTER.md` created in `docs/01_governance/`
 - [ ] `config/governance/active_coo.yaml` created (stub or initial value)
-- [ ] `Council_Protocol_v1.3.md` binding G-CBS references patched or annotated
+- [ ] `docs/02_protocols/Council_Protocol_v1.3.md` binding G-CBS references patched or annotated
 - [ ] G-CBS Standard annotated as Draft/Advisory
 - [ ] DAP doc has bounded Gate 3 exceptions for audit/result/proposal/receipt/evidence artefacts
 - [ ] Build Loop doc has scoped canonicality header


### PR DESCRIPTION
## Summary

Planning-only capture for WP2 authority-audit CEO decisions D1-D4b.

- Ratifies WP2 CEO decision packet status
- Adds WP2 implementation plan artifact
- No implementation artifacts
- No runtime, schema, parser, FSM, WP3, or WP4 changes

## Scope

Changed files:
- `artifacts/plans/WP2_CEO_DECISION_PACKET_2026-04-27.md`
- `artifacts/plans/WP2_IMPLEMENTATION_PLAN_2026-04-27.md`

Related issue: #45

## Validation

From branch receipt:
- `git diff --check`: clean
- `python3 scripts/workflow/quality_gate.py check --scope changed --json`: 0 blocking failures

Implementation pass remains separate.