### PR TITLE
feat: add doc_ingest stage to stewardship runner

### DIFF
--- a/config/architecture/import_policy.yaml
+++ b/config/architecture/import_policy.yaml
@@ -1,7 +1,7 @@
 schema_version: import_policy.v1
 bootstrap_source: .context/REPO_MAP.md
 
-# Flat per-module allowed-import declaration for all 22 runtime packages.
+# Flat per-module allowed-import declaration for all 23 runtime packages.
 # Cross-package imports not listed here are policy violations.
 # Same-package imports are always allowed and not checked.
 # Imports of non-policy targets (e.g. runtime.errors, stdlib, third-party) are skipped.
@@ -45,6 +45,8 @@ modules:
   - name: runtime.safety
     allowed_imports: [runtime.util]
   - name: runtime.state
+    allowed_imports: []
+  - name: runtime.stewardship
     allowed_imports: []
   - name: runtime.tools
     allowed_imports: [runtime.agents, runtime.api, runtime.orchestration, runtime.util]

--- a/config/schemas/doc_steward_ingest_manifest_v1.json
+++ b/config/schemas/doc_steward_ingest_manifest_v1.json
@@ -54,12 +54,7 @@
     },
     "binding_class": {
       "type": "string",
-      "enum": [
-        "FOUNDATIONAL",
-        "GOVERNANCE",
-        "PROTOCOL",
-        "RUNTIME"
-      ],
+      "enum": ["FOUNDATIONAL", "GOVERNANCE", "PROTOCOL", "RUNTIME"],
       "description": "Pulled from docs/01_governance/ARTEFACT_INDEX.json meta.binding_classes."
     },
     "canonicality": {
@@ -108,10 +103,7 @@
     },
     "commit": {
       "type": "object",
-      "required": [
-        "enabled",
-        "message"
-      ],
+      "required": ["enabled", "message"],
       "additionalProperties": false,
       "properties": {
         "enabled": {

--- a/config/schemas/doc_steward_ingest_manifest_v1.json
+++ b/config/schemas/doc_steward_ingest_manifest_v1.json
@@ -54,12 +54,25 @@
     },
     "binding_class": {
       "type": "string",
-      "enum": ["FOUNDATIONAL", "GOVERNANCE", "PROTOCOL", "RUNTIME"],
+      "enum": [
+        "FOUNDATIONAL",
+        "GOVERNANCE",
+        "PROTOCOL",
+        "RUNTIME"
+      ],
       "description": "Pulled from docs/01_governance/ARTEFACT_INDEX.json meta.binding_classes."
     },
     "canonicality": {
       "type": "string",
-      "enum": ["canonical", "derived", "proposal", "draft", "stale", "archive", "external"],
+      "enum": [
+        "canonical",
+        "derived",
+        "proposal",
+        "draft",
+        "stale",
+        "archive",
+        "external"
+      ],
       "description": "Pulled from live repo audit (LIFEOS_AUTHORITY_AUDIT_RESULT_2026-04-27.md)."
     },
     "supersedes": {
@@ -72,15 +85,33 @@
     "related": {
       "type": "object",
       "properties": {
-        "issues": {"type": "array", "items": {"type": "string"}},
-        "prs": {"type": "array", "items": {"type": "string"}},
-        "adrs": {"type": "array", "items": {"type": "string"}}
+        "issues": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "prs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "adrs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       },
       "additionalProperties": false
     },
     "commit": {
       "type": "object",
-      "required": ["enabled", "message"],
+      "required": [
+        "enabled",
+        "message"
+      ],
       "additionalProperties": false,
       "properties": {
         "enabled": {

--- a/config/schemas/doc_steward_ingest_manifest_v1.json
+++ b/config/schemas/doc_steward_ingest_manifest_v1.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "doc_steward.protocol_v1_1.ingest_manifest.v1",
+  "title": "Document Steward Ingest Manifest v1",
+  "description": "Manifest for deterministic doc_ingest stage in the Stewardship Runner.",
+  "type": "object",
+  "required": [
+    "schema",
+    "schema_version",
+    "source_path",
+    "dest_path",
+    "title",
+    "description",
+    "artefact_key",
+    "target_index_path",
+    "binding_class",
+    "canonicality",
+    "supersedes",
+    "related",
+    "commit"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema": {
+      "const": "doc_steward.protocol_v1_1.ingest_manifest.v1"
+    },
+    "schema_version": {
+      "const": "1.0"
+    },
+    "source_path": {
+      "type": "string",
+      "description": "Absolute or repo-relative path to source document."
+    },
+    "dest_path": {
+      "type": "string",
+      "description": "Repo-relative destination path. Must satisfy DSP naming convention."
+    },
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "description": "Short description for suggested INDEX.md diff only."
+    },
+    "artefact_key": {
+      "type": "string",
+      "description": "Unique key within target index (for dict-shaped indices) or path identifier."
+    },
+    "target_index_path": {
+      "type": "string",
+      "pattern": "^docs/[^/]+/ARTEFACT_INDEX\\.json$",
+      "description": "Repo-relative path to target ARTEFACT_INDEX.json."
+    },
+    "binding_class": {
+      "type": "string",
+      "enum": ["FOUNDATIONAL", "GOVERNANCE", "PROTOCOL", "RUNTIME"],
+      "description": "Pulled from docs/01_governance/ARTEFACT_INDEX.json meta.binding_classes."
+    },
+    "canonicality": {
+      "type": "string",
+      "enum": ["canonical", "derived", "proposal", "draft", "stale", "archive", "external"],
+      "description": "Pulled from live repo audit (LIFEOS_AUTHORITY_AUDIT_RESULT_2026-04-27.md)."
+    },
+    "supersedes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Repo-relative paths of documents superseded by this ingestion."
+    },
+    "related": {
+      "type": "object",
+      "properties": {
+        "issues": {"type": "array", "items": {"type": "string"}},
+        "prs": {"type": "array", "items": {"type": "string"}},
+        "adrs": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "commit": {
+      "type": "object",
+      "required": ["enabled", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Must be true AND CLI --commit must be present for commit to proceed."
+        },
+        "message": {
+          "type": "string",
+          "description": "Conventional commit message. Excluded from fingerprint computation."
+        }
+      }
+    }
+  }
+}

--- a/config/steward_runner.yaml
+++ b/config/steward_runner.yaml
@@ -42,7 +42,6 @@ git:
   #   - No globs, absolute paths, or ".." allowed
   commit_paths:
     - "docs/"
-    - "artifacts/ledger/dl_doc/"
 
 logging:
   # Directory for JSONL logs (J2)
@@ -74,7 +73,7 @@ doc_ingest:
     - "docs/11_admin/"
     - "docs/12_productisation/"
   # Allowed target_index_path values (invariant 11-perm).
-  # Empty list = no restriction beyond existence check.
+  # Empty list = fail closed; no target indexes are permitted.
   permitted_target_index_paths:
     - "docs/02_protocols/ARTEFACT_INDEX.json"
     - "docs/03_runtime/ARTEFACT_INDEX.json"

--- a/config/steward_runner.yaml
+++ b/config/steward_runner.yaml
@@ -42,6 +42,7 @@ git:
   #   - No globs, absolute paths, or ".." allowed
   commit_paths:
     - "docs/"
+    - "artifacts/ledger/dl_doc/"
 
 logging:
   # Directory for JSONL logs (J2)
@@ -56,3 +57,24 @@ logging:
 determinism:
   # Run ID is required (C1)
   run_id_required: true
+
+doc_ingest:
+  # Roots under which ingested docs may land (invariant 7).
+  # Protected areas (00_foundations, 01_governance, 99_archive) are excluded.
+  allowed_dest_roots:
+    - "docs/02_protocols/"
+    - "docs/03_runtime/"
+    - "docs/04_project_builder/"
+    - "docs/05_agents/"
+    - "docs/06_user_surface/"
+    - "docs/07_testing/"
+    - "docs/08_manuals/"
+    - "docs/09_prompts/"
+    - "docs/10_meta/"
+    - "docs/11_admin/"
+    - "docs/12_productisation/"
+  # Allowed target_index_path values (invariant 11-perm).
+  # Empty list = no restriction beyond existence check.
+  permitted_target_index_paths:
+    - "docs/02_protocols/ARTEFACT_INDEX.json"
+    - "docs/03_runtime/ARTEFACT_INDEX.json"

--- a/runtime/stewardship/__init__.py
+++ b/runtime/stewardship/__init__.py
@@ -1,0 +1,5 @@
+# runtime/stewardship/__init__.py
+"""
+Runtime Stewardship Package.
+Provides deterministic document ingestion and stewardship utilities.
+"""

--- a/runtime/stewardship/doc_ingest.py
+++ b/runtime/stewardship/doc_ingest.py
@@ -72,6 +72,8 @@ class DocIngestResult:
     dest_path_written: str | None = None
     commit_enabled_for_runner: bool = False
     log_dir: Path | None = None
+    pre_ingest_index_path: str | None = None      # repo-relative, for rollback
+    pre_ingest_index_snapshot: str | None = None  # raw content before mutation, for rollback
 
     def to_dict(self) -> dict:
         return {
@@ -441,9 +443,12 @@ def _run_locked(
 
     # Invariant 12: detect index shape
     try:
-        index_data = json.loads(target_index_path.read_bytes())
+        raw_index_bytes = target_index_path.read_bytes()
+        index_data = json.loads(raw_index_bytes)
     except (json.JSONDecodeError, OSError) as exc:
         return fail(f"target_index_parse_failed:{exc}", "INV-12", fingerprint)
+    # Save snapshot before any mutation (used by rollback on downstream failure)
+    pre_ingest_index_snapshot = raw_index_bytes.decode("utf-8")
 
     shape = _detect_index_shape(index_data)
     if shape == "unknown":
@@ -552,6 +557,8 @@ def _run_locked(
         dest_path_written=dest_rel_str,
         commit_enabled_for_runner=True,
         log_dir=log_dir,
+        pre_ingest_index_path=raw_index.lstrip("/"),
+        pre_ingest_index_snapshot=pre_ingest_index_snapshot,
     )
 
 
@@ -588,6 +595,48 @@ def emit_result_packet(
     out_path = out_dir / "doc_steward_result.json"
     out_path.write_text(json.dumps(packet, indent=2) + "\n", encoding="utf-8")
     return out_path
+
+
+def rollback_worktree_mutations(
+    ingest_result: DocIngestResult,
+    repo_root: Path,
+    trace: Any = None,
+) -> bool:
+    """
+    Restore worktree to pre-ingest state after a downstream pipeline failure.
+    Returns True if rollback fully succeeded, False if any step failed.
+    Only meaningful when ingest_result.commit_enabled_for_runner is True.
+    """
+    if not ingest_result.commit_enabled_for_runner:
+        return True  # Dry-run path: no mutations occurred
+
+    overall_success = True
+
+    # Remove newly created dest_path (did not exist before ingest)
+    if ingest_result.dest_path_written:
+        dest = repo_root / ingest_result.dest_path_written
+        try:
+            if dest.exists():
+                dest.unlink()
+        except OSError as exc:
+            if trace:
+                trace("rollback_step_fail", step="dest_unlink", reason=str(exc))
+            overall_success = False
+
+    # Restore target index to pre-ingest content
+    if (
+        ingest_result.pre_ingest_index_path
+        and ingest_result.pre_ingest_index_snapshot is not None
+    ):
+        index_path = repo_root / ingest_result.pre_ingest_index_path
+        try:
+            index_path.write_text(ingest_result.pre_ingest_index_snapshot, encoding="utf-8")
+        except OSError as exc:
+            if trace:
+                trace("rollback_step_fail", step="index_restore", reason=str(exc))
+            overall_success = False
+
+    return overall_success
 
 
 def _is_dest_allowed(dest_rel_str: str, allowed_dest_roots: list[str]) -> bool:

--- a/runtime/stewardship/doc_ingest.py
+++ b/runtime/stewardship/doc_ingest.py
@@ -200,6 +200,21 @@ def _emit_index_diff(
     (log_dir / "index_diff.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
+def _check_dl_doc_idempotency(repo_root: Path, fingerprint: str) -> bool:
+    """Scan dl_doc for a successful DOC_STEWARD_RESULT packet matching this fingerprint."""
+    dl_doc_dir = repo_root / "artifacts" / "ledger" / "dl_doc"
+    if not dl_doc_dir.exists():
+        return False
+    for result_file in dl_doc_dir.glob("**/doc_steward_result.json"):
+        try:
+            data = json.loads(result_file.read_bytes())
+            if data.get("manifest_fingerprint") == fingerprint and data.get("status") == "SUCCESS":
+                return True
+        except (json.JSONDecodeError, OSError):
+            continue
+    return False
+
+
 def _load_completed_ledger(ledger_path: Path) -> set[str]:
     if not ledger_path.exists():
         return set()
@@ -345,16 +360,25 @@ def _run_locked(
     trace("fingerprint_computed", fingerprint=fingerprint)
 
     # Idempotent check (invariant 17)
-    completed = _load_completed_ledger(ledger_path)
-    if fingerprint in completed:
-        trace("idempotent_noop", fingerprint=fingerprint)
-        result = DocIngestResult(
+    # Authoritative source: existing DOC_STEWARD_RESULT packets in dl_doc
+    if _check_dl_doc_idempotency(repo_root, fingerprint):
+        trace("idempotent_noop", fingerprint=fingerprint, source="dl_doc")
+        return DocIngestResult(
             success=True,
             manifest_fingerprint=fingerprint,
             is_idempotent_noop=True,
             log_dir=log_dir,
         )
-        return result
+    # Local cache: completed.json in logs/ (optimization, not authoritative)
+    completed = _load_completed_ledger(ledger_path)
+    if fingerprint in completed:
+        trace("idempotent_noop", fingerprint=fingerprint, source="local_cache")
+        return DocIngestResult(
+            success=True,
+            manifest_fingerprint=fingerprint,
+            is_idempotent_noop=True,
+            log_dir=log_dir,
+        )
 
     # Write normalized manifest for audit
     (log_dir / "manifest.normalized.json").write_text(
@@ -410,11 +434,10 @@ def _run_locked(
     if not target_index_path.exists():
         return fail(f"target_index_not_found:{raw_index}", "INV-11", fingerprint)
 
-    # Check permitted_target_index_paths config guard
-    if permitted_index_paths:
-        raw_index_norm = raw_index.lstrip("/")
-        if not any(raw_index_norm == p.lstrip("/") for p in permitted_index_paths):
-            return fail(f"target_index_not_permitted:{raw_index}", "INV-11-perm", fingerprint)
+    # Invariant 11-perm: permitted_target_index_paths whitelist — empty = fail closed
+    raw_index_norm = raw_index.lstrip("/")
+    if not any(raw_index_norm == p.lstrip("/") for p in permitted_index_paths):
+        return fail(f"target_index_not_permitted:{raw_index}", "INV-11-perm", fingerprint)
 
     # Invariant 12: detect index shape
     try:

--- a/runtime/stewardship/doc_ingest.py
+++ b/runtime/stewardship/doc_ingest.py
@@ -72,7 +72,7 @@ class DocIngestResult:
     dest_path_written: str | None = None
     commit_enabled_for_runner: bool = False
     log_dir: Path | None = None
-    pre_ingest_index_path: str | None = None      # repo-relative, for rollback
+    pre_ingest_index_path: str | None = None  # repo-relative, for rollback
     pre_ingest_index_snapshot: str | None = None  # raw content before mutation, for rollback
 
     def to_dict(self) -> dict:
@@ -624,10 +624,7 @@ def rollback_worktree_mutations(
             overall_success = False
 
     # Restore target index to pre-ingest content
-    if (
-        ingest_result.pre_ingest_index_path
-        and ingest_result.pre_ingest_index_snapshot is not None
-    ):
+    if ingest_result.pre_ingest_index_path and ingest_result.pre_ingest_index_snapshot is not None:
         index_path = repo_root / ingest_result.pre_ingest_index_path
         try:
             index_path.write_text(ingest_result.pre_ingest_index_snapshot, encoding="utf-8")

--- a/runtime/stewardship/doc_ingest.py
+++ b/runtime/stewardship/doc_ingest.py
@@ -1,0 +1,575 @@
+"""
+doc_ingest: Deterministic document ingestion stage for the Stewardship Runner.
+
+Invoked exclusively via:
+    python scripts/steward_runner.py --run-id <ID> --ingest <manifest_path>
+
+Never run standalone. All invariants in Issue #56 are enforced here.
+"""
+
+import fcntl
+import hashlib
+import json
+import os
+import re
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Enums pulled from live repo (docs/01_governance/ARTEFACT_INDEX.json meta.binding_classes)
+VALID_BINDING_CLASSES = frozenset({"FOUNDATIONAL", "GOVERNANCE", "PROTOCOL", "RUNTIME"})
+
+# Canonicality values from live repo audit (docs/audit/LIFEOS_AUTHORITY_AUDIT_RESULT_2026-04-27.md)
+VALID_CANONICALITY_VALUES = frozenset(
+    {"canonical", "derived", "proposal", "draft", "stale", "archive", "external"}
+)
+
+SCHEMA_ID = "doc_steward.protocol_v1_1.ingest_manifest.v1"
+SCHEMA_VERSION = "1.0"
+
+# DAP M-3 + Document Steward Protocol Section 7 naming pattern
+_FILENAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_\-]*_v\d+\.\d+(\.\d+)?\.md$")
+
+# Required metadata headers per Document Steward Protocol Section 3.1 ("Status, Authority, Date")
+_REQUIRED_HEADERS = ["**Status**:", "**Authority**:"]
+
+# Fields excluded from fingerprint computation (invariant 16)
+_FINGERPRINT_EXCLUDE = {"commit"}
+
+# Fields excluded from forbidden-fields check
+_FORBIDDEN_MANIFEST_FIELDS = {
+    "regenerate_strategic_corpus",
+    "index_section",
+}
+
+_REQUIRED_MANIFEST_FIELDS = {
+    "schema",
+    "schema_version",
+    "source_path",
+    "dest_path",
+    "title",
+    "description",
+    "artefact_key",
+    "target_index_path",
+    "binding_class",
+    "canonicality",
+    "supersedes",
+    "related",
+    "commit",
+}
+
+
+@dataclass
+class DocIngestResult:
+    success: bool
+    failure_reason: str | None = None
+    failure_invariant: str | None = None
+    manifest_fingerprint: str | None = None
+    is_idempotent_noop: bool = False
+    staged_files: list[str] = field(default_factory=list)
+    dest_path_written: str | None = None
+    commit_enabled_for_runner: bool = False
+    log_dir: Path | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "success": self.success,
+            "failure_reason": self.failure_reason,
+            "failure_invariant": self.failure_invariant,
+            "manifest_fingerprint": self.manifest_fingerprint,
+            "is_idempotent_noop": self.is_idempotent_noop,
+            "staged_files": self.staged_files,
+            "dest_path_written": self.dest_path_written,
+        }
+
+
+def _compute_fingerprint(manifest: dict) -> str:
+    """SHA256 over canonicalized manifest excluding commit block (invariant 16)."""
+    filtered = {k: v for k, v in manifest.items() if k not in _FINGERPRINT_EXCLUDE}
+    canonical = json.dumps(filtered, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def _detect_index_shape(index_data: Any) -> str:
+    """Returns 'dict', 'array', or 'unknown'."""
+    artefacts = index_data.get("artefacts") if isinstance(index_data, dict) else None
+    if isinstance(artefacts, dict):
+        return "dict"
+    if isinstance(artefacts, list):
+        return "array"
+    return "unknown"
+
+
+def _has_artefact_key_collision(
+    index_data: dict, shape: str, artefact_key: str, dest_rel: str
+) -> bool:
+    artefacts = index_data.get("artefacts")
+    if shape == "dict" and isinstance(artefacts, dict):
+        return artefact_key in artefacts and not artefact_key.startswith("_comment_")
+    if shape == "array" and isinstance(artefacts, list):
+        for entry in artefacts:
+            if isinstance(entry, dict) and entry.get("path") == dest_rel:
+                return True
+    return False
+
+
+def _update_index(
+    index_data: dict,
+    shape: str,
+    artefact_key: str,
+    dest_rel: str,
+    supersedes: list[str],
+) -> list[str]:
+    """
+    Mutate index_data in-place. Returns list of suggested-patch lines for
+    dict-shape superseded_by (which cannot be stored inline).
+    """
+    suggested_patches: list[str] = []
+
+    if shape == "dict":
+        artefacts = index_data["artefacts"]
+        artefacts[artefact_key] = dest_rel
+        # Dict shape stores only string paths — cannot add superseded_by inline.
+        # Emit suggested patch per invariant 15.
+        for sup in supersedes:
+            suggested_patches.append(
+                f"# Suggested: annotate superseded doc {sup} -> superseded_by: {dest_rel}"
+            )
+
+    elif shape == "array":
+        artefacts = index_data["artefacts"]
+        # Add new entry
+        new_entry: dict[str, Any] = {"path": dest_rel}
+        artefacts.append(new_entry)
+        # Update superseded entries with superseded_by (invariant 15)
+        for entry in artefacts:
+            if isinstance(entry, dict) and entry.get("path") in supersedes:
+                entry["superseded_by"] = dest_rel
+
+    return suggested_patches
+
+
+def _emit_index_diff(
+    log_dir: Path,
+    manifest: dict,
+    index_data: dict,
+    shape: str,
+    dest_rel: str,
+    artefact_key: str,
+    suggested_patches: list[str],
+) -> None:
+    """Write index_diff.md with suggested INDEX.md entry and any patch suggestions."""
+    title = manifest.get("title", "")
+    description = manifest.get("description", "")
+    binding_class = manifest.get("binding_class", "")
+    target_index = manifest.get("target_index_path", "")
+
+    lines = [
+        "# Suggested INDEX.md diff",
+        "",
+        f"**Title**: {title}",
+        f"**Path**: {dest_rel}",
+        f"**Description**: {description}",
+        f"**Binding class**: {binding_class}",
+        f"**Target index**: {target_index}",
+        "",
+        "Add to `docs/INDEX.md` under the appropriate section:",
+        "",
+        "```",
+        f"- [{title}]({dest_rel}) — {description}",
+        "```",
+    ]
+
+    if suggested_patches:
+        lines += ["", "## Suggested superseded_by patches (dict-shaped index)", ""]
+        lines += suggested_patches
+
+    lines += [
+        "",
+        "INDEX.md auto-edit is deferred in v1. Apply the above manually.",
+    ]
+
+    (log_dir / "index_diff.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _load_completed_ledger(ledger_path: Path) -> set[str]:
+    if not ledger_path.exists():
+        return set()
+    try:
+        data = json.loads(ledger_path.read_bytes())
+        return set(data.get("completed", []))
+    except (json.JSONDecodeError, OSError):
+        return set()
+
+
+def _save_completed_ledger(ledger_path: Path, fingerprints: set[str]) -> None:
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    ledger_path.write_text(
+        json.dumps({"completed": sorted(fingerprints)}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def run(manifest_path: Path, runner_ctx: dict) -> DocIngestResult:
+    """
+    Execute the doc_ingest stage.
+
+    runner_ctx keys:
+        run_id:           str   — externally provided run identifier
+        repo_root:        Path  — canonical repo root
+        actually_commit:  bool  — True if CLI --commit was given
+        config:           dict  — full steward_runner config (mutable)
+    """
+    run_id: str = runner_ctx["run_id"]
+    repo_root: Path = runner_ctx["repo_root"]
+    actually_commit: bool = runner_ctx["actually_commit"]
+    config: dict = runner_ctx["config"]
+
+    ingest_config = config.get("doc_ingest", {})
+    allowed_dest_roots: list[str] = ingest_config.get("allowed_dest_roots", [])
+    permitted_index_paths: list[str] = ingest_config.get("permitted_target_index_paths", [])
+
+    log_dir = repo_root / "logs" / "steward_runner" / "doc_ingest" / run_id
+    log_dir.mkdir(parents=True, exist_ok=True)
+    trace_path = log_dir / "trace.jsonl"
+    ledger_path = repo_root / "logs" / "steward_runner" / "doc_ingest" / "completed.json"
+
+    def _trace(event: str, **kwargs: Any) -> None:
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        record: dict[str, Any] = {"event": event, "run_id": run_id, "timestamp": ts}
+        record.update(kwargs)
+        with open(trace_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+
+    def _fail(reason: str, invariant: str, fingerprint: str | None = None) -> DocIngestResult:
+        _trace("fail", failure_reason=reason, failure_invariant=invariant)
+        return DocIngestResult(
+            success=False,
+            failure_reason=reason,
+            failure_invariant=invariant,
+            manifest_fingerprint=fingerprint,
+            log_dir=log_dir,
+        )
+
+    # Workspace lock (invariant 20)
+    lock_path = repo_root / "logs" / "steward_runner" / "doc_ingest.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = open(lock_path, "w")  # noqa: WPS515
+    try:
+        fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        lock_file.close()
+        return _fail("workspace_lock_conflict", "INV-20")
+
+    try:
+        return _run_locked(
+            manifest_path=manifest_path,
+            run_id=run_id,
+            repo_root=repo_root,
+            actually_commit=actually_commit,
+            config=config,
+            allowed_dest_roots=allowed_dest_roots,
+            permitted_index_paths=permitted_index_paths,
+            log_dir=log_dir,
+            ledger_path=ledger_path,
+            trace=_trace,
+            fail=_fail,
+        )
+    finally:
+        fcntl.flock(lock_file, fcntl.LOCK_UN)
+        lock_file.close()
+
+
+def _run_locked(
+    manifest_path: Path,
+    run_id: str,
+    repo_root: Path,
+    actually_commit: bool,
+    config: dict,
+    allowed_dest_roots: list[str],
+    permitted_index_paths: list[str],
+    log_dir: Path,
+    ledger_path: Path,
+    trace: Any,
+    fail: Any,
+) -> DocIngestResult:
+    # Load manifest
+    try:
+        raw = manifest_path.read_bytes()
+        manifest = json.loads(raw)
+    except (json.JSONDecodeError, OSError) as exc:
+        return fail(f"manifest_load_failed:{exc}", "INV-manifest-load")
+
+    if not isinstance(manifest, dict):
+        return fail("manifest_not_a_dict", "INV-manifest-load")
+
+    # Forbidden fields check
+    for bad_field in _FORBIDDEN_MANIFEST_FIELDS:
+        if bad_field in manifest:
+            return fail(f"forbidden_field:{bad_field}", "INV-forbidden-field")
+
+    # Required fields
+    missing = _REQUIRED_MANIFEST_FIELDS - set(manifest.keys())
+    if missing:
+        return fail(f"missing_required_fields:{sorted(missing)}", "INV-required-fields")
+
+    # Schema identity
+    if manifest.get("schema") != SCHEMA_ID:
+        return fail(f"wrong_schema:{manifest.get('schema')}", "INV-schema")
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        return fail(f"wrong_schema_version:{manifest.get('schema_version')}", "INV-schema-version")
+
+    # Enum validation
+    if manifest["binding_class"] not in VALID_BINDING_CLASSES:
+        return fail(f"invalid_binding_class:{manifest['binding_class']}", "INV-binding-class")
+    if manifest["canonicality"] not in VALID_CANONICALITY_VALUES:
+        return fail(f"invalid_canonicality:{manifest['canonicality']}", "INV-canonicality")
+
+    # commit block
+    commit_block = manifest.get("commit", {})
+    if not isinstance(commit_block, dict) or not isinstance(commit_block.get("enabled"), bool):
+        return fail("invalid_commit_block", "INV-commit-block")
+
+    manifest_commit_enabled: bool = commit_block["enabled"]
+
+    # Compute fingerprint (invariant 16)
+    fingerprint = _compute_fingerprint(manifest)
+    trace("fingerprint_computed", fingerprint=fingerprint)
+
+    # Idempotent check (invariant 17)
+    completed = _load_completed_ledger(ledger_path)
+    if fingerprint in completed:
+        trace("idempotent_noop", fingerprint=fingerprint)
+        result = DocIngestResult(
+            success=True,
+            manifest_fingerprint=fingerprint,
+            is_idempotent_noop=True,
+            log_dir=log_dir,
+        )
+        return result
+
+    # Write normalized manifest for audit
+    (log_dir / "manifest.normalized.json").write_text(
+        json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+
+    # Resolve source_path (invariant 5)
+    raw_source = manifest["source_path"]
+    source_path = Path(raw_source) if os.path.isabs(raw_source) else repo_root / raw_source
+    if not source_path.exists():
+        return fail(f"source_not_found:{raw_source}", "INV-5", fingerprint)
+
+    # Resolve dest_path (invariant 6: normalize to repo-relative)
+    raw_dest = manifest["dest_path"]
+    if os.path.isabs(raw_dest):
+        try:
+            dest_rel = Path(raw_dest).relative_to(repo_root)
+        except ValueError:
+            return fail(f"dest_not_under_repo_root:{raw_dest}", "INV-6", fingerprint)
+    else:
+        dest_rel = Path(raw_dest)
+    dest_path = repo_root / dest_rel
+    dest_rel_str = dest_rel.as_posix()
+
+    # Invariant 7: allowed_dest_roots
+    if not _is_dest_allowed(dest_rel_str, allowed_dest_roots):
+        return fail(f"dest_outside_allowed_roots:{dest_rel_str}", "INV-7", fingerprint)
+
+    # Invariant 8: dest must not already exist (no replace in v1)
+    if dest_path.exists():
+        return fail(f"dest_already_exists:{dest_rel_str}", "INV-8", fingerprint)
+
+    # Invariant 9: filename naming convention
+    filename = dest_path.name
+    if not _FILENAME_PATTERN.match(filename):
+        return fail(f"filename_convention_violation:{filename}", "INV-9", fingerprint)
+
+    # Invariant 10: required metadata headers
+    try:
+        source_text = source_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return fail(f"source_read_failed:{exc}", "INV-10", fingerprint)
+    for header in _REQUIRED_HEADERS:
+        if header not in source_text:
+            return fail(f"missing_required_header:{header}", "INV-10", fingerprint)
+
+    # Invariant 11: target_index_path must exist
+    raw_index = manifest["target_index_path"]
+    if os.path.isabs(raw_index):
+        target_index_path = Path(raw_index)
+    else:
+        target_index_path = repo_root / raw_index
+    if not target_index_path.exists():
+        return fail(f"target_index_not_found:{raw_index}", "INV-11", fingerprint)
+
+    # Check permitted_target_index_paths config guard
+    if permitted_index_paths:
+        raw_index_norm = raw_index.lstrip("/")
+        if not any(raw_index_norm == p.lstrip("/") for p in permitted_index_paths):
+            return fail(f"target_index_not_permitted:{raw_index}", "INV-11-perm", fingerprint)
+
+    # Invariant 12: detect index shape
+    try:
+        index_data = json.loads(target_index_path.read_bytes())
+    except (json.JSONDecodeError, OSError) as exc:
+        return fail(f"target_index_parse_failed:{exc}", "INV-12", fingerprint)
+
+    shape = _detect_index_shape(index_data)
+    if shape == "unknown":
+        return fail(f"unknown_index_shape:{raw_index}", "INV-12", fingerprint)
+
+    # Invariant 13: artefact_key uniqueness
+    artefact_key = manifest["artefact_key"]
+    if _has_artefact_key_collision(index_data, shape, artefact_key, dest_rel_str):
+        return fail(f"artefact_key_collision:{artefact_key}", "INV-13", fingerprint)
+
+    # Invariants 14 & 15: supersedes targets must exist
+    supersedes: list[str] = manifest.get("supersedes", [])
+    for sup_raw in supersedes:
+        sup_path = Path(sup_raw) if os.path.isabs(sup_raw) else repo_root / sup_raw
+        if not sup_path.exists():
+            return fail(f"supersedes_target_missing:{sup_raw}", "INV-14", fingerprint)
+
+    # Dual-key commit gate (invariant 4 / AT-DI-03)
+    if actually_commit and not manifest_commit_enabled:
+        return fail("cli_commit_but_manifest_commit_disabled", "INV-4", fingerprint)
+
+    source_sha256 = _file_sha256(source_path)
+    trace(
+        "validation_complete",
+        source_sha256=source_sha256,
+        shape=shape,
+        dest=dest_rel_str,
+        fingerprint=fingerprint,
+    )
+
+    # === Dry-run path (invariant 2, 3) ===
+    if not actually_commit:
+        # No repo-tree mutation — emit preview only
+        _emit_index_diff(
+            log_dir=log_dir,
+            manifest=manifest,
+            index_data=index_data,
+            shape=shape,
+            dest_rel=dest_rel_str,
+            artefact_key=artefact_key,
+            suggested_patches=[],
+        )
+        trace("dry_run_complete", dest=dest_rel_str, fingerprint=fingerprint)
+        return DocIngestResult(
+            success=True,
+            manifest_fingerprint=fingerprint,
+            log_dir=log_dir,
+            commit_enabled_for_runner=False,
+        )
+
+    # === Commit path (invariant 4): actually_commit=True AND manifest_commit_enabled=True ===
+
+    # Copy source to dest atomically (write to tmp then rename)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_dest = dest_path.with_suffix(".tmp_ingest")
+    shutil.copy2(str(source_path), str(tmp_dest))
+    tmp_dest.rename(dest_path)
+    dest_sha256 = _file_sha256(dest_path)
+    trace(
+        "file_copied",
+        source=str(source_path),
+        dest=dest_rel_str,
+        source_sha256=source_sha256,
+        dest_sha256=dest_sha256,
+    )
+
+    # Update ARTEFACT_INDEX
+    suggested_patches = _update_index(
+        index_data=index_data,
+        shape=shape,
+        artefact_key=artefact_key,
+        dest_rel=dest_rel_str,
+        supersedes=supersedes,
+    )
+    # Write updated index atomically
+    tmp_index = target_index_path.with_suffix(".tmp_ingest")
+    tmp_index.write_text(
+        json.dumps(index_data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    tmp_index.rename(target_index_path)
+    trace("index_updated", target_index=raw_index, shape=shape, artefact_key=artefact_key)
+
+    # Emit index diff and suggested patches
+    _emit_index_diff(
+        log_dir=log_dir,
+        manifest=manifest,
+        index_data=index_data,
+        shape=shape,
+        dest_rel=dest_rel_str,
+        artefact_key=artefact_key,
+        suggested_patches=suggested_patches,
+    )
+
+    # Update idempotency ledger (gitignored, local only)
+    completed.add(fingerprint)
+    _save_completed_ledger(ledger_path, completed)
+
+    staged = sorted({dest_rel_str, raw_index.lstrip("/")})
+    trace("ingest_complete", staged_files=staged, fingerprint=fingerprint)
+
+    return DocIngestResult(
+        success=True,
+        manifest_fingerprint=fingerprint,
+        staged_files=staged,
+        dest_path_written=dest_rel_str,
+        commit_enabled_for_runner=True,
+        log_dir=log_dir,
+    )
+
+
+def emit_result_packet(
+    run_id: str,
+    repo_root: Path,
+    ingest_result: DocIngestResult,
+    commit_sha: str | None,
+    manifest: dict,
+) -> Path:
+    """
+    Write DOC_STEWARD_RESULT packet per Document_Steward_Protocol_v1.1 Section 10.1.
+    Returns the written packet path.
+    """
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    packet = {
+        "packet_type": "DOC_STEWARD_RESULT",
+        "ledger": "DL_DOC",
+        "run_id": run_id,
+        "completed_at": ts,
+        "status": "SUCCESS" if ingest_result.success else "FAILURE",
+        "manifest_fingerprint": ingest_result.manifest_fingerprint,
+        "dest_path": ingest_result.dest_path_written,
+        "staged_files": ingest_result.staged_files,
+        "commit_sha": commit_sha,
+        "is_idempotent_noop": ingest_result.is_idempotent_noop,
+        "failure_reason": ingest_result.failure_reason,
+        "failure_invariant": ingest_result.failure_invariant,
+        "schema": "doc_steward.protocol_v1_1.result_packet.v1",
+    }
+
+    out_dir = repo_root / "artifacts" / "ledger" / "dl_doc" / run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "doc_steward_result.json"
+    out_path.write_text(json.dumps(packet, indent=2) + "\n", encoding="utf-8")
+    return out_path
+
+
+def _is_dest_allowed(dest_rel_str: str, allowed_dest_roots: list[str]) -> bool:
+    for root in allowed_dest_roots:
+        prefix = root.rstrip("/") + "/"
+        if dest_rel_str.startswith(prefix):
+            return True
+    return False

--- a/scripts/steward_runner.py
+++ b/scripts/steward_runner.py
@@ -40,27 +40,29 @@ from typing import Any
 
 import yaml
 
-
 # --- Logging Infrastructure ---
+
 
 class DeterministicLogger:
     """JSONL logger with content-addressed stream storage."""
-    
-    def __init__(self, log_dir: Path, streams_dir: Path, run_id: str, timestamps_enabled: bool = True):
+
+    def __init__(
+        self, log_dir: Path, streams_dir: Path, run_id: str, timestamps_enabled: bool = True
+    ):
         self.log_dir = log_dir
         self.streams_dir = streams_dir
         self.run_id = run_id
         self.timestamps_enabled = timestamps_enabled
         self.log_file = log_dir / f"{run_id}.jsonl"
-        
+
         # Ensure directories exist
         self.log_dir.mkdir(parents=True, exist_ok=True)
         self.streams_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Clear any existing log for this run_id (idempotent reruns)
         if self.log_file.exists():
             self.log_file.unlink()
-    
+
     def _store_stream(self, content: str, suffix: str) -> str:
         """Store content in content-addressed file, return hash."""
         if not content:
@@ -71,15 +73,15 @@ class DeterministicLogger:
         if not stream_file.exists():
             stream_file.write_bytes(content_bytes)
         return sha
-    
+
     def log(self, event: str, step: str, status: str, **kwargs: Any) -> None:
         """Write a JSONL event line."""
-        
+
         if self.timestamps_enabled:
             ts = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
         else:
             ts = "1970-01-01T00:00:00Z"  # Deterministic fixed timestamp
-            
+
         record: dict[str, Any] = {
             "timestamp": ts,
             "run_id": self.run_id,
@@ -88,18 +90,26 @@ class DeterministicLogger:
             "status": status,
         }
         record.update(kwargs)
-        
+
         # P1-B: Enforce sorted file lists for determinism
-        for key in ("files", "changed_files", "staged_files", "validated_files", "unexpected_files", "disallowed_files", "commit_paths"):
+        for key in (
+            "files",
+            "changed_files",
+            "staged_files",
+            "validated_files",
+            "unexpected_files",
+            "disallowed_files",
+            "commit_paths",
+        ):
             if key in record and isinstance(record[key], list):
                 record[key] = sorted(record[key])
-        
+
         # Remove None values for cleaner logs
         record = {k: v for k, v in record.items() if v is not None}
-        
+
         with open(self.log_file, "a", encoding="utf-8") as f:
             f.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
-    
+
     def log_command(
         self,
         step: str,
@@ -114,7 +124,7 @@ class DeterministicLogger:
         """Log a command execution with content-addressed streams."""
         stdout_hash = self._store_stream(stdout, ".out")
         stderr_hash = self._store_stream(stderr, ".err")
-        
+
         self.log(
             event="command",
             step=step,
@@ -129,6 +139,7 @@ class DeterministicLogger:
 
 
 # --- Pipeline Stages ---
+
 
 def get_repo_root() -> Path:
     """Get canonical repo root via git."""
@@ -171,7 +182,7 @@ def get_changed_files() -> list[str]:
     )
     if not result.stdout.strip():
         return []
-    
+
     files = []
     for line in result.stdout.strip().split("\n"):
         if line:
@@ -181,7 +192,7 @@ def get_changed_files() -> list[str]:
             # Normalize to forward slashes (B3)
             filename = filename.replace("\\", "/")
             files.append(filename)
-    
+
     return sorted(files)
 
 
@@ -198,7 +209,7 @@ def run_command(
         capture_output=True,
         text=True,
     )
-    
+
     status = "pass" if result.returncode == 0 else "fail"
     logger.log_command(
         step=step,
@@ -209,11 +220,12 @@ def run_command(
         stdout=result.stdout,
         stderr=result.stderr,
     )
-    
+
     return result.returncode, result.stdout, result.stderr
 
 
 # --- Pipeline Execution ---
+
 
 def run_preflight(
     config: dict[str, Any],
@@ -223,24 +235,28 @@ def run_preflight(
 ) -> tuple[bool, str]:
     """Preflight checks. Returns (success, git_head_before)."""
     git_head = get_git_head()
-    
+
     # C1: run_id is required (enforced by argparse, but double-check)
     if not run_id:
         logger.log("preflight", "preflight", "fail", reason="missing_run_id")
         return False, git_head
-    
+
     # C2: Check for clean start if required
     if config.get("git", {}).get("require_clean_start", False):
         if is_repo_dirty():
             logger.log(
-                "preflight", "preflight", "fail",
+                "preflight",
+                "preflight",
+                "fail",
                 reason="dirty_repo",
                 git_head_before=git_head,
             )
             return False, git_head
-    
+
     logger.log(
-        "preflight", "preflight", "pass",
+        "preflight",
+        "preflight",
+        "pass",
         repo_root=str(repo_root),
         git_head_before=git_head,
     )
@@ -256,10 +272,10 @@ def run_tests(
     tests_config = config.get("tests", {})
     command = tests_config.get("command", ["python", "-m", "pytest", "-q"])
     paths = tests_config.get("paths", [])
-    
+
     # P0-1: Append test paths to command argv
     argv = list(command) + list(paths)
-    
+
     exit_code, _, _ = run_command(argv, repo_root, logger, "tests")
     return exit_code == 0
 
@@ -272,12 +288,12 @@ def run_validators(
     """Run validators in order. Stops on first failure (E3). Returns success."""
     validators_config = config.get("validators", {})
     commands = validators_config.get("commands", [])
-    
+
     for i, command in enumerate(commands):
         exit_code, _, _ = run_command(command, repo_root, logger, f"validator_{i}")
         if exit_code != 0:
             return False
-    
+
     return True
 
 
@@ -290,26 +306,28 @@ def run_corpus(
     corpus_config = config.get("corpus", {})
     command = corpus_config.get("command", [])
     outputs_expected = corpus_config.get("outputs_expected", [])
-    
+
     if not command:
         logger.log("corpus", "corpus", "skip", reason="no_command")
         return True
-    
+
     exit_code, _, _ = run_command(command, repo_root, logger, "corpus")
     if exit_code != 0:
         return False
-    
+
     # F2: Verify expected outputs exist
     for output in outputs_expected:
         output_path = repo_root / output
         if not output_path.exists():
             logger.log(
-                "corpus", "corpus", "fail",
+                "corpus",
+                "corpus",
+                "fail",
                 reason="missing_output",
                 missing_file=output,
             )
             return False
-    
+
     return True
 
 
@@ -325,37 +343,38 @@ def run_change_detect(
     log_dir = log_dir.replace("\\", "/")
     if not log_dir.endswith("/"):
         log_dir += "/"
-    
+
     all_changed = get_changed_files()
-    
+
     # Filter out files in the log directory (runner's own artifacts)
     changed_files = [
-        f for f in all_changed 
-        if not f.startswith(log_dir) and f != log_dir.rstrip("/")
+        f for f in all_changed if not f.startswith(log_dir) and f != log_dir.rstrip("/")
     ]
-    
+
     if changed_files:
         logger.log(
-            "change_detect", "change_detect", "detected",
+            "change_detect",
+            "change_detect",
+            "detected",
             changed_files=changed_files,
         )
     else:
         logger.log("change_detect", "change_detect", "no_change")
-    
+
     return changed_files
 
 
 def normalize_commit_path(path: str) -> tuple[str, str | None]:
     r"""
     Normalize a commit_paths entry per Commit Paths Contract.
-    
+
     Returns (normalized_path, error_reason | None).
-    
+
     Contract:
     - Entries ending with / are directory prefixes
     - Entries not ending with / are exact files
     - Bare names (no / or .) are interpreted as directory prefixes (normalized + logged)
-    
+
     Fail-closed cases (error_reason is not None):
     - Absolute paths (Unix: /..., Windows: C:\, UNC: \\server, //server)
     - Path traversal (.. segment)
@@ -365,29 +384,29 @@ def normalize_commit_path(path: str) -> tuple[str, str | None]:
     original = path
     # Normalize backslashes to forward slashes
     normalized = path.replace("\\", "/")
-    
+
     # --- Fail-closed checks ---
-    
+
     # URL encoded chars rejection (P2-B)
     if "%" in normalized:
         return original, "url_encoded_chars"
-    
+
     # UNC path (//server or after backslash normalization) - check BEFORE Unix
     if normalized.startswith("//"):
         return original, "absolute_path_unc"
-    
+
     # Unix absolute path
     if normalized.startswith("/"):
         return original, "absolute_path_unix"
-    
+
     # Windows drive absolute (C:/ or C:)
     if len(normalized) >= 2 and normalized[1] == ":":
         return original, "absolute_path_windows"
-    
+
     # Glob patterns
     if "*" in normalized or "?" in normalized:
         return original, "glob_pattern"
-    
+
     # Segment-based path traversal and current-dir check
     segments = normalized.rstrip("/").split("/")
     for segment in segments:
@@ -395,16 +414,16 @@ def normalize_commit_path(path: str) -> tuple[str, str | None]:
             return original, "path_traversal"
         if segment == ".":
             return original, "current_dir_segment"
-    
+
     # --- Normalization ---
-    
+
     # Only normalize bare names (no / at all) that look like directories
     # Entries already containing / are treated as-is per contract
     if "/" not in path and not path.endswith("/"):
         # Bare name without extension → treat as directory prefix
         if "." not in path:
             normalized = normalized + "/"
-    
+
     return normalized, None
 
 
@@ -419,7 +438,7 @@ def run_commit(
 ) -> tuple[bool, str | None]:
     """
     Commit changes if allowed. Returns (success, git_head_after).
-    
+
     Implements Commit Paths Contract:
     - Directory prefixes (trailing /) or exact files
     - No globs, absolute paths, or path traversal
@@ -429,40 +448,45 @@ def run_commit(
     commit_enabled = git_config.get("commit_enabled", False)
     raw_commit_paths = git_config.get("commit_paths", [])
     commit_message_template = git_config.get(
-        "commit_message_template",
-        "[steward] Autonomous run {run_id}"
+        "commit_message_template", "[steward] Autonomous run {run_id}"
     )
-    
+
     # G2: No changes = no commit needed
     if not changed_files:
         return True, None
-    
+
     # Check if commit should be skipped
     if dry_run or no_commit or not commit_enabled:
         reason = "dry_run" if dry_run else ("no_commit" if no_commit else "disabled")
         logger.log(
-            "commit", "commit", "skipped",
+            "commit",
+            "commit",
+            "skipped",
             reason=reason,
             changed_files=changed_files,
         )
         return True, None
-    
+
     # C5: Verify commit_paths allowlist is non-empty
     if not raw_commit_paths:
         logger.log(
-            "commit", "commit", "fail",
+            "commit",
+            "commit",
+            "fail",
             reason="empty_commit_paths",
             changed_files=changed_files,
         )
         return False, None
-    
+
     # P1-2: Normalize and validate commit_paths
     commit_paths: list[str] = []
     for raw_path in raw_commit_paths:
         normalized, error_reason = normalize_commit_path(raw_path)
         if error_reason is not None:
             logger.log(
-                "commit", "commit", "fail",
+                "commit",
+                "commit",
+                "fail",
                 reason="invalid_commit_path",
                 error=error_reason,
                 invalid_path=raw_path,
@@ -470,7 +494,7 @@ def run_commit(
             )
             return False, None
         commit_paths.append(normalized)
-    
+
     # C5: Verify all changes are within allowlist
     disallowed = []
     for changed_file in changed_files:
@@ -487,29 +511,33 @@ def run_commit(
                     break
         if not allowed:
             disallowed.append(changed_file)
-    
+
     if disallowed:
         logger.log(
-            "commit", "commit", "fail",
+            "commit",
+            "commit",
+            "fail",
             reason="changes_outside_allowlist",
             disallowed_files=disallowed,
             changed_files=changed_files,
         )
         return False, None
-    
+
     # P1-1: Stage using git add -A with allowlisted roots
     # Derive unique roots from commit_paths
     roots = sorted(set(commit_paths))
-    
+
     message = commit_message_template.format(run_id=run_id)
-    
+
     # Stage all changes under allowed roots
     # P1-A: Re-check for dirty state before commit to prevent race conditions
     current_changed = get_changed_files()
     unexpected = set(current_changed) - set(changed_files)
     if unexpected:
         logger.log(
-            "commit", "commit", "fail",
+            "commit",
+            "commit",
+            "fail",
             reason="repo_dirty_during_run",
             unexpected_files=list(unexpected),
         )
@@ -524,12 +552,14 @@ def run_commit(
     )
     if result.returncode != 0:
         logger.log(
-            "commit", "commit", "fail",
+            "commit",
+            "commit",
+            "fail",
             reason="git_add_failed",
             stderr=result.stderr,
         )
         return False, None
-    
+
     # Commit
     result = subprocess.run(
         ["git", "commit", "-m", message],
@@ -539,20 +569,24 @@ def run_commit(
     )
     if result.returncode != 0:
         logger.log(
-            "commit", "commit", "fail",
+            "commit",
+            "commit",
+            "fail",
             reason="git_commit_failed",
             stderr=result.stderr,
         )
         return False, None
-    
+
     git_head_after = get_git_head()
     logger.log(
-        "commit", "commit", "pass",
+        "commit",
+        "commit",
+        "pass",
         git_head_after=git_head_after,
         changed_files=changed_files,
         commit_paths=commit_paths,
     )
-    
+
     return True, git_head_after
 
 
@@ -564,13 +598,16 @@ def run_postflight(
 ) -> None:
     """Final logging."""
     logger.log(
-        "postflight", "postflight", "complete" if success else "failed",
+        "postflight",
+        "postflight",
+        "complete" if success else "failed",
         git_head_before=git_head_before,
         git_head_after=git_head_after,
     )
 
 
 # --- Main Entry Point ---
+
 
 def load_config(config_path: Path) -> dict[str, Any]:
     """Load YAML configuration."""
@@ -593,7 +630,7 @@ def main() -> int:
         required=True,
         help="Required. Unique identifier for this run.",
     )
-    
+
     # P1-D: Mutually exclusive commit control
     commit_group = parser.add_mutually_exclusive_group()
     commit_group.add_argument(
@@ -606,52 +643,72 @@ def main() -> int:
         action="store_true",
         help="Actually commit changes (explicit opt-in required)",
     )
-    
+
     parser.add_argument(
         "--step",
-        choices=["preflight", "tests", "validators", "corpus", "change_detect", "commit", "postflight"],
+        choices=[
+            "preflight",
+            "tests",
+            "validators",
+            "corpus",
+            "change_detect",
+            "commit",
+            "postflight",
+        ],
         help="Run single step only (for debugging).",
     )
-    
+
+    parser.add_argument(
+        "--ingest",
+        type=Path,
+        default=None,
+        metavar="MANIFEST_PATH",
+        help="Path to doc_ingest manifest JSON. Adds deterministic doc ingestion stage.",
+    )
+
     args = parser.parse_args()
-    
+
     # Resolve repo root (A3)
     try:
         repo_root = get_repo_root()
     except RuntimeError as e:
         print(f"Error: {e}", file=sys.stderr)
         return 1
-    
+
     os.chdir(repo_root)
-    
+
     # Load config
     config_path = repo_root / args.config
     if not config_path.exists():
         print(f"Error: Config file not found: {config_path}", file=sys.stderr)
         return 1
-    
+
     config = load_config(config_path)
-    
+
     # Initialize logger
     logging_config = config.get("logging", {})
     log_dir = repo_root / logging_config.get("log_dir", "logs/steward_runner")
     streams_dir = repo_root / logging_config.get("streams_dir", "logs/steward_runner/streams")
-    
+
     logger = DeterministicLogger(
-        log_dir, 
-        streams_dir, 
+        log_dir,
+        streams_dir,
         args.run_id,
-        timestamps_enabled=config.get("determinism", {}).get("timestamps", True)
+        timestamps_enabled=config.get("determinism", {}).get("timestamps", True),
     )
-    
+
     # --- Pipeline Execution ---
-    
+
     single_step = args.step
     success = True
     git_head_before = ""
     git_head_after = None
     changed_files: list[str] = []
-    
+    ingest_result = None
+
+    # Compute commit intent once (used by doc_ingest and commit stages)
+    actually_commit = args.commit
+
     # PREFLIGHT
     if single_step is None or single_step == "preflight":
         success, git_head_before = run_preflight(config, logger, repo_root, args.run_id)
@@ -660,7 +717,45 @@ def main() -> int:
             return 1
         if single_step == "preflight":
             return 0
-    
+
+    # DOC_INGEST (after preflight, before validators — invariant 1)
+    if args.ingest is not None and single_step is None:
+        from runtime.stewardship.doc_ingest import emit_result_packet
+        from runtime.stewardship.doc_ingest import run as doc_ingest_run
+
+        manifest_path = repo_root / args.ingest if not args.ingest.is_absolute() else args.ingest
+        runner_ctx = {
+            "run_id": args.run_id,
+            "repo_root": repo_root,
+            "actually_commit": actually_commit,
+            "config": config,
+        }
+        ingest_result = doc_ingest_run(manifest_path, runner_ctx)
+        logger.log(
+            "doc_ingest",
+            "doc_ingest",
+            "pass" if ingest_result.success else "fail",
+            manifest=str(args.ingest),
+            fingerprint=ingest_result.manifest_fingerprint,
+            failure_reason=ingest_result.failure_reason,
+            failure_invariant=ingest_result.failure_invariant,
+            is_idempotent_noop=ingest_result.is_idempotent_noop,
+        )
+        if not ingest_result.success:
+            run_postflight(logger, False, git_head_before, None)
+            return 1
+        if ingest_result.is_idempotent_noop:
+            # Idempotent no-op: skip remaining pipeline stages
+            run_postflight(logger, True, git_head_before, None)
+            return 0
+        # Inject manifest commit intent into runner config so commit stage respects dual-key
+        if ingest_result.commit_enabled_for_runner:
+            config.setdefault("git", {})["commit_enabled"] = True
+            dl_doc_path = "artifacts/ledger/dl_doc/"
+            existing_paths = config.get("git", {}).get("commit_paths", [])
+            if dl_doc_path not in existing_paths:
+                config.setdefault("git", {}).setdefault("commit_paths", []).append(dl_doc_path)
+
     # TESTS
     if single_step is None or single_step == "tests":
         success = run_tests(config, logger, repo_root)
@@ -669,7 +764,7 @@ def main() -> int:
             return 1
         if single_step == "tests":
             return 0
-    
+
     # VALIDATORS
     if single_step is None or single_step == "validators":
         success = run_validators(config, logger, repo_root)
@@ -678,7 +773,7 @@ def main() -> int:
             return 1
         if single_step == "validators":
             return 0
-    
+
     # CORPUS
     if single_step is None or single_step == "corpus":
         success = run_corpus(config, logger, repo_root)
@@ -687,33 +782,61 @@ def main() -> int:
             return 1
         if single_step == "corpus":
             return 0
-    
+
     # CHANGE DETECT
     if single_step is None or single_step == "change_detect":
         changed_files = run_change_detect(config, logger)
         if single_step == "change_detect":
             return 0
-    
+
     # COMMIT
     if single_step is None or single_step == "commit":
         # P1-D: Default is dry-run. Commit requires explicit --commit flag.
-        actually_commit = args.commit
         # dry_run arg is redundant if commit arg is not present, but for compatibility/clarity:
         dry_run = args.dry_run or (not actually_commit)
-        
+
         success, git_head_after = run_commit(
-            config, logger, repo_root, args.run_id,
-            changed_files, dry_run, False, # no_commit removed, logic handled by dry_run
+            config,
+            logger,
+            repo_root,
+            args.run_id,
+            changed_files,
+            dry_run,
+            False,  # no_commit removed, logic handled by dry_run
         )
         if not success:
             run_postflight(logger, False, git_head_before, None)
             return 1
+
+        # Emit DOC_STEWARD_RESULT packet if ingest committed (invariant — result packet)
+        if (
+            args.ingest is not None
+            and ingest_result is not None
+            and ingest_result.commit_enabled_for_runner
+            and git_head_after
+        ):
+            import json as _json
+
+            manifest_path = (
+                repo_root / args.ingest if not args.ingest.is_absolute() else args.ingest
+            )
+            try:
+                manifest_data = _json.loads(manifest_path.read_bytes())
+            except (OSError, _json.JSONDecodeError):
+                manifest_data = {}
+            from runtime.stewardship.doc_ingest import emit_result_packet
+
+            packet_path = emit_result_packet(
+                args.run_id, repo_root, ingest_result, git_head_after, manifest_data
+            )
+            logger.log("doc_ingest_result", "doc_ingest", "pass", packet=str(packet_path))
+
         if single_step == "commit":
             return 0
-    
+
     # POSTFLIGHT
     run_postflight(logger, True, git_head_before, git_head_after)
-    
+
     return 0
 
 

--- a/scripts/steward_runner.py
+++ b/scripts/steward_runner.py
@@ -606,6 +606,84 @@ def run_postflight(
     )
 
 
+# --- Doc-Ingest Helpers ---
+
+
+def _commit_result_packet(
+    packet_path: Path,
+    run_id: str,
+    logger: DeterministicLogger,
+    repo_root: Path,
+) -> tuple[bool, str | None]:
+    """Stage and commit the DOC_STEWARD_RESULT packet as a dedicated second commit."""
+    rel_packet = str(packet_path.relative_to(repo_root))
+
+    result = subprocess.run(
+        ["git", "add", "--", rel_packet],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logger.log(
+            "commit_packet", "doc_ingest", "fail",
+            reason="git_add_packet_failed",
+            stderr=result.stderr,
+            packet=rel_packet,
+        )
+        return False, None
+
+    result = subprocess.run(
+        ["git", "commit", "-m", f"[steward] result packet {run_id}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        logger.log(
+            "commit_packet", "doc_ingest", "fail",
+            reason="git_commit_packet_failed",
+            stderr=result.stderr,
+            packet=rel_packet,
+        )
+        return False, None
+
+    sha = get_git_head()
+    logger.log("commit_packet", "doc_ingest", "pass", commit_sha_b=sha, packet=rel_packet)
+    return True, sha
+
+
+def _rollback_ingest_if_needed(
+    ingest_result: Any,
+    repo_root: Path,
+    logger: DeterministicLogger,
+) -> None:
+    """Rollback doc_ingest worktree mutations when a downstream pipeline stage fails."""
+    if not ingest_result or not ingest_result.commit_enabled_for_runner:
+        return
+
+    from runtime.stewardship.doc_ingest import rollback_worktree_mutations
+
+    def _trace(event: str, **kw: Any) -> None:
+        logger.log(event, "doc_ingest_rollback", "fail", **kw)
+
+    rollback_ok = rollback_worktree_mutations(ingest_result, repo_root, trace=_trace)
+    status = "rollback_success" if rollback_ok else "rollback_failed"
+    logger.log("rollback", "doc_ingest", status, dest_path=ingest_result.dest_path_written)
+
+    if not rollback_ok:
+        git_status = subprocess.run(
+            ["git", "status", "--short"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        logger.log(
+            "rollback_evidence", "doc_ingest", "rollback_failed",
+            git_status=git_status.stdout.strip(),
+        )
+
+
 # --- Main Entry Point ---
 
 
@@ -748,18 +826,15 @@ def main() -> int:
             # Idempotent no-op: skip remaining pipeline stages
             run_postflight(logger, True, git_head_before, None)
             return 0
-        # Inject manifest commit intent into runner config so commit stage respects dual-key
+        # Enable commit for doc+index first commit; result packet gets its own second commit
         if ingest_result.commit_enabled_for_runner:
             config.setdefault("git", {})["commit_enabled"] = True
-            dl_doc_path = "artifacts/ledger/dl_doc/"
-            existing_paths = config.get("git", {}).get("commit_paths", [])
-            if dl_doc_path not in existing_paths:
-                config.setdefault("git", {}).setdefault("commit_paths", []).append(dl_doc_path)
 
     # TESTS
     if single_step is None or single_step == "tests":
         success = run_tests(config, logger, repo_root)
         if not success:
+            _rollback_ingest_if_needed(ingest_result, repo_root, logger)
             run_postflight(logger, False, git_head_before, None)
             return 1
         if single_step == "tests":
@@ -769,6 +844,7 @@ def main() -> int:
     if single_step is None or single_step == "validators":
         success = run_validators(config, logger, repo_root)
         if not success:
+            _rollback_ingest_if_needed(ingest_result, repo_root, logger)
             run_postflight(logger, False, git_head_before, None)
             return 1
         if single_step == "validators":
@@ -778,6 +854,7 @@ def main() -> int:
     if single_step is None or single_step == "corpus":
         success = run_corpus(config, logger, repo_root)
         if not success:
+            _rollback_ingest_if_needed(ingest_result, repo_root, logger)
             run_postflight(logger, False, git_head_before, None)
             return 1
         if single_step == "corpus":
@@ -792,7 +869,6 @@ def main() -> int:
     # COMMIT
     if single_step is None or single_step == "commit":
         # P1-D: Default is dry-run. Commit requires explicit --commit flag.
-        # dry_run arg is redundant if commit arg is not present, but for compatibility/clarity:
         dry_run = args.dry_run or (not actually_commit)
 
         success, git_head_after = run_commit(
@@ -805,10 +881,11 @@ def main() -> int:
             False,  # no_commit removed, logic handled by dry_run
         )
         if not success:
+            _rollback_ingest_if_needed(ingest_result, repo_root, logger)
             run_postflight(logger, False, git_head_before, None)
             return 1
 
-        # Emit DOC_STEWARD_RESULT packet if ingest committed (invariant — result packet)
+        # Two-commit model: after commit A (doc+index), emit packet then commit B (packet).
         if (
             args.ingest is not None
             and ingest_result is not None
@@ -826,10 +903,31 @@ def main() -> int:
                 manifest_data = {}
             from runtime.stewardship.doc_ingest import emit_result_packet
 
+            # Emit packet with commit-A SHA included
             packet_path = emit_result_packet(
                 args.run_id, repo_root, ingest_result, git_head_after, manifest_data
             )
-            logger.log("doc_ingest_result", "doc_ingest", "pass", packet=str(packet_path))
+
+            # Commit B: dedicated commit for the result packet
+            commit_b_ok, git_head_b = _commit_result_packet(
+                packet_path, args.run_id, logger, repo_root
+            )
+            if not commit_b_ok:
+                logger.log(
+                    "doc_ingest_result", "doc_ingest", "fail",
+                    packet=str(packet_path),
+                    commit_sha_a=git_head_after,
+                )
+                run_postflight(logger, False, git_head_before, git_head_after)
+                return 1
+
+            logger.log(
+                "doc_ingest_result", "doc_ingest", "pass",
+                packet=str(packet_path),
+                commit_sha_a=git_head_after,
+                commit_sha_b=git_head_b,
+            )
+            git_head_after = git_head_b  # final HEAD is the packet commit
 
         if single_step == "commit":
             return 0

--- a/scripts/steward_runner.py
+++ b/scripts/steward_runner.py
@@ -626,7 +626,9 @@ def _commit_result_packet(
     )
     if result.returncode != 0:
         logger.log(
-            "commit_packet", "doc_ingest", "fail",
+            "commit_packet",
+            "doc_ingest",
+            "fail",
             reason="git_add_packet_failed",
             stderr=result.stderr,
             packet=rel_packet,
@@ -641,7 +643,9 @@ def _commit_result_packet(
     )
     if result.returncode != 0:
         logger.log(
-            "commit_packet", "doc_ingest", "fail",
+            "commit_packet",
+            "doc_ingest",
+            "fail",
             reason="git_commit_packet_failed",
             stderr=result.stderr,
             packet=rel_packet,
@@ -679,7 +683,9 @@ def _rollback_ingest_if_needed(
             text=True,
         )
         logger.log(
-            "rollback_evidence", "doc_ingest", "rollback_failed",
+            "rollback_evidence",
+            "doc_ingest",
+            "rollback_failed",
             git_status=git_status.stdout.strip(),
         )
 
@@ -914,7 +920,9 @@ def main() -> int:
             )
             if not commit_b_ok:
                 logger.log(
-                    "doc_ingest_result", "doc_ingest", "fail",
+                    "doc_ingest_result",
+                    "doc_ingest",
+                    "fail",
                     packet=str(packet_path),
                     commit_sha_a=git_head_after,
                 )
@@ -922,7 +930,9 @@ def main() -> int:
                 return 1
 
             logger.log(
-                "doc_ingest_result", "doc_ingest", "pass",
+                "doc_ingest_result",
+                "doc_ingest",
+                "pass",
                 packet=str(packet_path),
                 commit_sha_a=git_head_after,
                 commit_sha_b=git_head_b,

--- a/tests_recursive/test_doc_ingest.py
+++ b/tests_recursive/test_doc_ingest.py
@@ -20,10 +20,12 @@ sys.path.insert(0, str(REPO_ROOT))
 from runtime.stewardship.doc_ingest import (  # noqa: E402
     SCHEMA_ID,
     SCHEMA_VERSION,
+    DocIngestResult,
     _compute_fingerprint,
     _detect_index_shape,
     _has_artefact_key_collision,
     _update_index,
+    emit_result_packet,
     run,
 )
 
@@ -83,6 +85,12 @@ def _make_dict_index() -> dict:
     }
 
 
+_DEFAULT_PERMITTED_INDEX_PATHS = [
+    "docs/02_protocols/ARTEFACT_INDEX.json",
+    "docs/03_runtime/ARTEFACT_INDEX.json",
+]
+
+
 def _make_runner_ctx(
     repo_root: Path,
     run_id: str = "test-run-001",
@@ -90,10 +98,19 @@ def _make_runner_ctx(
     allowed_dest_roots: list[str] | None = None,
     permitted_index_paths: list[str] | None = None,
 ) -> dict:
+    """
+    Build a runner context dict.
+    permitted_index_paths=None  → use v1 defaults (02_protocols, 03_runtime only)
+    permitted_index_paths=[]    → explicitly empty → fails closed for all index paths
+    """
     config: dict[str, Any] = {
         "doc_ingest": {
             "allowed_dest_roots": allowed_dest_roots or ["docs/02_protocols/"],
-            "permitted_target_index_paths": permitted_index_paths or [],
+            "permitted_target_index_paths": (
+                _DEFAULT_PERMITTED_INDEX_PATHS
+                if permitted_index_paths is None
+                else permitted_index_paths
+            ),
         },
         "git": {"commit_enabled": False},
     }
@@ -688,3 +705,94 @@ def test_update_index_array_shape():
     assert "docs/new.md" in paths
     old_entry = next(e for e in entries if isinstance(e, dict) and e.get("path") == "docs/old.md")
     assert old_entry.get("superseded_by") == "docs/new.md"
+
+
+# ─── Fix 1: permitted_target_index_paths semantics ───────────────────────────
+
+
+def test_governance_index_rejected_by_default_config(tmp_path):
+    """docs/01_governance/ARTEFACT_INDEX.json is rejected under default v1 config."""
+    repo_root, source_path, _ = _scaffold_repo(tmp_path)
+
+    gov_dir = repo_root / "docs" / "01_governance"
+    gov_dir.mkdir(parents=True, exist_ok=True)
+    gov_index = gov_dir / "ARTEFACT_INDEX.json"
+    gov_index.write_text(json.dumps(_make_dict_index(), indent=2), encoding="utf-8")
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path="docs/02_protocols/Test_Protocol_v1.0.md",
+        target_index_path="docs/01_governance/ARTEFACT_INDEX.json",
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    # Default ctx uses _DEFAULT_PERMITTED_INDEX_PATHS (02_protocols, 03_runtime only)
+    ctx = _make_runner_ctx(repo_root)
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-11-perm"
+
+
+def test_empty_permitted_index_paths_fails_closed(tmp_path):
+    """Empty permitted_target_index_paths fails closed for all target indexes."""
+    repo_root, source_path, _ = _scaffold_repo(tmp_path)
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path="docs/02_protocols/Test_Protocol_v1.0.md",
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    # Explicitly empty list → fail closed (no index is permitted)
+    ctx = _make_runner_ctx(repo_root, permitted_index_paths=[])
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-11-perm"
+
+
+# ─── Fix 2: authoritative idempotency from dl_doc result packets ─────────────
+
+
+def test_idempotency_from_dl_doc_result_packet(tmp_path):
+    """Idempotency detected from DOC_STEWARD_RESULT in dl_doc, not only completed.json."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=True,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    fingerprint = _compute_fingerprint(manifest)
+
+    # Plant a successful DOC_STEWARD_RESULT packet in dl_doc
+    prior_result = DocIngestResult(
+        success=True,
+        manifest_fingerprint=fingerprint,
+        dest_path_written=dest_rel,
+        staged_files=[dest_rel],
+    )
+    emit_result_packet(
+        run_id="prior-run-001",
+        repo_root=repo_root,
+        ingest_result=prior_result,
+        commit_sha="deadbeef001",
+        manifest=manifest,
+    )
+
+    # Ensure local completed.json cache does NOT exist
+    ledger_path = repo_root / "logs" / "steward_runner" / "doc_ingest" / "completed.json"
+    if ledger_path.exists():
+        ledger_path.unlink()
+
+    # Second run: should detect idempotency from dl_doc, NOT from local cache
+    ctx = _make_runner_ctx(repo_root, run_id="test-run-002", actually_commit=True)
+    result = run(manifest_path, ctx)
+
+    assert result.success, f"Expected idempotent success, got: {result.failure_reason}"
+    assert result.is_idempotent_noop

--- a/tests_recursive/test_doc_ingest.py
+++ b/tests_recursive/test_doc_ingest.py
@@ -933,6 +933,7 @@ def test_rollback_cleans_partial_mutation_dest_only(tmp_path):
 
     # Corrupt the result snapshot so index restore will fail
     from dataclasses import replace
+
     broken_result = replace(
         result,
         pre_ingest_index_path="nonexistent/path/INDEX.json",

--- a/tests_recursive/test_doc_ingest.py
+++ b/tests_recursive/test_doc_ingest.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+"""
+Acceptance Tests for doc_ingest stage (AT-DI-01 through AT-DI-18).
+
+Tests use tmp_path for isolation — no git worktrees required (WSL-safe).
+
+Run with:
+    python3 -m pytest tests_recursive/test_doc_ingest.py -v
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Allow importing runtime.stewardship.doc_ingest
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from runtime.stewardship.doc_ingest import (  # noqa: E402
+    SCHEMA_ID,
+    SCHEMA_VERSION,
+    _compute_fingerprint,
+    _detect_index_shape,
+    _has_artefact_key_collision,
+    _update_index,
+    run,
+)
+
+# ─── Fixtures ────────────────────────────────────────────────────────────────
+
+
+def _make_source_doc(path: Path, title: str = "Test Doc") -> None:
+    """Write a minimal DSP-compliant source document."""
+    path.write_text(
+        f"# {title}\n\n**Status**: Draft\n**Authority**: Test\n\nContent.\n",
+        encoding="utf-8",
+    )
+
+
+def _make_manifest(
+    source_path: str,
+    dest_path: str,
+    target_index_path: str,
+    artefact_key: str = "test_key",
+    commit_enabled: bool = False,
+    supersedes: list[str] | None = None,
+    binding_class: str = "PROTOCOL",
+    canonicality: str = "draft",
+) -> dict:
+    return {
+        "schema": SCHEMA_ID,
+        "schema_version": SCHEMA_VERSION,
+        "source_path": source_path,
+        "dest_path": dest_path,
+        "title": "Test Protocol v1.0",
+        "description": "A test protocol document.",
+        "artefact_key": artefact_key,
+        "target_index_path": target_index_path,
+        "binding_class": binding_class,
+        "canonicality": canonicality,
+        "supersedes": supersedes or [],
+        "related": {"issues": [], "prs": [], "adrs": []},
+        "commit": {"enabled": commit_enabled, "message": "test: ingest test doc"},
+    }
+
+
+def _make_array_index() -> dict:
+    return {
+        "meta": {"version": "1.0.0"},
+        "artefacts": [
+            {"_comment": "Active Protocols"},
+        ],
+    }
+
+
+def _make_dict_index() -> dict:
+    return {
+        "meta": {"version": "1.0.0", "binding_classes": {"PROTOCOL": "Active protocols"}},
+        "artefacts": {
+            "_comment_protocols": "=== 02_protocols: Active Protocols ===",
+        },
+    }
+
+
+def _make_runner_ctx(
+    repo_root: Path,
+    run_id: str = "test-run-001",
+    actually_commit: bool = False,
+    allowed_dest_roots: list[str] | None = None,
+    permitted_index_paths: list[str] | None = None,
+) -> dict:
+    config: dict[str, Any] = {
+        "doc_ingest": {
+            "allowed_dest_roots": allowed_dest_roots or ["docs/02_protocols/"],
+            "permitted_target_index_paths": permitted_index_paths or [],
+        },
+        "git": {"commit_enabled": False},
+    }
+    return {
+        "run_id": run_id,
+        "repo_root": repo_root,
+        "actually_commit": actually_commit,
+        "config": config,
+    }
+
+
+def _write_manifest(tmp_path: Path, manifest: dict) -> Path:
+    p = tmp_path / "manifest.json"
+    p.write_text(json.dumps(manifest), encoding="utf-8")
+    return p
+
+
+def _scaffold_repo(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """
+    Create a minimal repo-like layout in tmp_path.
+    Returns (repo_root, source_path, index_path).
+    """
+    repo_root = tmp_path / "repo"
+    src_dir = repo_root / "staging"
+    dest_dir = repo_root / "docs" / "02_protocols"
+    index_dir = repo_root / "docs" / "02_protocols"
+    logs_dir = repo_root / "logs"
+
+    for d in [src_dir, dest_dir, logs_dir]:
+        d.mkdir(parents=True, exist_ok=True)
+
+    source_path = src_dir / "Test_Protocol_v1.0.md"
+    _make_source_doc(source_path)
+
+    index_path = index_dir / "ARTEFACT_INDEX.json"
+    index_path.write_text(json.dumps(_make_array_index(), indent=2), encoding="utf-8")
+
+    return repo_root, source_path, index_path
+
+
+# ─── AT-DI-01: dry-run emits preview, no mutation ────────────────────────────
+
+
+def test_AT_DI_01_dry_run_no_mutation(tmp_path):
+    """Valid dry-run emits preview logs/diffs and performs no repo-tree mutation."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=False,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=False)
+
+    result = run(manifest_path, ctx)
+
+    assert result.success, f"Expected success, got: {result.failure_reason}"
+    assert not result.is_idempotent_noop
+
+    # No file was written to dest
+    assert not (repo_root / dest_rel).exists(), "dest_path must not exist after dry-run"
+
+    # Index was NOT mutated
+    index_after = json.loads(index_path.read_bytes())
+    assert index_after == _make_array_index(), "ARTEFACT_INDEX must not be mutated in dry-run"
+
+    # Preview logs were emitted
+    log_dir = repo_root / "logs" / "steward_runner" / "doc_ingest" / ctx["run_id"]
+    assert (log_dir / "trace.jsonl").exists()
+    assert (log_dir / "index_diff.md").exists()
+
+
+# ─── AT-DI-02: valid commit copies, updates index, emits result ───────────────
+
+
+def test_AT_DI_02_commit_run(tmp_path):
+    """Valid commit run copies source to dest, updates target ARTEFACT_INDEX."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=True,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)
+
+    result = run(manifest_path, ctx)
+
+    assert result.success, f"Expected success, got: {result.failure_reason}"
+    assert not result.is_idempotent_noop
+    assert result.commit_enabled_for_runner
+
+    # File was copied
+    dest_path = repo_root / dest_rel
+    assert dest_path.exists(), "dest_path must exist after commit run"
+    assert dest_path.read_text() == source_path.read_text()
+
+    # Index was updated with new path entry
+    index_after = json.loads(index_path.read_bytes())
+    paths = [e.get("path") for e in index_after["artefacts"] if isinstance(e, dict) and "path" in e]
+    assert dest_rel in paths, f"dest_rel must be in updated index, got: {paths}"
+
+
+# ─── AT-DI-03: CLI --commit without manifest.commit.enabled fails ─────────────
+
+
+def test_AT_DI_03_cli_commit_manifest_disabled(tmp_path):
+    """CLI --commit without manifest.commit.enabled=true fails closed."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path="docs/02_protocols/Test_Protocol_v1.0.md",
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=False,  # disabled
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)  # CLI says commit
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-4"
+    assert "manifest_commit_disabled" in result.failure_reason
+
+
+# ─── AT-DI-04: manifest.commit.enabled without CLI --commit does not commit ───
+
+
+def test_AT_DI_04_manifest_enabled_no_cli_commit(tmp_path):
+    """manifest.commit.enabled=true without CLI --commit does not commit."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=True,  # manifest says yes
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=False)  # CLI says no
+
+    result = run(manifest_path, ctx)
+
+    assert result.success
+    # No file copied
+    assert not (repo_root / dest_rel).exists()
+    # commit_enabled_for_runner must be False (no CLI commit)
+    assert not result.commit_enabled_for_runner
+
+
+# ─── AT-DI-05: existing dest_path fails closed ───────────────────────────────
+
+
+def test_AT_DI_05_dest_already_exists(tmp_path):
+    """Existing dest_path fails closed."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+
+    # Pre-create the destination
+    (repo_root / dest_rel).write_text("already here", encoding="utf-8")
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=False)
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-8"
+
+
+# ─── AT-DI-06: missing source_path fails closed ──────────────────────────────
+
+
+def test_AT_DI_06_missing_source_path(tmp_path):
+    """Missing source_path fails closed."""
+    repo_root, _source, index_path = _scaffold_repo(tmp_path)
+
+    manifest = _make_manifest(
+        source_path="nonexistent/Source_Doc_v1.0.md",
+        dest_path="docs/02_protocols/Test_Protocol_v1.0.md",
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root)
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-5"
+
+
+# ─── AT-DI-07: dest_path outside allowed_dest_roots fails closed ─────────────
+
+
+def test_AT_DI_07_dest_outside_allowed_roots(tmp_path):
+    """dest_path outside allowed_dest_roots fails closed."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+
+    # dest goes to 01_governance — not in allowed roots
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path="docs/01_governance/Test_Protocol_v1.0.md",
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, allowed_dest_roots=["docs/02_protocols/"])
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-7"
+
+
+# ─── AT-DI-08: filename violating protocol naming fails closed ───────────────
+
+
+def test_AT_DI_08_filename_convention_violation(tmp_path):
+    """Filename violating protocol naming pattern fails closed."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path="docs/02_protocols/bad_name.md",  # no version suffix
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root)
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-9"
+
+
+# ─── AT-DI-09: missing required metadata header fails closed ─────────────────
+
+
+def test_AT_DI_09_missing_metadata_header(tmp_path):
+    """Missing required metadata header in source fails closed."""
+    repo_root, _, index_path = _scaffold_repo(tmp_path)
+
+    # Source without required headers
+    bad_source = repo_root / "staging" / "Bad_Protocol_v1.0.md"
+    bad_source.write_text("# Bad Doc\n\nNo status header here.\n", encoding="utf-8")
+
+    manifest = _make_manifest(
+        source_path=str(bad_source),
+        dest_path="docs/02_protocols/Bad_Protocol_v1.0.md",
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root)
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-10"
+
+
+# ─── AT-DI-10: artefact_key collision fails closed ───────────────────────────
+
+
+def test_AT_DI_10_artefact_key_collision_array(tmp_path):
+    """artefact_key (path) collision in array-shaped index fails closed."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+
+    # Pre-populate index with the same path
+    existing = _make_array_index()
+    existing["artefacts"].append({"path": dest_rel})
+    index_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root)
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-13"
+
+
+# ─── AT-DI-11: unknown target_index_path shape fails closed ─────────────────
+
+
+def test_AT_DI_11_unknown_index_shape(tmp_path):
+    """Unknown ARTEFACT_INDEX shape fails closed."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+
+    # Write index with artefacts as a string (unknown shape)
+    index_path.write_text(
+        json.dumps({"meta": {}, "artefacts": "bad_shape"}),
+        encoding="utf-8",
+    )
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path="docs/02_protocols/Test_Protocol_v1.0.md",
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root)
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-12"
+
+
+# ─── AT-DI-12: dict-shaped index update works ────────────────────────────────
+
+
+def test_AT_DI_12_dict_shaped_index_update(tmp_path):
+    """dict-shaped target-index update works."""
+    repo_root, source_path, _ = _scaffold_repo(tmp_path)
+
+    # Create a dict-shaped ARTEFACT_INDEX (like 01_governance, but in 02_protocols for test)
+    index_path = repo_root / "docs" / "02_protocols" / "ARTEFACT_INDEX.json"
+    index_path.write_text(json.dumps(_make_dict_index(), indent=2), encoding="utf-8")
+
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        artefact_key="test_protocol",
+        commit_enabled=True,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)
+
+    result = run(manifest_path, ctx)
+
+    assert result.success, f"Expected success, got: {result.failure_reason}"
+    index_after = json.loads(index_path.read_bytes())
+    assert index_after["artefacts"]["test_protocol"] == dest_rel
+
+
+# ─── AT-DI-13: array-shaped index update preserves schema shape ─────────────
+
+
+def test_AT_DI_13_array_shaped_index_update(tmp_path):
+    """array-shaped target-index update works without destroying schema shape."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=True,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)
+
+    result = run(manifest_path, ctx)
+
+    assert result.success
+    index_after = json.loads(index_path.read_bytes())
+    assert isinstance(index_after["artefacts"], list), "artefacts must remain a list"
+    paths = [e.get("path") for e in index_after["artefacts"] if isinstance(e, dict)]
+    assert dest_rel in paths
+
+
+# ─── AT-DI-14: supersedes target missing fails closed ────────────────────────
+
+
+def test_AT_DI_14_supersedes_missing(tmp_path):
+    """supersedes target missing fails closed with no partial update."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path="docs/02_protocols/Test_Protocol_v1.0.md",
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        supersedes=["docs/02_protocols/OldDoc_v1.0.md"],  # does not exist
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root)
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_invariant == "INV-14"
+    # Index must be unmodified
+    assert json.loads(index_path.read_bytes()) == _make_array_index()
+
+
+# ─── AT-DI-15: supersedes metadata update in array index ────────────────────
+
+
+def test_AT_DI_15_supersedes_metadata_update(tmp_path):
+    """supersedes metadata update works where schema supports superseded_by."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    old_rel = "docs/02_protocols/Old_Protocol_v1.0.md"
+    old_path = repo_root / old_rel
+    old_path.write_text("# Old\n**Status**: Superseded\n**Authority**: Test\n", encoding="utf-8")
+
+    # Pre-populate index with the old entry
+    existing = _make_array_index()
+    existing["artefacts"].append({"path": old_rel})
+    index_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    dest_rel = "docs/02_protocols/New_Protocol_v2.0.md"
+    _make_source_doc(repo_root / "staging" / "New_Protocol_v2.0.md")
+
+    manifest = _make_manifest(
+        source_path=str(repo_root / "staging" / "New_Protocol_v2.0.md"),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        artefact_key="new_protocol",
+        commit_enabled=True,
+        supersedes=[old_rel],
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)
+
+    result = run(manifest_path, ctx)
+
+    assert result.success, f"Expected success, got: {result.failure_reason}"
+    index_after = json.loads(index_path.read_bytes())
+    old_entry = next(
+        (e for e in index_after["artefacts"] if isinstance(e, dict) and e.get("path") == old_rel),
+        None,
+    )
+    assert old_entry is not None
+    assert old_entry.get("superseded_by") == dest_rel
+
+
+# ─── AT-DI-16: idempotent re-run is no-op success ───────────────────────────
+
+
+def test_AT_DI_16_idempotent_rerun(tmp_path):
+    """Identical manifest re-run is idempotent no-op success."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=True,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+
+    # First run (commit)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)
+    result1 = run(manifest_path, ctx)
+    assert result1.success
+
+    # Second run with same manifest (different run_id to avoid log collision)
+    ctx2 = _make_runner_ctx(repo_root, run_id="test-run-002", actually_commit=True)
+    result2 = run(manifest_path, ctx2)
+
+    assert result2.success
+    assert result2.is_idempotent_noop
+
+
+# ─── AT-DI-17: validator failure blocks commit ───────────────────────────────
+
+
+def test_AT_DI_17_validator_failure_records_failure(tmp_path):
+    """Invariant failure blocks commit and records failure result."""
+    repo_root, _, _ = _scaffold_repo(tmp_path)
+
+    # Source with missing headers → INV-10
+    bad_source = repo_root / "staging" / "Bad_v1.0.md"
+    bad_source.write_text("# No headers here\n\nContent.\n", encoding="utf-8")
+
+    manifest = _make_manifest(
+        source_path=str(bad_source),
+        dest_path="docs/02_protocols/Bad_v1.0.md",
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=True,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_reason is not None
+    assert result.failure_invariant is not None
+    # No file committed
+    assert not (repo_root / "docs/02_protocols/Bad_v1.0.md").exists()
+
+
+# ─── AT-DI-18: workspace lock prevents concurrent conflicts ─────────────────
+
+
+def test_AT_DI_18_workspace_lock(tmp_path):
+    """Workspace lock prevents concurrent conflicting ingest runs."""
+    import fcntl
+
+    repo_root, source_path, _ = _scaffold_repo(tmp_path)
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path="docs/02_protocols/Test_Protocol_v1.0.md",
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+
+    # Hold the lock manually
+    lock_path = repo_root / "logs" / "steward_runner" / "doc_ingest.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = open(lock_path, "w")
+    fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+
+    try:
+        ctx = _make_runner_ctx(repo_root)
+        result = run(manifest_path, ctx)
+        assert not result.success
+        assert result.failure_invariant == "INV-20"
+        assert "lock_conflict" in result.failure_reason
+    finally:
+        fcntl.flock(lock_file, fcntl.LOCK_UN)
+        lock_file.close()
+
+
+# ─── Unit tests for helper functions ─────────────────────────────────────────
+
+
+def test_detect_index_shape_dict():
+    data = {"artefacts": {"key": "val"}}
+    assert _detect_index_shape(data) == "dict"
+
+
+def test_detect_index_shape_array():
+    data = {"artefacts": []}
+    assert _detect_index_shape(data) == "array"
+
+
+def test_detect_index_shape_unknown():
+    data = {"artefacts": "bad"}
+    assert _detect_index_shape(data) == "unknown"
+
+
+def test_fingerprint_excludes_commit():
+    m1 = {"schema": SCHEMA_ID, "source_path": "x", "commit": {"enabled": False, "message": "a"}}
+    m2 = {"schema": SCHEMA_ID, "source_path": "x", "commit": {"enabled": False, "message": "b"}}
+    assert _compute_fingerprint(m1) == _compute_fingerprint(m2)
+
+
+def test_fingerprint_sensitive_to_content():
+    m1 = {"schema": SCHEMA_ID, "source_path": "x"}
+    m2 = {"schema": SCHEMA_ID, "source_path": "y"}
+    assert _compute_fingerprint(m1) != _compute_fingerprint(m2)
+
+
+def test_artefact_key_collision_dict():
+    data = {"artefacts": {"existing_key": "docs/foo.md"}}
+    assert _has_artefact_key_collision(data, "dict", "existing_key", "docs/foo.md")
+    assert not _has_artefact_key_collision(data, "dict", "new_key", "docs/bar.md")
+
+
+def test_artefact_key_collision_array():
+    data = {"artefacts": [{"path": "docs/foo.md"}]}
+    assert _has_artefact_key_collision(data, "array", "any_key", "docs/foo.md")
+    assert not _has_artefact_key_collision(data, "array", "any_key", "docs/bar.md")
+
+
+def test_update_index_dict_shape():
+    data = {"artefacts": {"_comment": "comment"}}
+    patches = _update_index(data, "dict", "new_key", "docs/new.md", [])
+    assert data["artefacts"]["new_key"] == "docs/new.md"
+    assert patches == []
+
+
+def test_update_index_array_shape():
+    data = {"artefacts": [{"path": "docs/old.md"}]}
+    _update_index(data, "array", "new_key", "docs/new.md", ["docs/old.md"])
+    entries = data["artefacts"]
+    paths = [e.get("path") for e in entries if isinstance(e, dict)]
+    assert "docs/new.md" in paths
+    old_entry = next(e for e in entries if isinstance(e, dict) and e.get("path") == "docs/old.md")
+    assert old_entry.get("superseded_by") == "docs/new.md"

--- a/tests_recursive/test_doc_ingest.py
+++ b/tests_recursive/test_doc_ingest.py
@@ -796,3 +796,150 @@ def test_idempotency_from_dl_doc_result_packet(tmp_path):
 
     assert result.success, f"Expected idempotent success, got: {result.failure_reason}"
     assert result.is_idempotent_noop
+
+
+# ─── Fix 3: rollback_worktree_mutations ──────────────────────────────────────
+
+
+from runtime.stewardship.doc_ingest import rollback_worktree_mutations  # noqa: E402
+
+
+def test_commit_path_result_has_index_snapshot(tmp_path):
+    """Commit-path run populates pre_ingest_index_snapshot for rollback."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+    original_index = index_path.read_text(encoding="utf-8")
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=True,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)
+
+    result = run(manifest_path, ctx)
+
+    assert result.success
+    assert result.commit_enabled_for_runner
+    assert result.pre_ingest_index_snapshot is not None
+    assert result.pre_ingest_index_path == "docs/02_protocols/ARTEFACT_INDEX.json"
+    # Snapshot must equal the original content before mutation
+    assert result.pre_ingest_index_snapshot == original_index
+
+
+def test_rollback_restores_dest_and_index(tmp_path):
+    """rollback_worktree_mutations removes dest_path and restores index."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+    index_before = _make_array_index()
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=True,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)
+
+    result = run(manifest_path, ctx)
+    assert result.success and result.commit_enabled_for_runner
+
+    # Precondition: mutations are visible
+    assert (repo_root / dest_rel).exists()
+    assert json.loads(index_path.read_bytes()) != index_before
+
+    ok = rollback_worktree_mutations(result, repo_root)
+
+    assert ok, "Rollback must return True on success"
+    assert not (repo_root / dest_rel).exists(), "dest_path must be removed by rollback"
+    assert json.loads(index_path.read_bytes()) == index_before, "index must be restored"
+
+
+def test_rollback_noop_for_dry_run(tmp_path):
+    """rollback_worktree_mutations is a no-op when commit_enabled_for_runner is False."""
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=False,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=False)
+
+    result = run(manifest_path, ctx)
+    assert result.success
+    assert not result.commit_enabled_for_runner
+
+    ok = rollback_worktree_mutations(result, repo_root)
+
+    assert ok
+    assert not (repo_root / dest_rel).exists()  # no mutation happened
+
+
+def test_validator_failure_after_ingest_records_reason(tmp_path):
+    """
+    Failure result from an invariant violation records failure_reason and failure_invariant.
+    This proves the failure path populates the relevant invariant for rollback logging.
+    """
+    repo_root, _, index_path = _scaffold_repo(tmp_path)
+
+    bad_source = repo_root / "staging" / "Bad_v1.0.md"
+    bad_source.write_text("# No status header\n\nContent.\n", encoding="utf-8")
+
+    manifest = _make_manifest(
+        source_path=str(bad_source),
+        dest_path="docs/02_protocols/Bad_v1.0.md",
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=True,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)
+
+    result = run(manifest_path, ctx)
+
+    assert not result.success
+    assert result.failure_reason is not None
+    assert result.failure_invariant is not None
+    # No mutation occurred — rollback not needed but must be safe
+    assert not (repo_root / "docs/02_protocols/Bad_v1.0.md").exists()
+    assert json.loads(index_path.read_bytes()) == _make_array_index()
+
+
+def test_rollback_cleans_partial_mutation_dest_only(tmp_path):
+    """
+    If index restore fails, rollback still removes dest_path and returns False.
+    Simulates partial rollback failure scenario.
+    """
+    repo_root, source_path, index_path = _scaffold_repo(tmp_path)
+    dest_rel = "docs/02_protocols/Test_Protocol_v1.0.md"
+
+    manifest = _make_manifest(
+        source_path=str(source_path),
+        dest_path=dest_rel,
+        target_index_path="docs/02_protocols/ARTEFACT_INDEX.json",
+        commit_enabled=True,
+    )
+    manifest_path = _write_manifest(tmp_path, manifest)
+    ctx = _make_runner_ctx(repo_root, actually_commit=True)
+
+    result = run(manifest_path, ctx)
+    assert result.success
+
+    # Corrupt the result snapshot so index restore will fail
+    from dataclasses import replace
+    broken_result = replace(
+        result,
+        pre_ingest_index_path="nonexistent/path/INDEX.json",
+    )
+
+    ok = rollback_worktree_mutations(broken_result, repo_root)
+
+    assert not ok, "Rollback with bad index path must return False"
+    # dest_path must still be removed despite index restore failure
+    assert not (repo_root / dest_rel).exists(), "dest_path must be removed even on partial failure"

--- a/tests_recursive/test_steward_runner.py
+++ b/tests_recursive/test_steward_runner.py
@@ -917,3 +917,307 @@ class TestAT18ExplicitDryRun:
         commit_skipped = find_event(events, "commit", "skipped")
         assert commit_skipped is not None
         assert commit_skipped.get("reason") == "dry_run"
+
+
+# ─── AT-19 through AT-25: doc_ingest two-commit model + rollback ─────────────
+
+
+INGEST_SCHEMA_ID = "doc_steward.protocol_v1_1.ingest_manifest.v1"
+
+
+def _make_ingest_manifest_data(worktree: Path) -> dict:
+    return {
+        "schema": INGEST_SCHEMA_ID,
+        "schema_version": "1.0",
+        "source_path": "staging/Test_Protocol_v1.0.md",
+        "dest_path": "docs/02_protocols/Test_Protocol_v1.0.md",
+        "title": "Test Protocol v1.0",
+        "description": "Integration test protocol.",
+        "artefact_key": "test_protocol_v1",
+        "target_index_path": "docs/02_protocols/ARTEFACT_INDEX.json",
+        "binding_class": "PROTOCOL",
+        "canonicality": "draft",
+        "supersedes": [],
+        "related": {"issues": [], "prs": [], "adrs": []},
+        "commit": {"enabled": True, "message": "test: ingest"},
+    }
+
+
+def _scaffold_ingest_env(worktree: Path) -> tuple[Path, Path, Path, Path]:
+    """
+    Create staging doc, ARTEFACT_INDEX, and manifest. Commit so worktree is clean.
+    Returns (source_path, dest_path, index_path, manifest_path).
+    """
+    staging = worktree / "staging"
+    staging.mkdir(exist_ok=True)
+    source = staging / "Test_Protocol_v1.0.md"
+    source.write_text(
+        "# Test Protocol v1.0\n\n**Status**: Draft\n**Authority**: Test\n\nContent.\n",
+        encoding="utf-8",
+    )
+
+    proto_dir = worktree / "docs" / "02_protocols"
+    proto_dir.mkdir(parents=True, exist_ok=True)
+    index_path = proto_dir / "ARTEFACT_INDEX.json"
+    index_path.write_text(
+        json.dumps({"meta": {"version": "1.0.0"}, "artefacts": [{"_comment": "protocols"}]},
+                   indent=2),
+        encoding="utf-8",
+    )
+
+    manifest_data = _make_ingest_manifest_data(worktree)
+    manifest_path = worktree / "manifest_test.json"
+    manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
+
+    subprocess.run(["git", "add", "-A"], cwd=worktree, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "[test] scaffold ingest env"],
+        cwd=worktree, capture_output=True,
+    )
+
+    dest = worktree / "docs" / "02_protocols" / "Test_Protocol_v1.0.md"
+    return source, dest, index_path, manifest_path
+
+
+def _ingest_config(
+    worktree: Path,
+    fail_tests: bool = False,
+    fail_validators: bool = False,
+    fail_corpus: bool = False,
+) -> Path:
+    tests_cmd = (
+        '["python3", "-c", "import sys; sys.exit(1)"]' if fail_tests
+        else '["python3", "-c", "print(\'ok\')"]'
+    )
+    validators_block = (
+        'commands:\n    - ["python3", "-c", "import sys; sys.exit(1)"]' if fail_validators
+        else "commands: []"
+    )
+    corpus_cmd = (
+        '["python3", "-c", "import sys; sys.exit(1)"]' if fail_corpus
+        else 'null'
+    )
+
+    content = f"""
+tests:
+  command: {tests_cmd}
+  paths: []
+
+validators:
+  {validators_block}
+
+corpus:
+  command: {corpus_cmd}
+  outputs_expected: []
+
+git:
+  require_clean_start: false
+  commit_enabled: false
+  commit_message_template: "[test] {{run_id}}"
+  commit_paths:
+    - "docs/"
+    - "staging/"
+
+logging:
+  log_dir: "logs/steward_runner"
+  streams_dir: "logs/steward_runner/streams"
+  format: "jsonl"
+
+determinism:
+  run_id_required: true
+  timestamps: false
+
+doc_ingest:
+  allowed_dest_roots:
+    - "docs/02_protocols/"
+  permitted_target_index_paths:
+    - "docs/02_protocols/ARTEFACT_INDEX.json"
+"""
+    cfg = worktree / "config" / "ingest_test.yaml"
+    cfg.parent.mkdir(exist_ok=True)
+    cfg.write_text(content, encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=worktree, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "[test] add ingest config"],
+        cwd=worktree, capture_output=True,
+    )
+    return cfg
+
+
+def _run_runner_with_ingest(
+    worktree: Path,
+    cfg: Path,
+    manifest_path: Path,
+    run_id: str,
+    commit: bool = True,
+) -> subprocess.CompletedProcess:
+    runner = worktree / "scripts" / "steward_runner.py"
+    cmd = [
+        PYTHON, str(runner),
+        "--config", str(cfg.relative_to(worktree)),
+        "--run-id", run_id,
+        "--ingest", str(manifest_path.relative_to(worktree)),
+    ]
+    if commit:
+        cmd.append("--commit")
+    return subprocess.run(cmd, cwd=worktree, capture_output=True, text=True)
+
+
+class TestDocIngestTwoCommitModel:
+    """AT-19 to AT-21: Two-commit ledger model — clean worktree + committed packet."""
+
+    def test_AT_19_successful_commit_leaves_clean_worktree(self, worktree, repo_root):
+        """Successful committed ingest leaves git status --short empty."""
+        _, dest, _, manifest_path = _scaffold_ingest_env(worktree)
+        cfg = _ingest_config(worktree)
+
+        result = _run_runner_with_ingest(worktree, cfg, manifest_path, "at19")
+
+        assert result.returncode == 0, f"Runner failed:\n{result.stderr}"
+
+        status = subprocess.run(
+            ["git", "status", "--short"],
+            cwd=worktree, capture_output=True, text=True,
+        )
+        assert status.stdout.strip() == "", (
+            f"Worktree must be clean after successful ingest commit. "
+            f"Dirty files:\n{status.stdout}"
+        )
+
+    def test_AT_20_result_packet_is_committed_not_dirty(self, worktree, repo_root):
+        """DOC_STEWARD_RESULT packet is tracked in HEAD, not just written to disk."""
+        _, dest, _, manifest_path = _scaffold_ingest_env(worktree)
+        cfg = _ingest_config(worktree)
+
+        result = _run_runner_with_ingest(worktree, cfg, manifest_path, "at20")
+
+        assert result.returncode == 0, f"Runner failed:\n{result.stderr}"
+
+        packet_path = worktree / "artifacts" / "ledger" / "dl_doc" / "at20" / "doc_steward_result.json"
+        assert packet_path.exists(), "Packet must exist on disk"
+
+        rel = str(packet_path.relative_to(worktree))
+        git_show = subprocess.run(
+            ["git", "show", f"HEAD:{rel}"],
+            cwd=worktree, capture_output=True, text=True,
+        )
+        assert git_show.returncode == 0, (
+            f"Packet must be committed in HEAD. git show stderr: {git_show.stderr}"
+        )
+
+    def test_AT_21_result_packet_records_doc_change_sha(self, worktree, repo_root):
+        """Packet commit_sha equals commit A (doc+index), not commit B (packet)."""
+        _, dest, _, manifest_path = _scaffold_ingest_env(worktree)
+        cfg = _ingest_config(worktree)
+
+        result = _run_runner_with_ingest(worktree, cfg, manifest_path, "at21")
+
+        assert result.returncode == 0, f"Runner failed:\n{result.stderr}"
+
+        log_file = worktree / "logs" / "steward_runner" / "at21.jsonl"
+        events = read_log_events(log_file)
+        result_event = next(
+            (e for e in events
+             if e.get("event") == "doc_ingest_result" and e.get("status") == "pass"),
+            None,
+        )
+        assert result_event is not None, "doc_ingest_result pass event must be in log"
+        commit_sha_a = result_event.get("commit_sha_a")
+        assert commit_sha_a, "commit_sha_a must be logged"
+
+        packet_path = worktree / "artifacts" / "ledger" / "dl_doc" / "at21" / "doc_steward_result.json"
+        packet = json.loads(packet_path.read_bytes())
+        assert packet["commit_sha"] == commit_sha_a, (
+            f"Packet commit_sha {packet['commit_sha']!r} must equal "
+            f"logged commit_sha_a {commit_sha_a!r}"
+        )
+
+        # commit A must be parent of HEAD (commit B)
+        parent = subprocess.run(
+            ["git", "rev-parse", "HEAD^"],
+            cwd=worktree, capture_output=True, text=True,
+        ).stdout.strip()
+        assert commit_sha_a == parent, (
+            f"commit A ({commit_sha_a}) must be the parent of HEAD (commit B)"
+        )
+
+
+class TestDocIngestRollbackOnFailure:
+    """AT-22 to AT-25: Rollback on downstream failure after doc_ingest mutation."""
+
+    def _assert_clean(self, worktree: Path) -> None:
+        status = subprocess.run(
+            ["git", "status", "--short"],
+            cwd=worktree, capture_output=True, text=True,
+        )
+        assert status.stdout.strip() == "", (
+            f"Worktree must be clean after rollback.\nDirty files:\n{status.stdout}"
+        )
+
+    def _assert_ingest_reversed(self, dest: Path, index_path: Path) -> None:
+        assert not dest.exists(), "dest_path must be absent after rollback"
+        index = json.loads(index_path.read_bytes())
+        paths = [
+            e.get("path") for e in index.get("artefacts", [])
+            if isinstance(e, dict) and "path" in e
+        ]
+        assert "docs/02_protocols/Test_Protocol_v1.0.md" not in paths, (
+            "Index must not contain ingested doc path after rollback"
+        )
+
+    def test_AT_22_validator_failure_rolls_back_ingest(self, worktree, repo_root):
+        """Validator failure after doc_ingest mutation restores the repo tree."""
+        _, dest, index_path, manifest_path = _scaffold_ingest_env(worktree)
+        cfg = _ingest_config(worktree, fail_validators=True)
+
+        result = _run_runner_with_ingest(worktree, cfg, manifest_path, "at22")
+
+        assert result.returncode != 0
+        self._assert_clean(worktree)
+        self._assert_ingest_reversed(dest, index_path)
+
+    def test_AT_23_corpus_failure_rolls_back_ingest(self, worktree, repo_root):
+        """Corpus failure after doc_ingest mutation restores the repo tree."""
+        _, dest, index_path, manifest_path = _scaffold_ingest_env(worktree)
+        cfg = _ingest_config(worktree, fail_corpus=True)
+
+        result = _run_runner_with_ingest(worktree, cfg, manifest_path, "at23")
+
+        assert result.returncode != 0
+        self._assert_clean(worktree)
+        self._assert_ingest_reversed(dest, index_path)
+
+    def test_AT_24_test_failure_rolls_back_ingest(self, worktree, repo_root):
+        """Test-suite failure after doc_ingest mutation restores the repo tree."""
+        _, dest, index_path, manifest_path = _scaffold_ingest_env(worktree)
+        cfg = _ingest_config(worktree, fail_tests=True)
+
+        result = _run_runner_with_ingest(worktree, cfg, manifest_path, "at24")
+
+        assert result.returncode != 0
+        self._assert_clean(worktree)
+        self._assert_ingest_reversed(dest, index_path)
+
+    def test_AT_25_rollback_logged_on_downstream_failure(self, worktree, repo_root):
+        """Downstream failure records rollback_success or rollback_failed in log."""
+        _, dest, index_path, manifest_path = _scaffold_ingest_env(worktree)
+        cfg = _ingest_config(worktree, fail_validators=True)
+
+        _run_runner_with_ingest(worktree, cfg, manifest_path, "at25")
+
+        log_file = worktree / "logs" / "steward_runner" / "at25.jsonl"
+        assert log_file.exists(), "Runner log must exist"
+        events = read_log_events(log_file)
+
+        rollback_event = next(
+            (e for e in events
+             if e.get("event") == "rollback" and e.get("step") == "doc_ingest"),
+            None,
+        )
+        assert rollback_event is not None, (
+            f"rollback event must be in log. Events: {[e.get('event') for e in events]}"
+        )
+        assert rollback_event.get("status") in ("rollback_success", "rollback_failed"), (
+            f"rollback status must be rollback_success or rollback_failed, "
+            f"got: {rollback_event.get('status')!r}"
+        )

--- a/tests_recursive/test_steward_runner.py
+++ b/tests_recursive/test_steward_runner.py
@@ -15,17 +15,17 @@ when run as a suite due to cumulative fixture cleanup overhead.
 See W0-T05 for tracking.
 """
 
+import importlib.util
 import json
 import os
 import shutil
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
-import importlib.util
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+
 
 # Skip entire module on WSL due to git worktree performance issues
 # Individual tests work, but full suite hangs due to cleanup overhead on /mnt/c/ paths
@@ -37,14 +37,21 @@ def _is_wsl():
     except (OSError, IOError):
         return False
 
+
 pytestmark = pytest.mark.skipif(
-    _is_wsl(),
-    reason="WSL git worktree operations too slow for full suite (W0-T05)"
+    _is_wsl(), reason="WSL git worktree operations too slow for full suite (W0-T05)"
 )
 
 PYTHON = sys.executable
+CORPUS_PRINT_COMMAND = 'command: ["python3", "-c", "print(\'corpus generated\')"]'
+DOC_WRITE_COMMAND = (
+    'command: ["python3", "-c", '
+    "\"import os; os.makedirs('docs', exist_ok=True); "
+    "open('docs/test.md', 'w').write('test')\"]"
+)
 
 # --- Test Fixtures ---
+
 
 @pytest.fixture
 def repo_root() -> Path:
@@ -61,29 +68,29 @@ def repo_root() -> Path:
 def worktree(repo_root: Path, tmp_path: Path):
     """
     Create a git worktree for isolated testing (H1).
-    
+
     Copies untracked/modified steward runner files to worktree so tests
     work before the runner is committed. Commits them so worktree is clean.
-    
+
     Yields the worktree path and cleans up after.
     """
     worktree_path = tmp_path / "test_worktree"
     branch_name = f"test-steward-{os.getpid()}"
-    
+
     # Create orphan branch for isolation
     subprocess.run(
         ["git", "branch", branch_name, "HEAD"],
         cwd=repo_root,
         capture_output=True,
     )
-    
+
     # Create worktree
     subprocess.run(
         ["git", "worktree", "add", str(worktree_path), branch_name],
         cwd=repo_root,
         capture_output=True,
     )
-    
+
     # Copy untracked/modified files needed for running tests
     # These files may not be committed yet during development
     files_to_copy = [
@@ -91,7 +98,7 @@ def worktree(repo_root: Path, tmp_path: Path):
         "config/steward_runner.yaml",
         "doc_steward/cli.py",
     ]
-    
+
     copied_any = False
     for rel_path in files_to_copy:
         src = repo_root / rel_path
@@ -100,7 +107,7 @@ def worktree(repo_root: Path, tmp_path: Path):
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dst)
             copied_any = True
-    
+
     # Commit copied files so worktree starts clean
     if copied_any:
         subprocess.run(
@@ -113,9 +120,9 @@ def worktree(repo_root: Path, tmp_path: Path):
             cwd=worktree_path,
             capture_output=True,
         )
-    
+
     yield worktree_path
-    
+
     # Cleanup
     subprocess.run(
         ["git", "worktree", "remove", "--force", str(worktree_path)],
@@ -134,7 +141,7 @@ def test_config(worktree: Path) -> Path:
     """Create a minimal test config in the worktree and commit it."""
     config_dir = worktree / "config"
     config_dir.mkdir(exist_ok=True)
-    
+
     config_content = """
 repo_root: "."
 
@@ -164,10 +171,10 @@ determinism:
   run_id_required: true
   timestamps: false
 """
-    
+
     config_path = config_dir / "test_runner.yaml"
     config_path.write_text(config_content)
-    
+
     # Commit the config so worktree starts clean
     subprocess.run(["git", "add", "-A"], cwd=worktree, capture_output=True)
     subprocess.run(
@@ -175,7 +182,7 @@ determinism:
         cwd=worktree,
         capture_output=True,
     )
-    
+
     return config_path
 
 
@@ -190,33 +197,33 @@ def run_steward(
 ) -> tuple[int, Path | None]:
     """
     Run the steward runner in the worktree.
-    
+
     Returns (exit_code, log_file_path or None).
     """
     runner_path = worktree / "scripts" / "steward_runner.py"
-    
+
     cmd = [PYTHON, str(runner_path)]
     cmd.extend(["--config", str(config_path.relative_to(worktree))])
-    
+
     if run_id:
         cmd.extend(["--run-id", run_id])
-    
+
     if dry_run:
         cmd.append("--dry-run")
-    
+
     if no_commit:
         cmd.append("--no-commit")
-        
+
     if commit:
         cmd.append("--commit")
-    
+
     result = subprocess.run(
         cmd,
         cwd=worktree,
         capture_output=True,
         text=True,
     )
-    
+
     # Find log file
     log_dir = worktree / "logs" / "steward_runner"
     log_file = None
@@ -224,7 +231,7 @@ def run_steward(
         expected_log = log_dir / f"{run_id}.jsonl"
         if expected_log.exists():
             log_file = expected_log
-    
+
     return result.returncode, log_file
 
 
@@ -247,44 +254,44 @@ def find_event(events: list[dict], step: str, status: str) -> dict | None:
 
 # --- Acceptance Tests ---
 
+
 class TestAT01MissingRunId:
     """AT-01: Missing run-id fails closed."""
-    
+
     def test_missing_run_id_fails(self, worktree: Path, test_config: Path):
         """Invoke without --run-id → exit != 0."""
         runner_path = worktree / "scripts" / "steward_runner.py"
-        
+
         result = subprocess.run(
             [PYTHON, str(runner_path), "--config", str(test_config.relative_to(worktree))],
             cwd=worktree,
             capture_output=True,
             text=True,
         )
-        
+
         assert result.returncode != 0, "Should fail without --run-id"
         assert "required" in result.stderr.lower() or "run-id" in result.stderr.lower()
 
 
 class TestAT02DirtyRepoStart:
     """AT-02: Dirty repo start fails when required."""
-    
+
     def test_dirty_repo_fails_with_require_clean(self, worktree: Path, test_config: Path):
         """With uncommitted change and require_clean_start=true → exit != 0."""
         # Update config to require clean start
         config_content = test_config.read_text().replace(
-            "require_clean_start: false",
-            "require_clean_start: true"
+            "require_clean_start: false", "require_clean_start: true"
         )
         test_config.write_text(config_content)
-        
+
         # Create uncommitted file
         dirty_file = worktree / "dirty_file.txt"
         dirty_file.write_text("uncommitted content")
-        
+
         exit_code, log_file = run_steward(worktree, test_config, run_id="at02-test")
-        
+
         assert exit_code != 0, "Should fail with dirty repo"
-        
+
         if log_file:
             events = read_log_events(log_file)
             fail_event = find_event(events, "preflight", "fail")
@@ -294,26 +301,26 @@ class TestAT02DirtyRepoStart:
 
 class TestAT03TestsFailureBlocksDownstream:
     """AT-03: Tests failure blocks downstream."""
-    
+
     def test_tests_failure_blocks_validators(self, worktree: Path, test_config: Path):
         """Make tests return non-zero → validators/corpus/commit never run."""
         # Update config with failing tests
         config_content = test_config.read_text().replace(
             'command: ["python3", "-c", "print(\'tests pass\')"]',
-            'command: ["python3", "-c", "import sys; sys.exit(1)"]'
+            'command: ["python3", "-c", "import sys; sys.exit(1)"]',
         )
         test_config.write_text(config_content)
-        
+
         exit_code, log_file = run_steward(worktree, test_config, run_id="at03-test")
-        
+
         assert exit_code != 0, "Should fail when tests fail"
-        
+
         if log_file:
             events = read_log_events(log_file)
             # Should have tests.fail
             tests_fail = find_event(events, "tests", "fail")
             assert tests_fail is not None, "Should have tests.fail event"
-            
+
             # Should NOT have validators or corpus events
             for event in events:
                 assert "validator" not in event.get("step", ""), "Validators should not run"
@@ -322,26 +329,26 @@ class TestAT03TestsFailureBlocksDownstream:
 
 class TestAT04ValidatorFailureBlocksCorpus:
     """AT-04: Validator failure blocks corpus."""
-    
+
     def test_validator_failure_blocks_corpus(self, worktree: Path, test_config: Path):
         """Tests pass, validator returns non-zero → corpus not executed."""
         # Update config with failing validator
         config_content = test_config.read_text().replace(
             "validators:\n  commands: []",
-            'validators:\n  commands:\n    - ["python3", "-c", "import sys; sys.exit(1)"]'
+            'validators:\n  commands:\n    - ["python3", "-c", "import sys; sys.exit(1)"]',
         )
         test_config.write_text(config_content)
-        
+
         exit_code, log_file = run_steward(worktree, test_config, run_id="at04-test")
-        
+
         assert exit_code != 0, "Should fail when validator fails"
-        
+
         if log_file:
             events = read_log_events(log_file)
             # Should have validator fail
             validator_fail = find_event(events, "validator_0", "fail")
             assert validator_fail is not None, "Should have validator.fail event"
-            
+
             # Should NOT have corpus event
             for event in events:
                 assert event.get("step") != "corpus", "Corpus should not run"
@@ -349,20 +356,19 @@ class TestAT04ValidatorFailureBlocksCorpus:
 
 class TestAT05CorpusExpectedOutputsEnforced:
     """AT-05: Corpus expected outputs enforced."""
-    
+
     def test_missing_corpus_output_fails(self, worktree: Path, test_config: Path):
         """Corpus exits 0 but any outputs_expected missing → fail."""
         # Update config to expect an output that won't be created
         config_content = test_config.read_text().replace(
-            "outputs_expected: []",
-            'outputs_expected: ["docs/nonexistent.md"]'
+            "outputs_expected: []", 'outputs_expected: ["docs/nonexistent.md"]'
         )
         test_config.write_text(config_content)
-        
+
         exit_code, log_file = run_steward(worktree, test_config, run_id="at05-test")
-        
+
         assert exit_code != 0, "Should fail when expected output missing"
-        
+
         if log_file:
             events = read_log_events(log_file)
             corpus_fail = find_event(events, "corpus", "fail")
@@ -372,13 +378,13 @@ class TestAT05CorpusExpectedOutputsEnforced:
 
 class TestAT06NoChangeNoCommit:
     """AT-06: No change = no commit."""
-    
+
     def test_no_change_exits_success(self, worktree: Path, test_config: Path):
         """Corpus runs, no changes → exit 0; no commit."""
         exit_code, log_file = run_steward(worktree, test_config, run_id="at06-test")
-        
+
         assert exit_code == 0, "Should succeed with no changes"
-        
+
         if log_file:
             events = read_log_events(log_file)
             no_change = find_event(events, "change_detect", "no_change")
@@ -387,25 +393,23 @@ class TestAT06NoChangeNoCommit:
 
 class TestAT07ChangeWithinAllowedPathsCommits:
     """AT-07: Change within allowed paths commits once."""
-    
+
     def test_allowed_change_commits(self, worktree: Path, test_config: Path):
         """Corpus creates diff only within commit_paths → exactly one commit."""
         # Enable commit and create a change in allowed path
         config_content = test_config.read_text().replace(
-            "commit_enabled: false",
-            "commit_enabled: true"
+            "commit_enabled: false", "commit_enabled: true"
         )
         # Make corpus create a file in docs/
         config_content = config_content.replace(
             'command: ["python3", "-c", "print(\'corpus generated\')"]',
-            'command: ["python3", "-c", "import os; os.makedirs(\'docs\', exist_ok=True); open(\'docs/test.md\', \'w\').write(\'test\')"]'
+            DOC_WRITE_COMMAND,
         )
         config_content = config_content.replace(
-            "commit_paths: [\"docs/\"]",
-            'commit_paths: ["docs/"]'
+            'commit_paths: ["docs/"]', 'commit_paths: ["docs/"]'
         )
         test_config.write_text(config_content)
-        
+
         # Commit the config change so only docs/ changes are uncommitted
         subprocess.run(["git", "add", "-A"], cwd=worktree, capture_output=True)
         subprocess.run(
@@ -413,29 +417,29 @@ class TestAT07ChangeWithinAllowedPathsCommits:
             cwd=worktree,
             capture_output=True,
         )
-        
+
         # Ensure docs dir exists
         (worktree / "docs").mkdir(exist_ok=True)
-        
+
         head_before = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             cwd=worktree,
             capture_output=True,
             text=True,
         ).stdout.strip()
-        
+
         exit_code, log_file = run_steward(worktree, test_config, run_id="at07-test", commit=True)
-        
+
         head_after = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             cwd=worktree,
             capture_output=True,
             text=True,
         ).stdout.strip()
-        
+
         assert exit_code == 0, "Should succeed with allowed changes"
         assert head_after != head_before, "HEAD should change after commit"
-        
+
         if log_file:
             events = read_log_events(log_file)
             commit_pass = find_event(events, "commit", "pass")
@@ -444,42 +448,39 @@ class TestAT07ChangeWithinAllowedPathsCommits:
 
 class TestAT08ChangeOutsideAllowedPathsFails:
     """AT-08: Change outside allowed paths fails closed."""
-    
+
     def test_disallowed_change_fails(self, worktree: Path, test_config: Path):
         """Diff touches any path outside commit_paths → exit != 0; no commit."""
         # Enable commit but create change outside allowed path
         config_content = test_config.read_text().replace(
-            "commit_enabled: false",
-            "commit_enabled: true"
+            "commit_enabled: false", "commit_enabled: true"
         )
         # Make corpus create a file outside docs/
         config_content = config_content.replace(
             'command: ["python3", "-c", "print(\'corpus generated\')"]',
-            'command: ["python3", "-c", "open(\'outside.txt\', \'w\').write(\'disallowed\')"]'
+            "command: [\"python3\", \"-c\", \"open('outside.txt', 'w').write('disallowed')\"]",
         )
         test_config.write_text(config_content)
-        
+
         head_before = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             cwd=worktree,
             capture_output=True,
             text=True,
         ).stdout.strip()
-        
 
-        
         exit_code, log_file = run_steward(worktree, test_config, run_id="at08-test", commit=True)
-        
+
         head_after = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             cwd=worktree,
             capture_output=True,
             text=True,
         ).stdout.strip()
-        
+
         assert exit_code != 0, "Should fail with disallowed changes"
         assert head_after == head_before, "HEAD should not change"
-        
+
         if log_file:
             events = read_log_events(log_file)
             commit_fail = find_event(events, "commit", "fail")
@@ -489,42 +490,41 @@ class TestAT08ChangeOutsideAllowedPathsFails:
 
 class TestAT09DryRunNeverCommits:
     """AT-09: Dry run never commits."""
-    
+
     def test_dry_run_skips_commit(self, worktree: Path, test_config: Path):
         """With allowable diff and --dry-run → exit 0; commit skipped."""
         # Enable commit and create allowed change
         config_content = test_config.read_text().replace(
-            "commit_enabled: false",
-            "commit_enabled: true"
+            "commit_enabled: false", "commit_enabled: true"
         )
         config_content = config_content.replace(
             'command: ["python3", "-c", "print(\'corpus generated\')"]',
-            'command: ["python3", "-c", "import os; os.makedirs(\'docs\', exist_ok=True); open(\'docs/test.md\', \'w\').write(\'test\')"]'
+            DOC_WRITE_COMMAND,
         )
         test_config.write_text(config_content)
-        
+
         (worktree / "docs").mkdir(exist_ok=True)
-        
+
         head_before = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             cwd=worktree,
             capture_output=True,
             text=True,
         ).stdout.strip()
-        
+
         # Run with --dry-run
         exit_code, log_file = run_steward(worktree, test_config, run_id="at09-test", dry_run=True)
-        
+
         head_after = subprocess.run(
             ["git", "rev-parse", "HEAD"],
             cwd=worktree,
             capture_output=True,
             text=True,
         ).stdout.strip()
-        
+
         assert exit_code == 0, "Should succeed with dry-run"
         assert head_after == head_before, "HEAD should not change with dry-run"
-        
+
         if log_file:
             events = read_log_events(log_file)
             commit_skipped = find_event(events, "commit", "skipped")
@@ -534,43 +534,42 @@ class TestAT09DryRunNeverCommits:
 
 class TestAT10LogDeterminism:
     """AT-10: Log determinism."""
-    
+
     def test_logs_are_deterministic(self, worktree: Path, test_config: Path):
         """Same repo state + same run_id → byte-identical JSONL."""
         run_id = "at10-determinism"
-        
+
         # First run
         exit_code1, log_file1 = run_steward(worktree, test_config, run_id=run_id)
         assert exit_code1 == 0
         assert log_file1 is not None
         content1 = log_file1.read_text()
-        
+
         # Delete log for second run
         log_file1.unlink()
-        
+
         # Second run with same state and run_id
         exit_code2, log_file2 = run_steward(worktree, test_config, run_id=run_id)
         assert exit_code2 == 0
         assert log_file2 is not None
         content2 = log_file2.read_text()
-        
+
         # H2: byte-identical
         assert content1 == content2, "Logs should be byte-identical for same state/run_id"
 
 
 class TestAT11TestScopeEnforcement:
     """AT-11: Test scope enforcement (P0-1)."""
-    
+
     def test_tests_argv_includes_paths(self, worktree: Path, test_config: Path):
         """tests.paths must appear in the tests step argv."""
         # Update config to have specific test paths
         config_content = test_config.read_text()
         config_content = config_content.replace(
-            "paths: []",
-            'paths: ["path_a", "path_b", "path_c"]'
+            "paths: []", 'paths: ["path_a", "path_b", "path_c"]'
         )
         test_config.write_text(config_content)
-        
+
         # Commit config change
         subprocess.run(["git", "add", "-A"], cwd=worktree, capture_output=True)
         subprocess.run(
@@ -578,43 +577,46 @@ class TestAT11TestScopeEnforcement:
             cwd=worktree,
             capture_output=True,
         )
-        
+
         exit_code, log_file = run_steward(worktree, test_config, run_id="at11-test")
-        
+
         # Test passes or fails, but we need to check the argv
         assert log_file is not None, "Should have log file"
-        
+
         events = read_log_events(log_file)
-        
+
         # Find the tests command event
         tests_event = None
         for event in events:
             if event.get("step") == "tests" and event.get("event") == "command":
                 tests_event = event
                 break
-        
+
         assert tests_event is not None, "Should have tests command event"
-        
+
         argv = tests_event.get("argv", [])
-        
+
         # Assert all paths are in argv in order
         assert "path_a" in argv, "path_a should be in argv"
         assert "path_b" in argv, "path_b should be in argv"
         assert "path_c" in argv, "path_c should be in argv"
-        
+
         # Assert paths appear after the command part
         path_a_idx = argv.index("path_a")
         path_b_idx = argv.index("path_b")
         path_c_idx = argv.index("path_c")
-        
+
         assert path_a_idx < path_b_idx < path_c_idx, "Paths should appear in config order"
 
 
 class TestAT12AllowlistNormalization:
     """AT-12: Allowlist normalization (bare names → directories)."""
-    
+
     @pytest.mark.xfail(
-        reason="Waived: governance/mission-registry-v0.1 — steward runner repair tracked separately. Remove when AT-12 is fixed.",
+        reason=(
+            "Waived: governance/mission-registry-v0.1 — steward runner repair "
+            "tracked separately. Remove when AT-12 is fixed."
+        ),
         strict=True,
     )
     def test_bare_name_normalized_to_directory(self, worktree: Path, test_config: Path):
@@ -623,18 +625,15 @@ class TestAT12AllowlistNormalization:
         config_content = test_config.read_text()
         config_content = config_content.replace(
             'commit_paths: ["docs/"]',
-            'commit_paths: ["docs"]'  # No trailing slash
+            'commit_paths: ["docs"]',  # No trailing slash
         )
-        config_content = config_content.replace(
-            "commit_enabled: false",
-            "commit_enabled: true"
-        )
+        config_content = config_content.replace("commit_enabled: false", "commit_enabled: true")
         config_content = config_content.replace(
             'command: ["python3", "-c", "print(\'corpus generated\')"]',
-            'command: ["python3", "-c", "import os; os.makedirs(\'docs\', exist_ok=True); open(\'docs/test.md\', \'w\').write(\'test\')"]'
+            DOC_WRITE_COMMAND,
         )
         test_config.write_text(config_content)
-        
+
         # Commit config changes
         subprocess.run(["git", "add", "-A"], cwd=worktree, capture_output=True)
         subprocess.run(
@@ -642,18 +641,18 @@ class TestAT12AllowlistNormalization:
             cwd=worktree,
             capture_output=True,
         )
-        
+
         (worktree / "docs").mkdir(exist_ok=True)
-        
+
         exit_code, log_file = run_steward(worktree, test_config, run_id="at12-test")
-        
+
         assert exit_code == 0, "Should succeed with bare name normalized"
         assert log_file is not None
-        
+
         events = read_log_events(log_file)
         commit_event = find_event(events, "commit", "pass")
         assert commit_event is not None, "Should have commit.pass event"
-        
+
         # Normalized paths should have trailing /
         commit_paths = commit_event.get("commit_paths", [])
         assert "docs/" in commit_paths, "Bare name 'docs' should normalize to 'docs/'"
@@ -661,49 +660,52 @@ class TestAT12AllowlistNormalization:
 
 class TestAT13FailClosedUnsafePaths:
     """AT-13: Fail-closed on unsafe commit paths."""
-    
-    @pytest.mark.parametrize("unsafe_path,expected_error", [
-        ("../docs/", "path_traversal"),
-        ("docs/../other/", "path_traversal"),
-        ("docs/*.md", "glob_pattern"),
-        ("docs/?.md", "glob_pattern"),
-        ("C:/temp/", "absolute_path_windows"),
-        ("C:\\temp\\", "absolute_path_windows"),
-        ("/absolute/path/", "absolute_path_unix"),
-        ("/absolute/path/", "absolute_path_unix"),
-        ("//server/share/", "absolute_path_unc"),
-        ("docs%2Ffolder", "url_encoded_chars"),  # P2-B
-    ])
-    def test_unsafe_path_fails(self, worktree: Path, test_config: Path, unsafe_path: str, expected_error: str):
+
+    @pytest.mark.parametrize(
+        "unsafe_path,expected_error",
+        [
+            ("../docs/", "path_traversal"),
+            ("docs/../other/", "path_traversal"),
+            ("docs/*.md", "glob_pattern"),
+            ("docs/?.md", "glob_pattern"),
+            ("C:/temp/", "absolute_path_windows"),
+            ("C:\\temp\\", "absolute_path_windows"),
+            ("/absolute/path/", "absolute_path_unix"),
+            ("/absolute/path/", "absolute_path_unix"),
+            ("//server/share/", "absolute_path_unc"),
+            ("docs%2Ffolder", "url_encoded_chars"),  # P2-B
+        ],
+    )
+    def test_unsafe_path_fails(
+        self, worktree: Path, test_config: Path, unsafe_path: str, expected_error: str
+    ):
         """Unsafe paths fail closed with clear error reason."""
         # Update config with unsafe path
         config_content = test_config.read_text()
         # Escape for YAML
         escaped_path = unsafe_path.replace("\\", "\\\\")
         config_content = config_content.replace(
-            'commit_paths: ["docs/"]',
-            f'commit_paths: ["{escaped_path}"]'
+            'commit_paths: ["docs/"]', f'commit_paths: ["{escaped_path}"]'
         )
-        config_content = config_content.replace(
-            "commit_enabled: false",
-            "commit_enabled: true"
-        )
+        config_content = config_content.replace("commit_enabled: false", "commit_enabled: true")
         # Create a change so commit is attempted
         config_content = config_content.replace(
             'command: ["python3", "-c", "print(\'corpus generated\')"]',
-            'command: ["python3", "-c", "import os; os.makedirs(\'docs\', exist_ok=True); open(\'docs/test.md\', \'w\').write(\'test\')"]'
+            DOC_WRITE_COMMAND,
         )
         test_config.write_text(config_content)
-        
+
         (worktree / "docs").mkdir(exist_ok=True)
-        
+
         (worktree / "docs").mkdir(exist_ok=True)
-        
-        exit_code, log_file = run_steward(worktree, test_config, run_id=f"at13-{expected_error}", commit=True)
-        
+
+        exit_code, log_file = run_steward(
+            worktree, test_config, run_id=f"at13-{expected_error}", commit=True
+        )
+
         assert exit_code != 0, f"Should fail with unsafe path: {unsafe_path}"
         assert log_file is not None
-        
+
         events = read_log_events(log_file)
         commit_fail = find_event(events, "commit", "fail")
         assert commit_fail is not None, "Should have commit.fail event"
@@ -717,7 +719,7 @@ class TestAT14DirtyDuringRun:
     def test_dirty_during_run_rejected(self, worktree: Path, test_config: Path):
         """
         Simulate race condition where repo becomes dirty between change_detect and commit.
-        
+
         Since existing tests use subprocess which makes patching hard, this test
         dynamically loads the runner module and tests run_commit directly.
         """
@@ -726,45 +728,46 @@ class TestAT14DirtyDuringRun:
         spec = importlib.util.spec_from_file_location("steward_runner", runner_path)
         runner_module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(runner_module)
-        
+
         # Setup mocks
         logger = MagicMock()
         config = {"git": {"commit_enabled": True, "commit_paths": ["docs/"]}}
         repo_root = worktree
         run_id = "at14-test"
-        
+
         # Initial changed files (detected by change_detect step)
         initial_changes = ["docs/valid_change.md"]
-        
+
         # Mock get_changed_files to return new dirty file on second call (inside run_commit)
         # First call is explicitly by our test (simulating change_detect)
         # Second call is inside run_commit -> triggers race condition check
-        with patch.object(runner_module, 'get_changed_files') as mock_get_changed:
+        with patch.object(runner_module, "get_changed_files") as mock_get_changed:
             # P1-A logic checks current_changed vs passed changed_files
             # We pass initial_changes to run_commit
             # verify_dirty_state calls get_changed_files()
-            
+
             # Scenario: get_changed_files returns extra file "injected.txt"
             mock_get_changed.return_value = ["docs/valid_change.md", "injected.txt"]
-            
+
             success, _ = runner_module.run_commit(
-                config, logger, repo_root, run_id,
-                initial_changes, False, False
+                config, logger, repo_root, run_id, initial_changes, False, False
             )
-            
+
             assert not success, "Should fail when new dirty file appears"
-            
+
             # Verify log call
             logger.log.assert_called_with(
-                "commit", "commit", "fail",
+                "commit",
+                "commit",
+                "fail",
                 reason="repo_dirty_during_run",
-                unexpected_files=["injected.txt"]
+                unexpected_files=["injected.txt"],
             )
 
 
 class TestAT15LogFieldSorting:
     """AT-15: Log field sorting (P1-B)."""
-    
+
     def test_log_lists_are_sorted(self, worktree: Path, test_config: Path):
         """File lists in logs must be sorted lexicographically."""
         # Create files in unsorted order
@@ -772,26 +775,25 @@ class TestAT15LogFieldSorting:
         filenames = ["z_file.md", "a_file.md", "m_file.md"]
         for name in filenames:
             (worktree / "docs" / name).write_text("test")
-            
+
         # Add them so they show up in changed_files (if committed, verify validated/staged)
         # We need commit_enabled=True to check staged_files/commit_paths
         config_content = test_config.read_text().replace(
-            "commit_enabled: false",
-            "commit_enabled: true"
+            "commit_enabled: false", "commit_enabled: true"
         )
         test_config.write_text(config_content)
-        
+
         # We need to make them dirty first (change_detect)
         # But for 'staged_files' inside commit event, they need to be valid
         # Let's clean worktree first then modify them?
         # fixture creates clean worktree.
         # newly created files are untracked.
-        
+
         exit_code, log_file = run_steward(worktree, test_config, run_id="at15-test", dry_run=True)
         assert exit_code == 0
-        
+
         events = read_log_events(log_file)
-        
+
         checked_any = False
         for event in events:
             for key in ("files", "changed_files", "commit_paths", "disallowed_files"):
@@ -800,44 +802,50 @@ class TestAT15LogFieldSorting:
                     if len(val) > 1:
                         assert val == sorted(val), f"{key} not sorted in {event['step']}"
                         checked_any = True
-        
+
         assert checked_any, "Should have checked at least one list"
 
 
 class TestAT16DefaultDryRun:
     """AT-16: Default is dry-run (P1-D)."""
-    
+
     def test_no_flags_is_dry_run(self, worktree: Path, test_config: Path):
         """Run without flags -> dry run, no commit."""
         # Enable commit in config, but CLI default should override
         config_content = test_config.read_text().replace(
-            "commit_enabled: false",
-            "commit_enabled: true"
+            "commit_enabled: false", "commit_enabled: true"
         )
         config_content = config_content.replace(
             'command: ["python3", "-c", "print(\'corpus generated\')"]',
-            'command: ["python3", "-c", "import os; os.makedirs(\'docs\', exist_ok=True); open(\'docs/test.md\', \'w\').write(\'test\')"]'
+            DOC_WRITE_COMMAND,
         )
         test_config.write_text(config_content)
-        
+
         # Don't pass dry_run=True, leave as default
         # But run_steward helper might need adjustment or allow None
         runner_path = worktree / "scripts" / "steward_runner.py"
-        
+
         # Manual run without helper to ensure no flags
         result = subprocess.run(
-            [PYTHON, str(runner_path), "--config", str(test_config.relative_to(worktree)), "--run-id", "at16"],
+            [
+                PYTHON,
+                str(runner_path),
+                "--config",
+                str(test_config.relative_to(worktree)),
+                "--run-id",
+                "at16",
+            ],
             cwd=worktree,
             capture_output=True,
             text=True,
         )
         assert result.returncode == 0
-        
+
         # Check log for skipped reason
         log_dir = worktree / "logs" / "steward_runner"
         log_file = log_dir / "at16.jsonl"
         events = read_log_events(log_file)
-        
+
         commit_skipped = find_event(events, "commit", "skipped")
         assert commit_skipped is not None
         assert commit_skipped.get("reason") == "dry_run"
@@ -845,19 +853,18 @@ class TestAT16DefaultDryRun:
 
 class TestAT17CommitFlagEnables:
     """AT-17: --commit flag enables commit (P1-D)."""
-    
+
     def test_commit_flag_enables(self, worktree: Path, test_config: Path):
         """Run with --commit -> commit happens."""
         config_content = test_config.read_text().replace(
-            "commit_enabled: false",
-            "commit_enabled: true"
+            "commit_enabled: false", "commit_enabled: true"
         )
         config_content = config_content.replace(
             'command: ["python3", "-c", "print(\'corpus generated\')"]',
-            'command: ["python3", "-c", "import os; os.makedirs(\'docs\', exist_ok=True); open(\'docs/test.md\', \'w\').write(\'test\')"]'
+            DOC_WRITE_COMMAND,
         )
         test_config.write_text(config_content)
-        
+
         # Commit config change so only docs/ changes are uncommitted
         subprocess.run(["git", "add", "-A"], cwd=worktree, capture_output=True)
         subprocess.run(
@@ -865,55 +872,64 @@ class TestAT17CommitFlagEnables:
             cwd=worktree,
             capture_output=True,
         )
-        
+
         # Pass --commit
         exit_code, log_file = run_steward(worktree, test_config, run_id="at17", commit=True)
         assert exit_code == 0
-        
+
         log_dir = worktree / "logs" / "steward_runner"
         log_file = log_dir / "at17.jsonl"
         events = read_log_events(log_file)
-        
+
         # Debug: Check change detection
         change_event = find_event(events, "change_detect", "detected")
         assert change_event is not None, f"Change detection failed. Events: {events}"
         assert "docs/test.md" in change_event.get("changed_files", []), "docs/test.md not detected"
-        
+
         commit_pass = find_event(events, "commit", "pass")
-        assert commit_pass is not None, f"Should have committed with --commit flag. Events: {events}"
+        assert commit_pass is not None, (
+            f"Should have committed with --commit flag. Events: {events}"
+        )
 
 
 class TestAT18ExplicitDryRun:
     """AT-18: Explicit --dry-run (P1-D)."""
-    
+
     def test_explicit_dry_run(self, worktree: Path, test_config: Path):
         """Run with --dry-run -> no commit."""
         # Same setup
         config_content = test_config.read_text().replace(
-            "commit_enabled: false",
-            "commit_enabled: true"
+            "commit_enabled: false", "commit_enabled: true"
         )
         config_content = config_content.replace(
             'command: ["python3", "-c", "print(\'corpus generated\')"]',
-            'command: ["python3", "-c", "import os; os.makedirs(\'docs\', exist_ok=True); open(\'docs/test.md\', \'w\').write(\'test\')"]'
+            DOC_WRITE_COMMAND,
         )
         test_config.write_text(config_content)
-        
+
         runner_path = worktree / "scripts" / "steward_runner.py"
-        
+
         # Pass --dry-run
         result = subprocess.run(
-            [PYTHON, str(runner_path), "--config", str(test_config.relative_to(worktree)), "--run-id", "at18", "--dry-run"],
+            [
+                PYTHON,
+                str(runner_path),
+                "--config",
+                str(test_config.relative_to(worktree)),
+                "--run-id",
+                "at18",
+                "--dry-run",
+            ],
             cwd=worktree,
             capture_output=True,
             text=True,
         )
         assert result.returncode == 0
-        
+
         log_dir = worktree / "logs" / "steward_runner"
         log_file = log_dir / "at18.jsonl"
         events = read_log_events(log_file)
-        
+
         commit_skipped = find_event(events, "commit", "skipped")
         assert commit_skipped is not None
         assert commit_skipped.get("reason") == "dry_run"
@@ -960,8 +976,9 @@ def _scaffold_ingest_env(worktree: Path) -> tuple[Path, Path, Path, Path]:
     proto_dir.mkdir(parents=True, exist_ok=True)
     index_path = proto_dir / "ARTEFACT_INDEX.json"
     index_path.write_text(
-        json.dumps({"meta": {"version": "1.0.0"}, "artefacts": [{"_comment": "protocols"}]},
-                   indent=2),
+        json.dumps(
+            {"meta": {"version": "1.0.0"}, "artefacts": [{"_comment": "protocols"}]}, indent=2
+        ),
         encoding="utf-8",
     )
 
@@ -972,7 +989,8 @@ def _scaffold_ingest_env(worktree: Path) -> tuple[Path, Path, Path, Path]:
     subprocess.run(["git", "add", "-A"], cwd=worktree, capture_output=True)
     subprocess.run(
         ["git", "commit", "-m", "[test] scaffold ingest env"],
-        cwd=worktree, capture_output=True,
+        cwd=worktree,
+        capture_output=True,
     )
 
     dest = worktree / "docs" / "02_protocols" / "Test_Protocol_v1.0.md"
@@ -986,17 +1004,16 @@ def _ingest_config(
     fail_corpus: bool = False,
 ) -> Path:
     tests_cmd = (
-        '["python3", "-c", "import sys; sys.exit(1)"]' if fail_tests
+        '["python3", "-c", "import sys; sys.exit(1)"]'
+        if fail_tests
         else '["python3", "-c", "print(\'ok\')"]'
     )
     validators_block = (
-        'commands:\n    - ["python3", "-c", "import sys; sys.exit(1)"]' if fail_validators
+        'commands:\n    - ["python3", "-c", "import sys; sys.exit(1)"]'
+        if fail_validators
         else "commands: []"
     )
-    corpus_cmd = (
-        '["python3", "-c", "import sys; sys.exit(1)"]' if fail_corpus
-        else 'null'
-    )
+    corpus_cmd = '["python3", "-c", "import sys; sys.exit(1)"]' if fail_corpus else "null"
 
     content = f"""
 tests:
@@ -1039,7 +1056,8 @@ doc_ingest:
     subprocess.run(["git", "add", "-A"], cwd=worktree, capture_output=True)
     subprocess.run(
         ["git", "commit", "-m", "[test] add ingest config"],
-        cwd=worktree, capture_output=True,
+        cwd=worktree,
+        capture_output=True,
     )
     return cfg
 
@@ -1053,10 +1071,14 @@ def _run_runner_with_ingest(
 ) -> subprocess.CompletedProcess:
     runner = worktree / "scripts" / "steward_runner.py"
     cmd = [
-        PYTHON, str(runner),
-        "--config", str(cfg.relative_to(worktree)),
-        "--run-id", run_id,
-        "--ingest", str(manifest_path.relative_to(worktree)),
+        PYTHON,
+        str(runner),
+        "--config",
+        str(cfg.relative_to(worktree)),
+        "--run-id",
+        run_id,
+        "--ingest",
+        str(manifest_path.relative_to(worktree)),
     ]
     if commit:
         cmd.append("--commit")
@@ -1077,11 +1099,12 @@ class TestDocIngestTwoCommitModel:
 
         status = subprocess.run(
             ["git", "status", "--short"],
-            cwd=worktree, capture_output=True, text=True,
+            cwd=worktree,
+            capture_output=True,
+            text=True,
         )
         assert status.stdout.strip() == "", (
-            f"Worktree must be clean after successful ingest commit. "
-            f"Dirty files:\n{status.stdout}"
+            f"Worktree must be clean after successful ingest commit. Dirty files:\n{status.stdout}"
         )
 
     def test_AT_20_result_packet_is_committed_not_dirty(self, worktree, repo_root):
@@ -1093,13 +1116,17 @@ class TestDocIngestTwoCommitModel:
 
         assert result.returncode == 0, f"Runner failed:\n{result.stderr}"
 
-        packet_path = worktree / "artifacts" / "ledger" / "dl_doc" / "at20" / "doc_steward_result.json"
+        packet_path = (
+            worktree / "artifacts" / "ledger" / "dl_doc" / "at20" / "doc_steward_result.json"
+        )
         assert packet_path.exists(), "Packet must exist on disk"
 
         rel = str(packet_path.relative_to(worktree))
         git_show = subprocess.run(
             ["git", "show", f"HEAD:{rel}"],
-            cwd=worktree, capture_output=True, text=True,
+            cwd=worktree,
+            capture_output=True,
+            text=True,
         )
         assert git_show.returncode == 0, (
             f"Packet must be committed in HEAD. git show stderr: {git_show.stderr}"
@@ -1117,15 +1144,20 @@ class TestDocIngestTwoCommitModel:
         log_file = worktree / "logs" / "steward_runner" / "at21.jsonl"
         events = read_log_events(log_file)
         result_event = next(
-            (e for e in events
-             if e.get("event") == "doc_ingest_result" and e.get("status") == "pass"),
+            (
+                e
+                for e in events
+                if e.get("event") == "doc_ingest_result" and e.get("status") == "pass"
+            ),
             None,
         )
         assert result_event is not None, "doc_ingest_result pass event must be in log"
         commit_sha_a = result_event.get("commit_sha_a")
         assert commit_sha_a, "commit_sha_a must be logged"
 
-        packet_path = worktree / "artifacts" / "ledger" / "dl_doc" / "at21" / "doc_steward_result.json"
+        packet_path = (
+            worktree / "artifacts" / "ledger" / "dl_doc" / "at21" / "doc_steward_result.json"
+        )
         packet = json.loads(packet_path.read_bytes())
         assert packet["commit_sha"] == commit_sha_a, (
             f"Packet commit_sha {packet['commit_sha']!r} must equal "
@@ -1135,7 +1167,9 @@ class TestDocIngestTwoCommitModel:
         # commit A must be parent of HEAD (commit B)
         parent = subprocess.run(
             ["git", "rev-parse", "HEAD^"],
-            cwd=worktree, capture_output=True, text=True,
+            cwd=worktree,
+            capture_output=True,
+            text=True,
         ).stdout.strip()
         assert commit_sha_a == parent, (
             f"commit A ({commit_sha_a}) must be the parent of HEAD (commit B)"
@@ -1148,7 +1182,9 @@ class TestDocIngestRollbackOnFailure:
     def _assert_clean(self, worktree: Path) -> None:
         status = subprocess.run(
             ["git", "status", "--short"],
-            cwd=worktree, capture_output=True, text=True,
+            cwd=worktree,
+            capture_output=True,
+            text=True,
         )
         assert status.stdout.strip() == "", (
             f"Worktree must be clean after rollback.\nDirty files:\n{status.stdout}"
@@ -1158,8 +1194,7 @@ class TestDocIngestRollbackOnFailure:
         assert not dest.exists(), "dest_path must be absent after rollback"
         index = json.loads(index_path.read_bytes())
         paths = [
-            e.get("path") for e in index.get("artefacts", [])
-            if isinstance(e, dict) and "path" in e
+            e.get("path") for e in index.get("artefacts", []) if isinstance(e, dict) and "path" in e
         ]
         assert "docs/02_protocols/Test_Protocol_v1.0.md" not in paths, (
             "Index must not contain ingested doc path after rollback"
@@ -1210,8 +1245,7 @@ class TestDocIngestRollbackOnFailure:
         events = read_log_events(log_file)
 
         rollback_event = next(
-            (e for e in events
-             if e.get("event") == "rollback" and e.get("step") == "doc_ingest"),
+            (e for e in events if e.get("event") == "rollback" and e.get("step") == "doc_ingest"),
             None,
         )
         assert rollback_event is not None, (

--- a/tools/validate_doc_steward_manifest.py
+++ b/tools/validate_doc_steward_manifest.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+validate_doc_steward_manifest.py — CLI validator for doc_ingest manifests.
+
+Usage:
+    python tools/validate_doc_steward_manifest.py <manifest_path> [--repo-root PATH]
+
+Exit codes:
+    0  manifest is valid
+    1  manifest is invalid (errors printed to stderr)
+    2  usage error
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _get_repo_root(repo_root_arg: str | None) -> Path:
+    if repo_root_arg:
+        return Path(repo_root_arg).resolve()
+    import subprocess
+
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print("Error: cannot determine repo root via git", file=sys.stderr)
+        sys.exit(2)
+    return Path(result.stdout.strip()).resolve()
+
+
+def validate(manifest_path: Path, repo_root: Path) -> list[str]:
+    """
+    Return list of error strings (empty = valid).
+    Validates against runtime/stewardship/doc_ingest invariants.
+    """
+    errors: list[str] = []
+
+    # Load manifest
+    try:
+        data = json.loads(manifest_path.read_bytes())
+    except (json.JSONDecodeError, OSError) as exc:
+        return [f"Cannot parse manifest JSON: {exc}"]
+
+    if not isinstance(data, dict):
+        return ["Manifest must be a JSON object."]
+
+    # Import enums and constants from doc_ingest
+    sys.path.insert(0, str(repo_root))
+    try:
+        from runtime.stewardship.doc_ingest import (
+            _FILENAME_PATTERN,
+            _FORBIDDEN_MANIFEST_FIELDS,
+            _REQUIRED_HEADERS,
+            _REQUIRED_MANIFEST_FIELDS,
+            SCHEMA_ID,
+            SCHEMA_VERSION,
+            VALID_BINDING_CLASSES,
+            VALID_CANONICALITY_VALUES,
+        )
+    except ImportError as exc:
+        return [f"Cannot import doc_ingest module: {exc}"]
+
+    # Forbidden fields
+    for bad in _FORBIDDEN_MANIFEST_FIELDS:
+        if bad in data:
+            errors.append(f"Forbidden field present: '{bad}'")
+
+    # Required fields
+    missing = _REQUIRED_MANIFEST_FIELDS - set(data.keys())
+    if missing:
+        errors.append(f"Missing required fields: {sorted(missing)}")
+        return errors  # Cannot continue without required fields
+
+    # Schema identity
+    if data.get("schema") != SCHEMA_ID:
+        errors.append(f"schema must be '{SCHEMA_ID}', got: {data.get('schema')!r}")
+    if data.get("schema_version") != SCHEMA_VERSION:
+        errors.append(
+            f"schema_version must be '{SCHEMA_VERSION}', got: {data.get('schema_version')!r}"
+        )
+
+    # Enum checks
+    if data.get("binding_class") not in VALID_BINDING_CLASSES:
+        errors.append(
+            f"binding_class '{data.get('binding_class')}' not in {sorted(VALID_BINDING_CLASSES)}"
+        )
+    if data.get("canonicality") not in VALID_CANONICALITY_VALUES:
+        errors.append(
+            f"canonicality '{data.get('canonicality')}' not in {sorted(VALID_CANONICALITY_VALUES)}"
+        )
+
+    # commit block
+    commit = data.get("commit", {})
+    if not isinstance(commit, dict):
+        errors.append("'commit' must be an object")
+    else:
+        if "enabled" not in commit:
+            errors.append("commit.enabled is required")
+        elif not isinstance(commit["enabled"], bool):
+            errors.append("commit.enabled must be a boolean")
+        if "message" not in commit:
+            errors.append("commit.message is required")
+
+    # source_path existence
+    raw_source = data.get("source_path", "")
+    import os
+
+    source_path = Path(raw_source) if os.path.isabs(raw_source) else repo_root / raw_source
+    if not source_path.exists():
+        errors.append(f"source_path does not exist: {raw_source}")
+
+    # dest_path naming convention
+    raw_dest = data.get("dest_path", "")
+    dest_name = Path(raw_dest).name
+    if not _FILENAME_PATTERN.match(dest_name):
+        errors.append(
+            f"dest_path filename '{dest_name}' does not match naming convention "
+            f"(expected: Name_vX.Y[.Z].md)"
+        )
+
+    # target_index_path existence
+    raw_index = data.get("target_index_path", "")
+    if raw_index:
+        index_path = Path(raw_index) if os.path.isabs(raw_index) else repo_root / raw_index
+        if not index_path.exists():
+            errors.append(f"target_index_path does not exist: {raw_index}")
+
+    # supersedes existence
+    for sup in data.get("supersedes", []):
+        sup_path = Path(sup) if os.path.isabs(sup) else repo_root / sup
+        if not sup_path.exists():
+            errors.append(f"supersedes target does not exist: {sup}")
+
+    # source metadata headers (only check if file exists)
+    if source_path.exists() and not errors:
+        try:
+            text = source_path.read_text(encoding="utf-8")
+            for hdr in _REQUIRED_HEADERS:
+                if hdr not in text:
+                    errors.append(f"Source file missing required header: {hdr}")
+        except OSError as exc:
+            errors.append(f"Cannot read source_path: {exc}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a doc_ingest manifest file.")
+    parser.add_argument("manifest", type=Path, help="Path to manifest JSON file")
+    parser.add_argument(
+        "--repo-root",
+        type=str,
+        default=None,
+        help="Repo root (default: detected via git)",
+    )
+    args = parser.parse_args()
+
+    if not args.manifest.exists():
+        print(f"Error: manifest file not found: {args.manifest}", file=sys.stderr)
+        return 2
+
+    repo_root = _get_repo_root(args.repo_root)
+    errors = validate(args.manifest, repo_root)
+
+    if errors:
+        print(f"INVALID: {args.manifest}", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(f"VALID: {args.manifest}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Patches three blocking issues before merge.

---

## Fix 1 — Two-commit ledger model

**Problem:** `emit_result_packet()` fired after `run_commit()`, writing
`artifacts/ledger/dl_doc/<run_id>/doc_steward_result.json` outside any commit.
Result: dirty worktree after every successful ingest, packet not in git history,
idempotency non-portable across machines.

**Fix:** Two-commit model:
- **Commit A** — ingested doc + target ARTEFACT_INDEX update
- **Commit B** — DOC_STEWARD_RESULT packet (contains commit A SHA)

Runner logs both `commit_sha_a` and `commit_sha_b`. Final `git status --short`
is always empty after a successful committed run.

`config/steward_runner.yaml` `commit_paths` no longer lists `artifacts/ledger/dl_doc/`;
the packet is committed via a dedicated `_commit_result_packet()` call, not through
the main `run_commit()` allowlist path.

---

## Fix 2 — Rollback on post-ingest downstream failure

**Problem:** `doc_ingest.run()` mutates the worktree (copies doc, updates index)
before tests/validators/corpus/commit run. Any downstream failure left the repo
partially mutated.

**Fix:**
- `DocIngestResult` now carries `pre_ingest_index_path` and `pre_ingest_index_snapshot`
  (captured before mutation).
- New `rollback_worktree_mutations()` in `doc_ingest.py` removes `dest_path` and
  restores the index from snapshot.
- `steward_runner.py` calls `_rollback_ingest_if_needed()` on every downstream
  failure (tests / validators / corpus / commit).
- Rollback outcome logged as `rollback_success` or `rollback_failed`; on failure,
  `git status --short` evidence is appended to the log.

---

## Fix 3 — Config comment

`permitted_target_index_paths` comment corrected:

```yaml
# Empty list = fail closed; no target indexes are permitted.
```

---

## Changed files

| File | Change |
|---|---|
| `runtime/stewardship/doc_ingest.py` | snapshot fields, `rollback_worktree_mutations()` |
| `scripts/steward_runner.py` | `_commit_result_packet()`, `_rollback_ingest_if_needed()`, two-commit pipeline |
| `config/steward_runner.yaml` | remove `dl_doc/` from `commit_paths`, fix comment |
| `tests_recursive/test_doc_ingest.py` | +5 rollback unit tests (35 total, all pass) |
| `tests_recursive/test_steward_runner.py` | +7 integration tests AT-19–AT-25 (WSL-skipped locally, active in CI) |

---

## Test results

- `python3 -m pytest tests_recursive/test_doc_ingest.py -q` → **35 passed**
- `python3 -m pytest tests_recursive/test_steward_runner.py -q` → **34 skipped** (WSL worktree skip; active in CI)

### New tests

**test_doc_ingest.py (unit — filesystem only, always run):**
- `test_commit_path_result_has_index_snapshot` — snapshot populated on commit-path run
- `test_rollback_restores_dest_and_index` — rollback removes dest and restores index
- `test_rollback_noop_for_dry_run` — rollback is no-op on dry-run result
- `test_validator_failure_after_ingest_records_reason` — failure invariant recorded
- `test_rollback_cleans_partial_mutation_dest_only` — partial rollback returns False

**test_steward_runner.py (integration — git worktree, CI-active):**
- AT-19: successful commit leaves `git status --short` empty
- AT-20: result packet is tracked in HEAD (not merely written to disk)
- AT-21: packet `commit_sha` equals commit A (parent of HEAD)
- AT-22: validator failure rolls back ingest mutation
- AT-23: corpus failure rolls back ingest mutation
- AT-24: test-suite failure rolls back ingest mutation
- AT-25: rollback status (`rollback_success`/`rollback_failed`) is logged

---

## Ledger semantics after this PR

A successful committed ingest produces exactly two commits:

```
commit B  [steward] result packet <run_id>
  └── artifacts/ledger/dl_doc/<run_id>/doc_steward_result.json
        { commit_sha: <commit_A_sha>, ... }

commit A  [steward] Autonomous run <run_id>
  └── docs/02_protocols/<doc>.md
  └── docs/02_protocols/ARTEFACT_INDEX.json
```

`git status --short` is empty after both commits. The packet records commit A's SHA,
making dl_doc idempotency portable across machines.