### PR TITLE
Add shared Google Calendar webhook surface

### DIFF
--- a/runtime/channels/google_calendar/__init__.py
+++ b/runtime/channels/google_calendar/__init__.py
@@ -1,0 +1,33 @@
+"""Shared Google Calendar webhook surface for LifeOS agents."""
+
+from runtime.channels.google_calendar.adapters import for_hermes, for_openclaw
+from runtime.channels.google_calendar.envelope import (
+    CalendarEventEnvelope,
+    CalendarPrivacyConfig,
+    GoogleCalendarEvent,
+    build_event_envelope,
+)
+from runtime.channels.google_calendar.processor import (
+    CalendarEventChangeBatch,
+    CalendarEventsClient,
+    CalendarWebhookProcessor,
+    GoogleCalendarNotification,
+    WebhookProcessResult,
+)
+from runtime.channels.google_calendar.state import CalendarChannelState, CalendarWebhookStateStore
+
+__all__ = [
+    "CalendarChannelState",
+    "CalendarEventChangeBatch",
+    "CalendarEventEnvelope",
+    "CalendarEventsClient",
+    "CalendarPrivacyConfig",
+    "CalendarWebhookProcessor",
+    "CalendarWebhookStateStore",
+    "GoogleCalendarEvent",
+    "GoogleCalendarNotification",
+    "WebhookProcessResult",
+    "build_event_envelope",
+    "for_hermes",
+    "for_openclaw",
+]

--- a/runtime/channels/google_calendar/adapters.py
+++ b/runtime/channels/google_calendar/adapters.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def for_openclaw(envelope: Mapping[str, Any]) -> dict[str, Any]:
+    """Thin adapter preserving shared envelope while tagging OpenClaw consumer."""
+    return {
+        "kind": "lifeos.calendar_event.forward.v0",
+        "target": "openclaw",
+        "envelope": dict(envelope),
+    }
+
+
+def for_hermes(envelope: Mapping[str, Any]) -> dict[str, Any]:
+    """Thin adapter preserving shared envelope while tagging Hermes consumer."""
+    return {
+        "kind": "lifeos.calendar_event.forward.v0",
+        "target": "hermes",
+        "envelope": dict(envelope),
+    }

