### PR TITLE
fix(receipts): validate EA worker receipts

### DIFF
--- a/runtime/receipts/ea_receipt.py
+++ b/runtime/receipts/ea_receipt.py
@@ -1,0 +1,93 @@
+"""Validator for EA worker receipts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+EA_RECEIPT_SCHEMA_VERSION = "ea_receipt.v0"
+EA_RECEIPT_REQUIRED_FIELDS = (
+    "schema_version",
+    "status",
+    "commands_run",
+    "inner_exit_codes",
+    "files_changed",
+    "tests_run",
+    "blockers",
+)
+EA_RECEIPT_STATUSES = {"success", "failure"}
+
+
+class EAReceiptValidationError(Exception):
+    """Raised when an EA receipt is missing or invalid."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__("Invalid EA receipt:\n" + "\n".join(f"  - {error}" for error in errors))
+
+
+def validate_ea_receipt(receipt: Any) -> list[str]:
+    """Return validation errors for an ea_receipt.v0 object."""
+    if not isinstance(receipt, dict):
+        return ["receipt must be a JSON object"]
+
+    errors: list[str] = []
+    for field in EA_RECEIPT_REQUIRED_FIELDS:
+        if field not in receipt:
+            errors.append(f"missing required field: {field}")
+
+    if errors:
+        return errors
+
+    if receipt["schema_version"] != EA_RECEIPT_SCHEMA_VERSION:
+        errors.append("schema_version must be ea_receipt.v0")
+
+    status = receipt["status"]
+    if status not in EA_RECEIPT_STATUSES:
+        errors.append("status must be one of: failure, success")
+
+    for field in ("commands_run", "files_changed", "tests_run", "blockers"):
+        value = receipt[field]
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            errors.append(f"{field} must be a list of strings")
+
+    exit_codes = receipt["inner_exit_codes"]
+    if not isinstance(exit_codes, list) or not all(
+        isinstance(item, int) and not isinstance(item, bool) for item in exit_codes
+    ):
+        errors.append("inner_exit_codes must be a list of integers")
+        exit_codes = []
+
+    if any(code != 0 for code in exit_codes) and status == "success":
+        errors.append("status must be failure when any inner_exit_codes value is nonzero")
+
+    blockers = receipt["blockers"]
+    if status == "failure" and isinstance(blockers, list) and not blockers:
+        errors.append("failure status requires non-empty blockers")
+
+    return errors
+
+
+def assert_valid_ea_receipt(receipt: Any) -> None:
+    """Raise EAReceiptValidationError when receipt is invalid."""
+    errors = validate_ea_receipt(receipt)
+    if errors:
+        raise EAReceiptValidationError(errors)
+
+
+def load_and_validate_ea_receipt(path: str | Path) -> dict[str, Any]:
+    """Load an EA receipt from disk and fail closed on missing or malformed JSON."""
+    receipt_path = Path(path)
+    try:
+        raw = receipt_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise EAReceiptValidationError([f"receipt not found: {receipt_path}"]) from exc
+
+    try:
+        receipt = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise EAReceiptValidationError([f"receipt is not valid JSON: {exc.msg}"]) from exc
+
+    assert_valid_ea_receipt(receipt)
+    return receipt

