### PR TITLE
Enforce Codex-only COO EA dispatch

### DIFF
--- a/.github/workflows/build_loop_nightly.yml
+++ b/.github/workflows/build_loop_nightly.yml
@@ -56,36 +56,17 @@ jobs:
           git config core.autocrlf false
 
       # ── CLI tool validation ────────────────────────────────
-      - name: Validate CLI tools
+      - name: Validate Codex CLI
         id: cli_check
         run: |
-          missing=()
-          present=()
-
-          for tool in claude codex gemini; do
-            if command -v "$tool" > /dev/null 2>&1; then
-              echo "${tool}: OK"
-              present+=("$tool")
-            else
-              echo "::warning::CLI tool not found: ${tool}"
-              missing+=("$tool")
-            fi
-          done
-
-          if [ ${#present[@]} -eq 0 ]; then
-            echo "::error::No CLI tools available. At least one of (claude, codex, gemini) is required."
+          if command -v codex > /dev/null 2>&1; then
+            echo "codex: OK"
+            echo "has_cli=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Codex CLI is required for COO-dispatched EA execution. No Claude/Gemini fallback is allowed."
             echo "has_cli=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
-
-          if [ ${#missing[@]} -gt 0 ]; then
-            MISSING_LIST=$(IFS=,; echo "${missing[*]}")
-            echo "CLI_DEGRADED=1" >> "$GITHUB_ENV"
-            echo "CLI_MISSING=${MISSING_LIST}" >> "$GITHUB_ENV"
-            echo "::warning::Degraded CLI mode — missing tools: ${MISSING_LIST}"
-          fi
-
-          echo "has_cli=true" >> "$GITHUB_OUTPUT"
 
       # ── Pre-flight checks ─────────────────────────────────
       - name: Pre-flight test suite

--- a/.github/workflows/build_loop_nightly.yml
+++ b/.github/workflows/build_loop_nightly.yml
@@ -96,7 +96,8 @@ jobs:
 
           if [ -f /tmp/nightly_order.yaml ]; then
             echo "has_task=true" >> "$GITHUB_OUTPUT"
-            echo "task_ref=$(python -c "import yaml; print(yaml.safe_load(open('/tmp/nightly_order.yaml'))['task_ref'])")" >> "$GITHUB_OUTPUT"
+            TASK_REF=$(python -c "import yaml; print(yaml.safe_load(open('/tmp/nightly_order.yaml'))['task_ref'])")
+            echo "task_ref=$TASK_REF" >> "$GITHUB_OUTPUT"
           else
             echo "has_task=false" >> "$GITHUB_OUTPUT"
             echo "::warning::No tasks available in inbox or queue"
@@ -122,7 +123,8 @@ jobs:
         if: steps.resolve.outputs.has_task == 'true' && inputs.dry_run != 'true'
         run: |
           set +e
-          python -m runtime.cli dispatch submit /tmp/nightly_order.yaml --json > /tmp/dispatch_result.json 2>/tmp/dispatch_stderr.log
+          python -m runtime.cli dispatch submit /tmp/nightly_order.yaml --json \
+            > /tmp/dispatch_result.json 2>/tmp/dispatch_stderr.log
           EXIT_CODE=$?
           set -e
 
@@ -135,8 +137,14 @@ jobs:
           fi
 
           # Extract outcome for issue labeling
-          OUTCOME=$(python -c "import json; d=json.load(open('/tmp/dispatch_result.json')); print(d.get('outcome','UNKNOWN'))" 2>/dev/null || echo "UNKNOWN")
-          REASON=$(python -c "import json; d=json.load(open('/tmp/dispatch_result.json')); print(d.get('reason',''))" 2>/dev/null || echo "")
+          OUTCOME=$(
+            python -c "import json; d=json.load(open('/tmp/dispatch_result.json')); print(d.get('outcome','UNKNOWN'))" \
+              2>/dev/null || echo "UNKNOWN"
+          )
+          REASON=$(
+            python -c "import json; d=json.load(open('/tmp/dispatch_result.json')); print(d.get('reason',''))" \
+              2>/dev/null || echo ""
+          )
           echo "dispatch_outcome=$OUTCOME" >> "$GITHUB_OUTPUT"
           echo "dispatch_reason=$REASON" >> "$GITHUB_OUTPUT"
 

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -58,10 +58,13 @@ model_selection:
 
 
 agents:
+  # COO-dispatched EA policy: Codex is the only execution lane.
+  # Fail closed instead of silently falling back to Claude/Gemini/API dispatch.
   steward:
     dispatch_mode: cli
-    cli_provider: gemini
-    cli_fallback: claude_code
+    cli_provider: codex
+    cli_fallback: ""
+    allow_api_fallback: false
     provider: zen
     model: "claude-sonnet-4-5"
     endpoint: "https://opencode.ai/zen/v1/messages"
@@ -77,7 +80,8 @@ agents:
   builder:
     dispatch_mode: cli
     cli_provider: codex
-    cli_fallback: claude_code
+    cli_fallback: ""
+    allow_api_fallback: false
     provider: zen
     model: "claude-sonnet-4-5"
     endpoint: "https://opencode.ai/zen/v1/messages"
@@ -92,8 +96,9 @@ agents:
 
   designer:
     dispatch_mode: cli
-    cli_provider: claude_code
-    cli_fallback: gemini
+    cli_provider: codex
+    cli_fallback: ""
+    allow_api_fallback: false
     provider: zen
     model: "claude-sonnet-4-5"
     endpoint: "https://opencode.ai/zen/v1/messages"
@@ -121,8 +126,9 @@ agents:
 
   build_cycle:
     dispatch_mode: cli
-    cli_provider: claude_code
-    cli_fallback: codex
+    cli_provider: codex
+    cli_fallback: ""
+    allow_api_fallback: false
     provider: zen
     model: "claude-sonnet-4-5"
     endpoint: "https://opencode.ai/zen/v1/messages"
@@ -179,22 +185,22 @@ cli_providers:
     default_model: ""
     timeout_seconds: 600
     sandbox: true
-    enabled: true
+    enabled: false
   claude_code:
     binary: "claude"
     default_model: ""
     timeout_seconds: 600
     sandbox: true
-    enabled: true
+    enabled: false
 
 council:
   topology: HYBRID
   provider_overrides:
-    Architecture: claude_code
-    Risk: claude_code
-    Governance: claude_code
-    Implementation: claude_code
-    Strategy: claude_code
+    Architecture: codex
+    Risk: codex
+    Governance: codex
+    Implementation: codex
+    Strategy: codex
     Pragmatism: codex
 
 # Zen configuration (Primary)

--- a/runtime/agents/api.py
+++ b/runtime/agents/api.py
@@ -679,16 +679,23 @@ def call_agent_cli(
         logger.info("Role %s not configured for CLI; falling back to API", call.role)
         return call_agent(call, run_id, logger_instance, config)
 
+    agent_cfg = get_agent_config(call.role, config)
+    allow_api_fallback = getattr(agent_cfg, "allow_api_fallback", True)
+
     # CLI providers do not currently expose token usage in a canonical schema.
-    # Preserve call_agent() semantics by using the API path when usage is required.
+    # Preserve call_agent() semantics by using the API path when fallback is allowed.
     if call.require_usage:
+        if not allow_api_fallback:
+            raise AgentAPIError(
+                f"Role {call.role!r} requires token usage, but CLI dispatch cannot provide "
+                "canonical usage and API fallback disabled."
+            )
         logger.info(
             "Role %s requested require_usage; falling back to API for token accounting",
             call.role,
         )
         return call_agent(call, run_id, logger_instance, config)
 
-    agent_cfg = get_agent_config(call.role, config)
     cli_provider_name = agent_cfg.cli_provider
 
     # Compute deterministic IDs
@@ -715,8 +722,16 @@ def call_agent_cli(
         result = _try_cli_dispatch(prompt, agent_cfg.cli_fallback, config, run_id=run_id)
         used_provider = agent_cfg.cli_fallback
 
-    # All CLI providers failed → fall back to API
+    # All CLI providers failed → fall back to API only when policy allows it
     if result is None:
+        if not allow_api_fallback:
+            attempted = [cli_provider_name]
+            if agent_cfg.cli_fallback:
+                attempted.append(agent_cfg.cli_fallback)
+            raise AgentAPIError(
+                f"CLI dispatch failed for role {call.role!r}; API fallback disabled "
+                f"(attempted: {', '.join(attempted)})"
+            )
         logger.warning("All CLI providers failed for %s; falling back to API", call.role)
         return call_agent(call, run_id, logger_instance, config)
 

--- a/runtime/agents/models.py
+++ b/runtime/agents/models.py
@@ -155,6 +155,7 @@ class AgentConfig:
     )
     cli_provider: str = ""  # e.g. "codex", "gemini", "claude_code"
     cli_fallback: str = ""  # secondary CLI provider name for fallback
+    allow_api_fallback: bool = True  # false = fail closed if CLI dispatch cannot run
 
 
 @dataclass
@@ -253,6 +254,7 @@ def load_model_config(config_path: Optional[str] = None) -> ModelConfig:
             dispatch_mode=cfg.get("dispatch_mode", "api"),
             cli_provider=cfg.get("cli_provider", ""),
             cli_fallback=cfg.get("cli_fallback", ""),
+            allow_api_fallback=cfg.get("allow_api_fallback", True),
         )
 
     # Load CLI provider configs

--- a/runtime/orchestration/council/multi_provider.py
+++ b/runtime/orchestration/council/multi_provider.py
@@ -112,6 +112,7 @@ def build_multi_provider_executor(
                     api_key_env="",
                     dispatch_mode="cli",
                     cli_provider=cli_provider_name,
+                    allow_api_fallback=False,
                 )
                 config_copy = copy.copy(config)
                 config_copy.agents = dict(config.agents)

--- a/runtime/tests/test_codex_only_dispatch_policy.py
+++ b/runtime/tests/test_codex_only_dispatch_policy.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from runtime.agents.api import AgentAPIError, AgentCall, call_agent_cli
+from runtime.agents.cli_dispatch import CLIDispatchResult, CLIProvider
+from runtime.agents.models import load_model_config
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_configured_cli_dispatch_policy_is_codex_only() -> None:
+    config = load_model_config(str(REPO_ROOT / "config" / "models.yaml"))
+
+    cli_roles = {
+        role: agent
+        for role, agent in config.agents.items()
+        if agent.dispatch_mode == "cli"
+    }
+    assert cli_roles, "expected at least one CLI-dispatched role"
+
+    for role, agent in cli_roles.items():
+        assert agent.cli_provider == "codex", f"{role} must dispatch through Codex"
+        assert agent.cli_fallback == "", f"{role} must not fall back to another CLI EA"
+        assert getattr(agent, "allow_api_fallback", None) is False, (
+            f"{role} must fail closed instead of falling back to API dispatch"
+        )
+
+    enabled_cli_providers = [
+        name for name, provider in config.cli_providers.items() if provider.enabled
+    ]
+    assert enabled_cli_providers == ["codex"]
+
+    assert config.council_provider_overrides
+    assert set(config.council_provider_overrides.values()) == {"codex"}
+
+
+def test_build_loop_workflow_requires_codex_only_cli() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "build_loop_nightly.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "command -v codex" in workflow
+    assert "for tool in claude codex gemini" not in workflow
+    assert "At least one of (claude, codex, gemini)" not in workflow
+
+
+@patch("runtime.agents.api.call_agent")
+@patch("runtime.agents.cli_dispatch.dispatch_cli_agent")
+@patch("runtime.agents.api._load_role_prompt", return_value=("system prompt", "sha256:abc"))
+def test_cli_dispatch_can_fail_closed_when_api_fallback_is_disabled(
+    mock_prompt, mock_dispatch, mock_call_agent
+) -> None:
+    config = load_model_config(str(REPO_ROOT / "config" / "models.yaml"))
+    agent = config.agents["builder"]
+    assert agent.cli_provider == "codex"
+    setattr(agent, "allow_api_fallback", False)
+
+    mock_dispatch.return_value = CLIDispatchResult(
+        output="",
+        exit_code=1,
+        latency_ms=100,
+        provider=CLIProvider.CODEX,
+        model="",
+        partial=False,
+        errors=["usage limit"],
+    )
+
+    with pytest.raises(AgentAPIError, match="API fallback disabled"):
+        call_agent_cli(AgentCall(role="builder", packet={"task": "test"}), config=config)
+
+    mock_call_agent.assert_not_called()

--- a/runtime/tests/test_codex_only_dispatch_policy.py
+++ b/runtime/tests/test_codex_only_dispatch_policy.py
@@ -7,7 +7,6 @@ from runtime.agents.api import AgentAPIError, AgentCall, call_agent_cli
 from runtime.agents.cli_dispatch import CLIDispatchResult, CLIProvider
 from runtime.agents.models import load_model_config
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -15,9 +14,7 @@ def test_configured_cli_dispatch_policy_is_codex_only() -> None:
     config = load_model_config(str(REPO_ROOT / "config" / "models.yaml"))
 
     cli_roles = {
-        role: agent
-        for role, agent in config.agents.items()
-        if agent.dispatch_mode == "cli"
+        role: agent for role, agent in config.agents.items() if agent.dispatch_mode == "cli"
     }
     assert cli_roles, "expected at least one CLI-dispatched role"
 
@@ -56,7 +53,7 @@ def test_cli_dispatch_can_fail_closed_when_api_fallback_is_disabled(
     config = load_model_config(str(REPO_ROOT / "config" / "models.yaml"))
     agent = config.agents["builder"]
     assert agent.cli_provider == "codex"
-    setattr(agent, "allow_api_fallback", False)
+    agent.allow_api_fallback = False
 
     mock_dispatch.return_value = CLIDispatchResult(
         output="",

--- a/runtime/tools/workflow_pack.py
+++ b/runtime/tools/workflow_pack.py
@@ -815,7 +815,7 @@ def discover_changed_files(repo_root: Path, branch: str | None = None) -> list[s
                     continue
                 candidate_path = repo / candidate
                 if candidate_path.is_dir():
-                    for nested in candidate_path.rglob("*"):
+                    for nested in sorted(candidate_path.rglob("*")):
                         if nested.is_file():
                             files.append(str(nested.relative_to(repo)).replace(os.sep, "/"))
                     continue


### PR DESCRIPTION
## Summary
- Route COO-dispatched EA CLI roles through Codex only.
- Disable Claude/Gemini CLI providers and fail closed instead of falling back to API/other CLIs.
- Require Codex in the build-loop workflow and add regression coverage for the Codex-only policy.

## Test plan
- [x] `pytest runtime/tests/test_codex_only_dispatch_policy.py -q`
- [x] `pytest runtime/tests/test_call_agent_cli.py runtime/tests/test_multi_provider_lenses.py runtime/tests/test_codex_only_dispatch_policy.py -q`
- [x] `pytest runtime/tests -q` — 3210 passed, 6 skipped

Notes:
- `lane:codex` label was created on the repo for COO-dispatched EA work.
- Direct Codex smoke dispatch is still blocked by Codex usage quota until reset, not by LifeOS wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)