--- a/runtime/channels/google_calendar/envelope.py
+++ b/runtime/channels/google_calendar/envelope.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+EventAction = Literal["created", "updated", "cancelled"]
+
+
+@dataclass(frozen=True)
+class CalendarPrivacyConfig:
+    include_description: bool = False
+    include_attendees: bool = False
+    include_attendee_emails: bool = False
+
+
+@dataclass(frozen=True)
+class GoogleCalendarEvent:
+    event_id: str
+    status: str = "confirmed"
+    summary: str | None = None
+    html_link: str | None = None
+    created: str | None = None
+    updated: str | None = None
+    start: dict[str, Any] = field(default_factory=dict)
+    end: dict[str, Any] = field(default_factory=dict)
+    organizer: dict[str, Any] = field(default_factory=dict)
+    attendees: tuple[dict[str, Any], ...] = field(default_factory=tuple)
+    description: str | None = None
+
+    @classmethod
+    def from_api(cls, payload: dict[str, Any]) -> "GoogleCalendarEvent":
+        raw_attendees = payload.get("attendees") or []
+        attendees = tuple(item for item in raw_attendees if isinstance(item, dict))
+        return cls(
+            event_id=str(payload.get("id", "")).strip(),
+            status=str(payload.get("status", "confirmed")).strip() or "confirmed",
+            summary=payload.get("summary") if isinstance(payload.get("summary"), str) else None,
+            html_link=payload.get("htmlLink") if isinstance(payload.get("htmlLink"), str) else None,
+            created=payload.get("created") if isinstance(payload.get("created"), str) else None,
+            updated=payload.get("updated") if isinstance(payload.get("updated"), str) else None,
+            start=payload.get("start") if isinstance(payload.get("start"), dict) else {},
+            end=payload.get("end") if isinstance(payload.get("end"), dict) else {},
+            organizer=(
+                payload.get("organizer") if isinstance(payload.get("organizer"), dict) else {}
+            ),
+            attendees=attendees,
+            description=(
+                payload.get("description") if isinstance(payload.get("description"), str) else None
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class CalendarEventEnvelope:
+    schema_version: str
+    source: str
+    calendar_id: str
+    event_id: str
+    action: EventAction
+    time_window: dict[str, Any]
+    organizer: dict[str, Any]
+    attendees: dict[str, Any] | list[dict[str, Any]]
+    link: str | None
+    summary: str | None
+    description: str | None
+    privacy: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "schema_version": self.schema_version,
+            "source": self.source,
+            "calendar_id": self.calendar_id,
+            "event_id": self.event_id,
+            "action": self.action,
+            "time_window": self.time_window,
+            "organizer": self.organizer,
+            "attendees": self.attendees,
+            "link": self.link,
+            "summary": self.summary,
+            "privacy": self.privacy,
+        }
+        if self.description is not None:
+            payload["description"] = self.description
+        return payload
+
+
+def _event_action(event: GoogleCalendarEvent, *, previous_sync_token: str | None) -> EventAction:
+    if event.status == "cancelled":
+        return "cancelled"
+    if not previous_sync_token:
+        return "created"
+    if event.created and event.updated and event.created == event.updated:
+        return "created"
+    return "updated"
+
+
+def _time_window(event: GoogleCalendarEvent) -> dict[str, Any]:
+    return {
+        "start": event.start.get("dateTime") or event.start.get("date"),
+        "end": event.end.get("dateTime") or event.end.get("date"),
+        "all_day": bool(event.start.get("date") and not event.start.get("dateTime")),
+        "timezone": event.start.get("timeZone") or event.end.get("timeZone"),
+    }
+
+
+def _organizer(event: GoogleCalendarEvent) -> dict[str, Any]:
+    return {
+        "display_name": event.organizer.get("displayName"),
+        "email": event.organizer.get("email"),
+        "self": event.organizer.get("self"),
+    }
+
+
+def _attendees(
+    attendees: tuple[dict[str, Any], ...], privacy: CalendarPrivacyConfig
+) -> dict[str, Any] | list[dict[str, Any]]:
+    if not privacy.include_attendees:
+        return {"redacted": True, "count": len(attendees)}
+
+    visible = []
+    for attendee in attendees:
+        item = {
+            "display_name": attendee.get("displayName"),
+            "response_status": attendee.get("responseStatus"),
+            "optional": attendee.get("optional"),
+        }
+        if privacy.include_attendee_emails:
+            item["email"] = attendee.get("email")
+        visible.append(item)
+    return visible
+
+
+def build_event_envelope(
+    *,
+    calendar_id: str,
+    event: GoogleCalendarEvent,
+    previous_sync_token: str | None,
+    privacy: CalendarPrivacyConfig | None = None,
+) -> dict[str, Any]:
+    if privacy is None:
+        privacy = CalendarPrivacyConfig()
+    envelope = CalendarEventEnvelope(
+        schema_version="lifeos.calendar_event.v0",
+        source="google_calendar",
+        calendar_id=calendar_id,
+        event_id=event.event_id,
+        action=_event_action(event, previous_sync_token=previous_sync_token),
+        time_window=_time_window(event),
+        organizer=_organizer(event),
+        attendees=_attendees(event.attendees, privacy),
+        link=event.html_link,
+        summary=event.summary,
+        description=event.description if privacy.include_description else None,
+        privacy={
+            "description_included": privacy.include_description,
+            "attendees_included": privacy.include_attendees,
+            "attendee_emails_included": privacy.include_attendee_emails,
+        },
+    )
+    return envelope.to_dict()

--- a/runtime/channels/google_calendar/envelope.py
+++ b/runtime/channels/google_calendar/envelope.py
@@ -31,8 +31,11 @@ class GoogleCalendarEvent:
     def from_api(cls, payload: dict[str, Any]) -> "GoogleCalendarEvent":
         raw_attendees = payload.get("attendees") or []
         attendees = tuple(item for item in raw_attendees if isinstance(item, dict))
+        event_id = str(payload.get("id", "")).strip()
+        if not event_id:
+            raise ValueError("google_calendar_event_missing_id")
         return cls(
-            event_id=str(payload.get("id", "")).strip(),
+            event_id=event_id,
             status=str(payload.get("status", "confirmed")).strip() or "confirmed",
             summary=payload.get("summary") if isinstance(payload.get("summary"), str) else None,
             html_link=payload.get("htmlLink") if isinstance(payload.get("htmlLink"), str) else None,

--- a/runtime/channels/google_calendar/processor.py
+++ b/runtime/channels/google_calendar/processor.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from runtime.channels.google_calendar.envelope import (
+    CalendarPrivacyConfig,
+    GoogleCalendarEvent,
+    build_event_envelope,
+)
+from runtime.channels.google_calendar.state import CalendarChannelState, CalendarWebhookStateStore
+
+
+@dataclass(frozen=True)
+class GoogleCalendarNotification:
+    channel_id: str
+    resource_id: str
+    resource_state: str
+    message_number: int
+    resource_uri: str | None = None
+    channel_expiration: str | None = None
+
+    @classmethod
+    def from_headers(cls, headers: dict[str, str]) -> "GoogleCalendarNotification":
+        normalized = {key.lower(): value for key, value in headers.items()}
+        return cls(
+            channel_id=normalized["x-goog-channel-id"].strip(),
+            resource_id=normalized["x-goog-resource-id"].strip(),
+            resource_state=normalized["x-goog-resource-state"].strip(),
+            message_number=int(normalized["x-goog-message-number"]),
+            resource_uri=normalized.get("x-goog-resource-uri"),
+            channel_expiration=normalized.get("x-goog-channel-expiration"),
+        )
+
+    @property
+    def dedupe_key(self) -> str:
+        return f"{self.channel_id}:{self.resource_id}:{self.message_number}"
+
+
+@dataclass(frozen=True)
+class CalendarEventChangeBatch:
+    events: tuple[dict[str, Any], ...]
+    next_sync_token: str
+
+
+class CalendarEventsClient(Protocol):
+    def list_event_changes(
+        self,
+        *,
+        calendar_id: str,
+        sync_token: str | None,
+    ) -> CalendarEventChangeBatch:
+        """Return changed events and next sync token. Implementer owns Google API calls."""
+
+
+@dataclass(frozen=True)
+class WebhookProcessResult:
+    status: str
+    calendar_id: str | None = None
+    envelopes: tuple[dict[str, Any], ...] = ()
+    dedupe_key: str | None = None
+    reason: str | None = None
+    initial_sync_suppressed: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "calendar_id": self.calendar_id,
+            "envelopes": list(self.envelopes),
+            "dedupe_key": self.dedupe_key,
+            "reason": self.reason,
+            "initial_sync_suppressed": self.initial_sync_suppressed,
+        }
+
+
+class CalendarWebhookProcessor:
+    def __init__(
+        self,
+        *,
+        state_store: CalendarWebhookStateStore,
+        events_client: CalendarEventsClient,
+        privacy: CalendarPrivacyConfig | None = None,
+    ) -> None:
+        self._state_store = state_store
+        self._events_client = events_client
+        self._privacy = privacy or CalendarPrivacyConfig()
+
+    def register_channel(
+        self,
+        *,
+        channel_id: str,
+        resource_id: str,
+        calendar_id: str = "primary",
+        expiration_ms: int | None = None,
+        sync_token: str | None = None,
+    ) -> CalendarChannelState:
+        state = self._state_store.load()
+        channel = CalendarChannelState(
+            channel_id=channel_id,
+            resource_id=resource_id,
+            calendar_id=calendar_id,
+            expiration_ms=expiration_ms,
+            sync_token=sync_token,
+        )
+        state.channels[channel_id] = channel
+        self._state_store.save(state)
+        return channel
+
+    def process_notification(
+        self,
+        notification: GoogleCalendarNotification,
+    ) -> WebhookProcessResult:
+        state = self._state_store.load()
+        channel = state.channels.get(notification.channel_id)
+        if channel is None:
+            return WebhookProcessResult(
+                status="ignored",
+                dedupe_key=notification.dedupe_key,
+                reason="unknown_channel",
+            )
+        if channel.resource_id != notification.resource_id:
+            return WebhookProcessResult(
+                status="ignored",
+                calendar_id=channel.calendar_id,
+                dedupe_key=notification.dedupe_key,
+                reason="resource_id_mismatch",
+            )
+        if state.has_processed(notification.dedupe_key):
+            return WebhookProcessResult(
+                status="duplicate",
+                calendar_id=channel.calendar_id,
+                dedupe_key=notification.dedupe_key,
+                reason="already_processed",
+            )
+
+        previous_sync_token = channel.sync_token
+        batch = self._events_client.list_event_changes(
+            calendar_id=channel.calendar_id,
+            sync_token=previous_sync_token,
+        )
+        channel.sync_token = batch.next_sync_token
+        if notification.channel_expiration:
+            channel.channel_expiration = notification.channel_expiration
+        state.channels[notification.channel_id] = channel
+        state.mark_processed(notification.dedupe_key)
+        self._state_store.save(state)
+
+        if notification.resource_state == "sync" or previous_sync_token is None:
+            return WebhookProcessResult(
+                status="initial_sync",
+                calendar_id=channel.calendar_id,
+                dedupe_key=notification.dedupe_key,
+                reason="initial_sync_suppressed",
+                initial_sync_suppressed=True,
+            )
+
+        envelopes = tuple(
+            build_event_envelope(
+                calendar_id=channel.calendar_id,
+                event=GoogleCalendarEvent.from_api(event_payload),
+                previous_sync_token=previous_sync_token,
+                privacy=self._privacy,
+            )
+            for event_payload in batch.events
+        )
+        return WebhookProcessResult(
+            status="processed",
+            calendar_id=channel.calendar_id,
+            envelopes=envelopes,
+            dedupe_key=notification.dedupe_key,
+        )
+
+    def process_headers(self, headers: dict[str, str]) -> WebhookProcessResult:
+        """Webhook endpoint entrypoint for raw Google Calendar push headers."""
+        return self.process_notification(GoogleCalendarNotification.from_headers(headers))

--- a/runtime/channels/google_calendar/processor.py
+++ b/runtime/channels/google_calendar/processor.py
@@ -23,11 +23,24 @@ class GoogleCalendarNotification:
     @classmethod
     def from_headers(cls, headers: dict[str, str]) -> "GoogleCalendarNotification":
         normalized = {key.lower(): value for key, value in headers.items()}
+        required_headers = (
+            "x-goog-channel-id",
+            "x-goog-resource-id",
+            "x-goog-resource-state",
+            "x-goog-message-number",
+        )
+        missing_headers = [header for header in required_headers if header not in normalized]
+        if missing_headers:
+            raise ValueError(f"missing_google_calendar_headers:{','.join(missing_headers)}")
+        try:
+            message_number = int(normalized["x-goog-message-number"])
+        except ValueError as exc:
+            raise ValueError("invalid_google_calendar_message_number") from exc
         return cls(
             channel_id=normalized["x-goog-channel-id"].strip(),
             resource_id=normalized["x-goog-resource-id"].strip(),
             resource_state=normalized["x-goog-resource-state"].strip(),
-            message_number=int(normalized["x-goog-message-number"]),
+            message_number=message_number,
             resource_uri=normalized.get("x-goog-resource-uri"),
             channel_expiration=normalized.get("x-goog-channel-expiration"),
         )
@@ -134,11 +147,40 @@ class CalendarWebhookProcessor:
             )
 
         previous_sync_token = channel.sync_token