--- a/runtime/tests/receipts/test_ea_receipt.py
+++ b/runtime/tests/receipts/test_ea_receipt.py
@@ -1,0 +1,119 @@
+"""Tests for ea_receipt.v0 validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from runtime.receipts.ea_receipt import (
+    EAReceiptValidationError,
+    load_and_validate_ea_receipt,
+    validate_ea_receipt,
+)
+
+
+def _valid_receipt() -> dict[str, object]:
+    return {
+        "schema_version": "ea_receipt.v0",
+        "status": "success",
+        "commands_run": ["pytest runtime/tests/receipts/test_ea_receipt.py -q"],
+        "inner_exit_codes": [0],
+        "files_changed": ["runtime/receipts/ea_receipt.py"],
+        "tests_run": ["runtime/tests/receipts/test_ea_receipt.py"],
+        "blockers": [],
+    }
+
+
+def test_success_receipt_valid() -> None:
+    assert validate_ea_receipt(_valid_receipt()) == []
+
+
+def test_failure_receipt_valid_with_blocker() -> None:
+    receipt = _valid_receipt()
+    receipt["status"] = "failure"
+    receipt["inner_exit_codes"] = [1]
+    receipt["blockers"] = ["targeted tests failed"]
+
+    assert validate_ea_receipt(receipt) == []
+
+
+def test_missing_receipt_fails_closed(tmp_path: Path) -> None:
+    with pytest.raises(EAReceiptValidationError, match="receipt not found"):
+        load_and_validate_ea_receipt(tmp_path / "ea_receipt.json")
+
+
+def test_malformed_json_fails_closed(tmp_path: Path) -> None:
+    path = tmp_path / "ea_receipt.json"
+    path.write_text("{", encoding="utf-8")
+
+    with pytest.raises(EAReceiptValidationError, match="receipt is not valid JSON"):
+        load_and_validate_ea_receipt(path)
+
+
+def test_missing_keys_fail() -> None:
+    receipt = _valid_receipt()
+    del receipt["commands_run"]
+
+    assert validate_ea_receipt(receipt) == ["missing required field: commands_run"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("schema_version", "ea_receipt.v1", "schema_version must be ea_receipt.v0"),
+        ("status", "blocked", "status must be one of: failure, success"),
+    ],
+)
+def test_bad_schema_or_status_fail(field: str, value: str, expected: str) -> None:
+    receipt = _valid_receipt()
+    receipt[field] = value
+
+    assert expected in validate_ea_receipt(receipt)
+
+
+def test_nonzero_success_mismatch_fails() -> None:
+    receipt = _valid_receipt()
+    receipt["inner_exit_codes"] = [0, 2]
+
+    assert (
+        "status must be failure when any inner_exit_codes value is nonzero"
+        in validate_ea_receipt(receipt)
+    )
+
+
+def test_failure_without_blocker_fails() -> None:
+    receipt = _valid_receipt()
+    receipt["status"] = "failure"
+
+    assert "failure status requires non-empty blockers" in validate_ea_receipt(receipt)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("commands_run", ["ok", 1], "commands_run must be a list of strings"),
+        ("inner_exit_codes", [False], "inner_exit_codes must be a list of integers"),
+        (
+            "files_changed",
+            "runtime/receipts/ea_receipt.py",
+            "files_changed must be a list of strings",
+        ),
+        ("tests_run", [None], "tests_run must be a list of strings"),
+        ("blockers", [1], "blockers must be a list of strings"),
+    ],
+)
+def test_field_type_errors(field: str, value: object, expected: str) -> None:
+    receipt = _valid_receipt()
+    receipt[field] = value
+
+    assert expected in validate_ea_receipt(receipt)
+
+
+def test_load_and_validate_returns_receipt(tmp_path: Path) -> None:
+    receipt = _valid_receipt()
+    path = tmp_path / "ea_receipt.json"
+    path.write_text(json.dumps(receipt), encoding="utf-8")
+
+    assert load_and_validate_ea_receipt(path) == receipt


### PR DESCRIPTION
Closes #60

## Changes

- Adds `ea_receipt.v0` validator in `runtime/receipts/ea_receipt.py`
- Adds focused validation tests in `runtime/tests/receipts/test_ea_receipt.py`
- Fails closed for missing/malformed receipts
- Requires failure receipts for non-zero inner command exits
- Requires blockers on failure status

## Evidence

COO-verified targeted suite:

```text
pytest runtime/tests/receipts/test_ea_receipt.py runtime/tests/test_emit_dispatch_receipt.py runtime/tests/orchestration/coo/test_invoke_receipts.py -q
43 passed
```

EA clean run also reported changed-scope quality gate blocking checks passed:

- ruff check: pass
- ruff format --check: pass
- mypy: unavailable locally/advisory

## Notes

This PR intentionally implements only the first guardrail: receipt validation. Broader dispatch integration remains future work.