+        if notification.resource_state == "sync" and previous_sync_token is not None:
+            channel.initial_sync_seen = True
+            if notification.channel_expiration:
+                channel.channel_expiration = notification.channel_expiration
+            state.channels[notification.channel_id] = channel
+            state.mark_processed(notification.dedupe_key)
+            self._state_store.save(state)
+            return WebhookProcessResult(
+                status="initial_sync",
+                calendar_id=channel.calendar_id,
+                dedupe_key=notification.dedupe_key,
+                reason="initial_sync_suppressed",
+                initial_sync_suppressed=True,
+            )
+
         batch = self._events_client.list_event_changes(
             calendar_id=channel.calendar_id,
             sync_token=previous_sync_token,
         )
+        envelopes = ()
+        if notification.resource_state != "sync" and previous_sync_token is not None:
+            envelopes = tuple(
+                build_event_envelope(
+                    calendar_id=channel.calendar_id,
+                    event=GoogleCalendarEvent.from_api(event_payload),
+                    previous_sync_token=previous_sync_token,
+                    privacy=self._privacy,
+                )
+                for event_payload in batch.events
+            )
+
         channel.sync_token = batch.next_sync_token
+        if notification.resource_state == "sync" or previous_sync_token is None:
+            channel.initial_sync_seen = True
         if notification.channel_expiration:
             channel.channel_expiration = notification.channel_expiration
         state.channels[notification.channel_id] = channel
@@ -154,15 +196,6 @@ class CalendarWebhookProcessor:
                 initial_sync_suppressed=True,
             )
 
-        envelopes = tuple(
-            build_event_envelope(
-                calendar_id=channel.calendar_id,
-                event=GoogleCalendarEvent.from_api(event_payload),
-                previous_sync_token=previous_sync_token,
-                privacy=self._privacy,
-            )
-            for event_payload in batch.events
-        )
         return WebhookProcessResult(
             status="processed",
             calendar_id=channel.calendar_id,

--- a/runtime/channels/google_calendar/state.py
+++ b/runtime/channels/google_calendar/state.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from runtime.util.atomic_write import atomic_write_json
+
+DEFAULT_STATE_PATH = Path.home() / ".config" / "lifeos-google" / "calendar_webhooks" / "state.json"
+DEFAULT_GWS_BIN = Path.home() / ".config" / "lifeos-google" / "bin" / "lifeos-gws"
+
+
+@dataclass
+class CalendarChannelState:
+    channel_id: str
+    resource_id: str
+    calendar_id: str = "primary"
+    sync_token: str | None = None
+    expiration_ms: int | None = None
+    channel_expiration: str | None = None
+    renewal_requested_at: str | None = None
+    initial_sync_seen: bool = False
+
+    def renewal_due(self, *, now_ms: int, lead_ms: int = 86_400_000) -> bool:
+        if self.expiration_ms is None:
+            return False
+        return self.expiration_ms <= now_ms + lead_ms
+
+    def expired(self, *, now_ms: int) -> bool:
+        return self.expiration_ms is not None and self.expiration_ms <= now_ms
+
+
+@dataclass
+class CalendarWebhookState:
+    schema_version: str = "lifeos.google_calendar_webhook_state.v0"
+    channels: dict[str, CalendarChannelState] = field(default_factory=dict)
+    processed_notifications: list[str] = field(default_factory=list)
+    max_processed_notifications: int = 1000
+
+    def has_processed(self, dedupe_key: str) -> bool:
+        return dedupe_key in set(self.processed_notifications)
+
+    def mark_processed(self, dedupe_key: str) -> None:
+        if dedupe_key in self.processed_notifications:
+            return
+        self.processed_notifications.append(dedupe_key)
+        overflow = len(self.processed_notifications) - self.max_processed_notifications
+        if overflow > 0:
+            del self.processed_notifications[:overflow]
+
+    def channels_due_for_renewal(self, *, now_ms: int, lead_ms: int = 86_400_000) -> list[str]:
+        return sorted(
+            channel_id
+            for channel_id, channel in self.channels.items()
+            if channel.renewal_due(now_ms=now_ms, lead_ms=lead_ms)
+        )
+
+    def expired_channels(self, *, now_ms: int) -> list[str]:
+        return sorted(
+            channel_id
+            for channel_id, channel in self.channels.items()
+            if channel.expired(now_ms=now_ms)
+        )
+
+
+class CalendarWebhookStateStore:
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or DEFAULT_STATE_PATH
+
+    def load(self) -> CalendarWebhookState:
+        if not self.path.exists():
+            return CalendarWebhookState()
+        payload = json.loads(self.path.read_text(encoding="utf-8"))
+        channels = {
+            channel_id: CalendarChannelState(**channel_payload)
+            for channel_id, channel_payload in (payload.get("channels") or {}).items()
+        }
+        return CalendarWebhookState(
+            schema_version=payload.get(
+                "schema_version",
+                "lifeos.google_calendar_webhook_state.v0",
+            ),
+            channels=channels,
+            processed_notifications=list(payload.get("processed_notifications") or []),
+            max_processed_notifications=int(payload.get("max_processed_notifications", 1000)),
+        )
+
+    def save(self, state: CalendarWebhookState) -> None:
+        payload = {
+            "schema_version": state.schema_version,
+            "channels": {
+                channel_id: asdict(channel)
+                for channel_id, channel in sorted(state.channels.items())
+            },
+            "processed_notifications": list(state.processed_notifications),
+            "max_processed_notifications": state.max_processed_notifications,
+            "shared_google_surface": {
+                "default_gws_bin": str(DEFAULT_GWS_BIN),
+                "default_credentials_dir": str(Path.home() / ".config" / "lifeos-google"),
+                "notes": "Tests use injected clients; no real Google credentials required.",
+            },
+        }
+        atomic_write_json(self.path, payload, indent=2, sort_keys=True)

--- a/runtime/tests/channels/test_google_calendar_webhooks.py
+++ b/runtime/tests/channels/test_google_calendar_webhooks.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from runtime.channels.google_calendar import (
+    CalendarEventChangeBatch,
+    CalendarPrivacyConfig,
+    CalendarWebhookProcessor,
+    CalendarWebhookStateStore,
+    GoogleCalendarNotification,
+    for_hermes,
+    for_openclaw,
+)
+from runtime.channels.google_calendar.state import CalendarChannelState, CalendarWebhookState
+
+
+class FakeCalendarClient:
+    def __init__(self, batches: list[CalendarEventChangeBatch]) -> None:
+        self.batches = batches
+        self.calls: list[dict[str, Any]] = []
+
+    def list_event_changes(
+        self,
+        *,
+        calendar_id: str,
+        sync_token: str | None,
+    ) -> CalendarEventChangeBatch:
+        self.calls.append({"calendar_id": calendar_id, "sync_token": sync_token})
+        return self.batches.pop(0)
+
+
+def _store(tmp_path: Path) -> CalendarWebhookStateStore:
+    return CalendarWebhookStateStore(tmp_path / "calendar_state.json")
+
+
+def _notification(
+    message_number: int = 1,
+    resource_state: str = "exists",
+) -> GoogleCalendarNotification:
+    return GoogleCalendarNotification(
+        channel_id="chan-1",
+        resource_id="res-1",
+        resource_state=resource_state,
+        message_number=message_number,
+    )
+
+
+def test_state_persists_channels_tokens_and_dedupe(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    state = CalendarWebhookState()
+    state.channels["chan-1"] = CalendarChannelState(
+        channel_id="chan-1",
+        resource_id="res-1",
+        calendar_id="primary",
+        sync_token="sync-a",
+        expiration_ms=123456,
+    )
+    state.mark_processed("chan-1:res-1:1")
+
+    store.save(state)
+    loaded = store.load()
+
+    assert loaded.channels["chan-1"].sync_token == "sync-a"
+    assert loaded.channels["chan-1"].expiration_ms == 123456
+    assert loaded.has_processed("chan-1:res-1:1")
+    assert ".config/lifeos-google" in store.path.read_text(encoding="utf-8")
+
+
+def test_processor_dedupes_notifications_and_updates_sync_token(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    processor = CalendarWebhookProcessor(
+        state_store=store,
+        events_client=FakeCalendarClient(
+            [
+                CalendarEventChangeBatch(
+                    events=(
+                        {
+                            "id": "evt-1",
+                            "summary": "Review",
+                            "created": "2026-04-28T00:00:00Z",
+                            "updated": "2026-04-28T01:00:00Z",
+                        },
+                    ),
+                    next_sync_token="sync-b",
+                )
+            ]
+        ),
+    )
+    processor.register_channel(
+        channel_id="chan-1",
+        resource_id="res-1",
+        sync_token="sync-a",
+    )
+
+    first = processor.process_notification(_notification())
+    second = processor.process_notification(_notification())
+
+    assert first.status == "processed"
+    assert len(first.envelopes) == 1
+    assert second.status == "duplicate"
+    assert store.load().channels["chan-1"].sync_token == "sync-b"
+
+
+def test_initial_sync_noise_suppressed_but_sync_token_persisted(tmp_path: Path) -> None:
+    client = FakeCalendarClient(
+        [CalendarEventChangeBatch(events=({"id": "evt-ignored"},), next_sync_token="sync-initial")]
+    )
+    store = _store(tmp_path)
+    processor = CalendarWebhookProcessor(state_store=store, events_client=client)
+    processor.register_channel(channel_id="chan-1", resource_id="res-1")
+
+    result = processor.process_notification(_notification(resource_state="sync"))
+
+    assert result.status == "initial_sync"
+    assert result.initial_sync_suppressed is True
+    assert result.envelopes == ()
+    assert store.load().channels["chan-1"].sync_token == "sync-initial"
+    assert client.calls == [{"calendar_id": "primary", "sync_token": None}]
+
+
+def test_envelope_privacy_minimizes_attendees_and_description(tmp_path: Path) -> None:
+    processor = CalendarWebhookProcessor(
+        state_store=_store(tmp_path),
+        events_client=FakeCalendarClient(
+            [
+                CalendarEventChangeBatch(
+                    events=(
+                        {
+                            "id": "evt-2",
+                            "summary": "Private meeting",
+                            "description": "sensitive notes",
+                            "htmlLink": "https://calendar.google.com/event?eid=evt-2",
+                            "created": "2026-04-27T00:00:00Z",
+                            "updated": "2026-04-28T00:00:00Z",
+                            "start": {"dateTime": "2026-04-28T09:00:00+10:00"},
+                            "end": {"dateTime": "2026-04-28T09:30:00+10:00"},
+                            "organizer": {"email": "owner@example.com"},
+                            "attendees": [
+                                {"email": "a@example.com", "responseStatus": "accepted"},
+                                {"email": "b@example.com", "responseStatus": "needsAction"},
+                            ],
+                        },
+                    ),
+                    next_sync_token="sync-next",
+                )
+            ]
+        ),
+    )
+    processor.register_channel(channel_id="chan-1", resource_id="res-1", sync_token="sync-a")
+
+    envelope = processor.process_notification(_notification()).envelopes[0]
+
+    assert envelope["action"] == "updated"
+    assert envelope["attendees"] == {"redacted": True, "count": 2}
+    assert "description" not in envelope
+    assert envelope["privacy"] == {
+        "description_included": False,
+        "attendees_included": False,
+        "attendee_emails_included": False,
+    }
+
+
+def test_privacy_can_include_attendees_without_emails(tmp_path: Path) -> None:
+    processor = CalendarWebhookProcessor(
+        state_store=_store(tmp_path),
+        events_client=FakeCalendarClient(
+            [
+                CalendarEventChangeBatch(
+                    events=(
+                        {
+                            "id": "evt-3",
+                            "attendees": [{"email": "a@example.com", "displayName": "Alex"}],
+                        },
+                    ),
+                    next_sync_token="sync-next",
+                )
+            ]
+        ),
+        privacy=CalendarPrivacyConfig(include_attendees=True),
+    )
+    processor.register_channel(channel_id="chan-1", resource_id="res-1", sync_token="sync-a")
+
+    envelope = processor.process_notification(_notification()).envelopes[0]
+
+    assert envelope["attendees"] == [
+        {"display_name": "Alex", "response_status": None, "optional": None}
+    ]
+
+
+def test_channel_renewal_and_expiry_detection(tmp_path: Path) -> None:
+    state = CalendarWebhookState()
+    state.channels["soon"] = CalendarChannelState(
+        channel_id="soon",
+        resource_id="res-soon",
+        expiration_ms=1_100,
+    )
+    state.channels["later"] = CalendarChannelState(
+        channel_id="later",
+        resource_id="res-later",
+        expiration_ms=10_000,
+    )
+
+    assert state.channels_due_for_renewal(now_ms=1_000, lead_ms=200) == ["soon"]
+    assert state.expired_channels(now_ms=1_101) == ["soon"]
+
+
+def test_shared_envelope_has_thin_hermes_and_openclaw_adapters() -> None:
+    envelope = {"schema_version": "lifeos.calendar_event.v0", "event_id": "evt-1"}
+
+    assert for_openclaw(envelope)["envelope"] == envelope
+    assert for_hermes(envelope)["envelope"] == envelope
+
+
+def test_processor_accepts_raw_google_webhook_headers(tmp_path: Path) -> None:
+    processor = CalendarWebhookProcessor(
+        state_store=_store(tmp_path),
+        events_client=FakeCalendarClient(
+            [CalendarEventChangeBatch(events=({"id": "evt-4"},), next_sync_token="sync-next")]
+        ),
+    )
+    processor.register_channel(channel_id="chan-1", resource_id="res-1", sync_token="sync-a")
+
+    result = processor.process_headers(
+        {
+            "X-Goog-Channel-ID": "chan-1",
+            "X-Goog-Resource-ID": "res-1",
+            "X-Goog-Resource-State": "exists",
+            "X-Goog-Message-Number": "4",
+        }
+    )
+
+    assert result.status == "processed"
+    assert result.dedupe_key == "chan-1:res-1:4"

--- a/runtime/tests/channels/test_google_calendar_webhooks.py
+++ b/runtime/tests/channels/test_google_calendar_webhooks.py
@@ -116,7 +116,52 @@ def test_initial_sync_noise_suppressed_but_sync_token_persisted(tmp_path: Path) 
     assert result.initial_sync_suppressed is True
     assert result.envelopes == ()
     assert store.load().channels["chan-1"].sync_token == "sync-initial"
+    assert store.load().channels["chan-1"].initial_sync_seen is True
     assert client.calls == [{"calendar_id": "primary", "sync_token": None}]
+
+
+def test_sync_notification_with_existing_token_does_not_fetch_or_drop_changes(
+    tmp_path: Path,
+) -> None:
+    client = FakeCalendarClient([])
+    store = _store(tmp_path)
+    processor = CalendarWebhookProcessor(state_store=store, events_client=client)
+    processor.register_channel(channel_id="chan-1", resource_id="res-1", sync_token="sync-a")
+
+    result = processor.process_notification(_notification(resource_state="sync"))
+
+    assert result.status == "initial_sync"
+    assert result.initial_sync_suppressed is True
+    assert client.calls == []
+    loaded_channel = store.load().channels["chan-1"]
+    assert loaded_channel.sync_token == "sync-a"
+    assert loaded_channel.initial_sync_seen is True
+
+
+def test_invalid_event_does_not_advance_sync_token_or_dedupe(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    processor = CalendarWebhookProcessor(
+        state_store=store,
+        events_client=FakeCalendarClient(
+            [
+                CalendarEventChangeBatch(
+                    events=({"summary": "missing id"},), next_sync_token="sync-b"
+                )
+            ]
+        ),
+    )
+    processor.register_channel(channel_id="chan-1", resource_id="res-1", sync_token="sync-a")
+
+    try:
+        processor.process_notification(_notification())
+    except ValueError as exc:
+        assert str(exc) == "google_calendar_event_missing_id"
+    else:
+        raise AssertionError("expected missing event id to fail")
+
+    loaded_state = store.load()
+    assert loaded_state.channels["chan-1"].sync_token == "sync-a"
+    assert not loaded_state.has_processed("chan-1:res-1:1")
 
 
 def test_envelope_privacy_minimizes_attendees_and_description(tmp_path: Path) -> None:
@@ -232,3 +277,20 @@ def test_processor_accepts_raw_google_webhook_headers(tmp_path: Path) -> None:
 
     assert result.status == "processed"
     assert result.dedupe_key == "chan-1:res-1:4"
+
+
+def test_processor_rejects_incomplete_raw_google_webhook_headers(tmp_path: Path) -> None:
+    processor = CalendarWebhookProcessor(
+        state_store=_store(tmp_path),
+        events_client=FakeCalendarClient([]),
+    )
+
+    try:
+        processor.process_headers({"X-Goog-Channel-ID": "chan-1"})
+    except ValueError as exc:
+        assert str(exc) == (
+            "missing_google_calendar_headers:"
+            "x-goog-resource-id,x-goog-resource-state,x-goog-message-number"
+        )
+    else:
+        raise AssertionError("expected missing headers to fail")


### PR DESCRIPTION
## Summary
- Adds a shared `runtime.channels.google_calendar` surface for Calendar push notifications, state persistence, dedupe, sync-token handling, expiry/renewal detection, and privacy-minimized event envelopes.
- Adds thin Hermes/OpenClaw forwarding adapters over the same shared envelope instead of duplicating agent-specific webhook glue.
- Keeps Google API calls behind an injectable client protocol; tests use fakes only and default state paths point at the shared `~/.config/lifeos-google` contract.

## Test plan
- [x] `pytest runtime/tests/channels/test_google_calendar_webhooks.py -q` — 8 passed
- [x] `pytest runtime/tests -q` — 3226 passed, 6 skipped, 7 existing warnings
- [x] `python3 scripts/workflow/quality_gate.py check --scope changed --json` — passed; 0 blocking failures; mypy advisory unavailable locally

## Execution notes
- Work order: marcusglee11/lifeos-operational-bus#10
- EA protocol source: LifeOS #60 / PR #61 receipt guardrails
- Codex produced the implementation; COO rebuilt a clean product branch without transient EA task/receipt artifacts.
- External EA receipt retained locally at `/tmp/issue10-ea-receipt.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
