### PR TITLE
Implement Work Management Framework v0.1

### DIFF
--- a/config/tasks/backlog.yaml
+++ b/config/tasks/backlog.yaml
@@ -2,6 +2,14 @@ schema_version: backlog.v1
 # WMF v0.1: items with id: WI-YYYY-NNN are Work Management Framework items.
 # See docs/02_protocols/Work_Management_Framework_v0.1.md for field schema and compatibility rules.
 # Legacy items use id: T-NNN and are not subject to WMF validation.
+# Canonical WMF fields supported here include: github_issue, status, priority,
+# priority_rationale, workstream, owner, blocked_by, plan_mode, plan_path,
+# acceptance_criteria, acceptance_ref, dispatch_ready, and closure_evidence.
+# Optional WMF fields include: size, risk, updated_at, awaiting_decision_by,
+# blocked_reason, unblock_condition, defer_until, defer_reason, duplicate_of,
+# superseded_by, plan_followup_required, followup_backlog_item, related_prs,
+# related_commits, and last_material_update_at.
+# The field "class" is not required.
 tasks:
 - id: T-001
   title: 'COO Bootstrap: Structured backlog (Step 1A)'

--- a/docs/02_protocols/Work_Management_Framework_v0.1.md
+++ b/docs/02_protocols/Work_Management_Framework_v0.1.md
@@ -5,118 +5,109 @@
 **Status**: Active
 **Version**: 0.1
 **Effective**: 2026-04-27
-**Authority**: LifeOS Constitution v2.0 → Governance Protocol v1.0
+**Authority**: LifeOS Constitution v2.0 → Governance Protocol v1.0 → active COO execution order
 
 ---
 
-## Purpose
+## 1. Purpose
 
-Provides a lightweight repo-backed project management layer for COO-managed work. Uses existing repo surfaces to support intake, prioritisation, dispatch, review, and closure of work items without a PM app, dashboard, or runtime orchestration changes.
+The Work Management Framework (WMF) is the lightweight repo-backed project-management layer for COO-managed LifeOS work. It uses existing repository surfaces to support intake, prioritisation, dispatch, review, and closure without introducing a PM application or runtime orchestration changes.
 
----
-
-## Surfaces
-
-| Surface | Role |
-|---------|------|
-| GitHub issues | Intake and coordination bus |
-| `config/tasks/backlog.yaml` | Canonical queue state |
-| `docs/11_admin/BACKLOG.md` | Derived, view-only summary (non-canonical) |
-| `artifacts/workstreams.yaml` | Workstream taxonomy |
-| `docs/02_protocols/Project_Planning_Protocol_v1.0.md` | Planning protocol reference |
-| `execution_order.v1` | Dispatch authority |
-| Closure evidence | Completion proof |
+WMF v0.1 answers one operational question: what is the canonical state of each COO-managed work item, and what evidence is required to move it forward?
 
 ---
 
-## ID Model
+## 2. Non-goals
+
+WMF v0.1 does **not** implement:
+
+- PM dashboards or application UI.
+- GitHub API reconciliation.
+- Automated GitHub issue creation or closing.
+- WIP limits or capacity planning.
+- Full transition-matrix enforcement.
+- `BACKLOG.md` auto-generation.
+- Parallel COO locking or transactional ID services.
+- Runtime execution behavior changes.
+- Broad architecture normalization.
+
+---
+
+## 3. Operating model
+
+### 3.1 Role boundaries
+
+| Role | WMF responsibility |
+|------|--------------------|
+| CEO | Approves kickoff, answers judgment blockers, accepts or rejects final result |
+| Active COO | Sole operational coordinator; owns dispatch, scope control, backlog writes, evidence review, and escalation |
+| EA/build agent | Makes repo edits, runs validator/tests, and reports evidence |
+| Reviewer | Reviews PR/diff/evidence and returns accept or fixes-requested |
+| Standby COO | May review or advise; must not write operational state unless explicitly promoted |
+
+### 3.2 Active-COO substrate semantics
+
+Only the active COO writes WMF operational state. Standby COOs, reviewers, and build agents may propose changes, but state transitions are not canonical until the active COO records them in `config/tasks/backlog.yaml`.
+
+Current v0.1 limitation: WMF assumes one active writer. It does not provide concurrent ID minting, file locking, or transaction semantics. If parallel operational writers are introduced, v0.2 must add a locked or transactional mint/write mechanism before more than one writer can mutate WMF state.
+
+---
+
+## 4. Authority matrix
+
+| Surface | Role | Authority |
+|---------|------|-----------|
+| GitHub issues | Intake and coordination bus | Non-canonical coordination; useful for discussion, acceptance criteria, PR links, and external visibility |
+| `config/tasks/backlog.yaml` | Canonical queue state | Authoritative for work-item status, priority, workstream, dispatch readiness, blockers, and closure evidence |
+| `docs/11_admin/BACKLOG.md` | Derived, view-only human summary | Non-canonical; must not contain unique work-item state |
+| `artifacts/workstreams.yaml` | Workstream taxonomy | Authoritative source for valid `workstream` values |
+| `docs/02_protocols/Project_Planning_Protocol_v1.0.md` | Formal planning protocol | Authoritative for formal plan content and review expectations |
+| `execution_order.v1` | Dispatch authority | Authorizes an executor to perform bounded work |
+| `closure_evidence` | Completion proof | Required evidence bundle for `CLOSED` work |
+
+Conflict rule: if GitHub issues, `BACKLOG.md`, or status summaries disagree with `config/tasks/backlog.yaml`, `backlog.yaml` wins for WMF queue state.
+
+---
+
+## 5. ID model
 
 - WMF work items use `id: WI-YYYY-NNN` as the primary identifier.
-  - `YYYY` is the 4-digit calendar year.
-  - `NNN` is a 3-digit zero-padded sequence number within that year (e.g., `001`, `042`).
+  - `YYYY` is the four-digit calendar year.
+  - `NNN` is a three-digit zero-padded sequence number within that year.
   - Example: `WI-2026-001`.
-- IDs are minted at `TRIAGED` state, atomically with the backlog write.
-- Legacy COO tasks use `id: T-NNN` format and are not WMF-managed.
-- No separate `wi_id` field. The `id` field is the canonical WMF identifier.
+- IDs are minted at `TRIAGED`, not `INTAKE`.
+- ID minting is valid only when the new ID and item state are written atomically to `config/tasks/backlog.yaml` in the same operational update.
+- Legacy COO tasks use `id: T-NNN`; they coexist in `config/tasks/backlog.yaml` and are not WMF-managed.
+- No separate `wi_id` field exists. The `id` field is canonical.
 
 ---
 
-## backlog.v1 Compatibility
+## 6. State machine
 
-Until `backlog.v2` or a dedicated `WorkItemEntry` schema exists, WI-* records in
-`config/tasks/backlog.yaml` are stored as `backlog.v1 TaskEntry`-compatible records.
-They must include the existing `backlog.v1` required fields **in addition to** WMF fields:
+### 6.1 Active v0.1 states
 
-| Required legacy field | Allowed values |
-|-----------------------|----------------|
-| `id` | `WI-YYYY-NNN` |
-| `title` | non-empty string |
-| `priority` | `P0 \| P1 \| P2 \| P3` |
-| `risk` | `low \| med \| high` |
-| `status` | WMF state (see §State Machine) |
-| `task_type` | `build \| content \| hygiene` |
-| `objective_ref` | non-empty string |
-| `created_at` | ISO 8601 timestamp |
-| `scope_paths` | list (may be empty) |
-| `tags` | list (may be empty) |
+| State | Meaning | Entry requirement | Exit requirement |
+|-------|---------|-------------------|------------------|
+| `INTAKE` | Captured but not yet assessed | Issue, note, or request exists | Triage decision |
+| `TRIAGED` | Assessed and accepted for tracking | `WI-YYYY-NNN` minted and `github_issue` recorded | Priority/workstream/next action clear |
+| `READY` | Ready to dispatch | Acceptance criteria or acceptance reference exists | Executor selected or blocker found |
+| `DISPATCHED` | Assigned to an executor | Dispatch authority exists, usually `execution_order.v1` | Work complete, blocked, or deferred |
+| `REVIEW` | Work submitted for review | Evidence or PR exists | Accepted/closed or fixes requested |
+| `CLOSED` | Accepted and complete | Closure evidence recorded | Terminal |
+| `BLOCKED` | Progress is blocked | `blocked_reason` or equivalent evidence exists | Unblocked, deferred, or re-triaged |
+| `DEFERRED` | Intentionally deferred | Deferral reason recorded | Re-triaged or rejected |
+| `REJECTED` | Not accepted for execution | Rejection reason recorded | Terminal |
+| `DUPLICATE` | Duplicate of another item | `duplicate_of` should identify canonical item | Terminal |
+| `SUPERSEDED` | Replaced by another item | `superseded_by` should identify replacement | Terminal |
 
-Do not omit required legacy fields or introduce hidden defaults. A WI item that passes
-the WMF validator must also be loadable by `runtime/orchestration/coo/backlog.py`
-without error.
+### 6.2 Legal transitions
 
----
-
-## WMF Field Schema
-
-Fields specific to WMF work items (`id: WI-YYYY-NNN`):
-
-| Field | Required | Type | Notes |
-|-------|----------|------|-------|
-| `github_issue` | at `TRIAGED`+ | `int` | GitHub issue number |
-| `workstream` | always | `str` | Key from `artifacts/workstreams.yaml` |
-| `acceptance_criteria` | at `READY`/`DISPATCHED` | `list[str]` or `str` | Or use `acceptance_ref` |
-| `acceptance_ref` | at `READY`/`DISPATCHED` | `str` | Pointer to external AC doc; alternative to `acceptance_criteria` |
-| `plan_mode` | always | `none \| plan_lite \| formal` | |
-| `plan_path` | if `formal` | `str` | Required when `plan_mode=formal` (no exceptions) |
-| `plan_followup_required` | no | `bool` | `true` = plan deferred; P0 expedited path |
-| `followup_backlog_item` | if P0 expedited | `WI-YYYY-NNN` | Required before `CLOSED` if P0 expedited |
-| `closure_evidence` | at `CLOSED` | `list[{type,ref,note}]` | All three keys required per entry |
-
-`class` is explicitly not required at any stage.
-
-`acceptance_criteria` accepts:
-
-- A non-empty string.
-- A non-empty `list[str]` (all entries non-empty). **Preferred format.**
-
----
-
-## State Machine
-
-Work items progress through the following states:
-
-| State | Meaning |
-|-------|---------|
-| `INTAKE` | Captured but not yet assessed |
-| `TRIAGED` | Assessed, ID minted, github_issue assigned |
-| `READY` | Acceptance criteria defined, ready to dispatch |
-| `DISPATCHED` | Assigned to an agent or executor |
-| `REVIEW` | Work complete, under review |
-| `CLOSED` | Accepted and closed; closure evidence recorded |
-| `BLOCKED` | Progress blocked; blocker documented in evidence |
-| `DEFERRED` | Intentionally deferred |
-| `REJECTED` | Rejected after assessment |
-| `DUPLICATE` | Duplicate of an existing item |
-| `SUPERSEDED` | Replaced by another item |
-
-### Legal Transitions
-
-```
+```text
 INTAKE       → TRIAGED | REJECTED | DUPLICATE
 TRIAGED      → READY | DEFERRED | REJECTED | BLOCKED
 READY        → DISPATCHED | BLOCKED | DEFERRED
 DISPATCHED   → REVIEW | BLOCKED
-REVIEW       → CLOSED | DISPATCHED  ← fixes-requested returns here
+REVIEW       → CLOSED | DISPATCHED
 CLOSED       → (terminal)
 BLOCKED      → READY | TRIAGED | DEFERRED
 DEFERRED     → TRIAGED | REJECTED
@@ -125,28 +116,50 @@ DUPLICATE    → (terminal)
 SUPERSEDED   → (terminal)
 ```
 
-`REVIEW` fixes-requested returns to `DISPATCHED` (not `READY`), as the executor
-must address the review findings before re-submitting.
+`REVIEW → DISPATCHED` is the fixes-requested path. Review fixes return to the executor; they do not go back to `READY`.
+
+### 6.3 Deferred states and concepts
+
+The following labels are intentionally not v0.1 states: `PLANNING_REQUIRED`, `IN_PROGRESS`, `ACCEPTED`, `BACKLOG_READY`, `READY_FOR_DISPATCH`. Represent these concepts with v0.1 fields instead:
+
+- Planning need: `plan_mode`, `plan_path`, `plan_followup_required`.
+- Active execution: `DISPATCHED` plus owner/executor metadata.
+- Acceptance: `CLOSED` plus `closure_evidence`.
+- Dispatch readiness: `READY` plus acceptance criteria/ref and planning fields.
 
 ---
 
-## Plan Mode Rules
+## 7. Planning and dispatch rules
 
-Every WMF item must declare a `plan_mode`. Allowed values:
+### 7.1 Plan modes
 
-| Value | Meaning |
-|-------|---------|
-| `none` | No plan required |
-| `plan_lite` | Lightweight inline plan |
-| `formal` | Formal plan document required |
+Every WMF item must declare `plan_mode`.
 
-### Rule: plan_mode=formal
+| Value | Meaning | Minimum expectation |
+|-------|---------|---------------------|
+| `none` | No separate plan needed | Acceptance criteria are enough |
+| `plan_lite` | Lightweight inline plan | Scope, risks, and verification fit inside the work item or issue |
+| `formal` | Formal implementation plan required | `plan_path` points to a plan governed by `Project_Planning_Protocol_v1.0.md` |
 
-`plan_mode=formal` **always** requires `plan_path`. No exceptions.
+`plan_mode=formal` requires a non-empty `plan_path`. No v0.1 exception changes that requirement. The expedited P0 path uses `plan_lite`, not `formal`.
 
-### P0 Expedited Path
+### 7.2 Formal plan threshold
 
-P0 expedited dispatch applies when all three conditions hold:
+Use `plan_mode=formal` when work changes runtime behavior, touches multiple subsystems, affects protected/authority surfaces, introduces non-trivial migration risk, or has ambiguous acceptance criteria that need explicit review before implementation.
+
+### 7.3 Plan-lite threshold
+
+Use `plan_mode=plan_lite` for bounded work where scope, risks, and verification can be captured in the issue or backlog item. A plan-lite item should still state:
+
+- Scope.
+- Non-scope.
+- Acceptance criteria or acceptance reference.
+- Verification commands.
+- Known risk or rollback note.
+
+### 7.4 P0 expedited path
+
+P0 expedited dispatch is allowed when all three fields are present:
 
 ```yaml
 priority: P0
@@ -154,56 +167,196 @@ plan_mode: plan_lite
 plan_followup_required: true
 ```
 
-Under P0 expedited:
+Under this path:
 
 - The item may enter `DISPATCHED` without `plan_path`.
-- A follow-up work item (`followup_backlog_item`) must be created before `CLOSED`.
-- `plan_mode=formal` is **not** the expedited path. Formal plan items always need `plan_path`.
+- The follow-up plan item may be created after dispatch.
+- The original item cannot enter `CLOSED` until `followup_backlog_item` is populated.
+
+### 7.5 Dispatch readiness checklist
+
+A WMF item is dispatch-ready only when:
+
+- `status` is `READY`.
+- `priority` and `priority_rationale` are present or the rationale is evident from the item context.
+- `workstream` is valid in `artifacts/workstreams.yaml`.
+- Acceptance criteria or `acceptance_ref` exists.
+- `plan_mode` is valid and any required `plan_path` exists.
+- Known blockers are absent or explicitly accepted by the active COO.
+- Dispatch authority is available before moving to `DISPATCHED`.
 
 ---
 
-## Closure Evidence
+## 8. Backlog schema
 
-Every item reaching `CLOSED` must include a `closure_evidence` list. Each entry must contain:
+### 8.1 backlog.v1 compatibility
+
+Until `backlog.v2` or a dedicated `WorkItemEntry` schema exists, WI records in `config/tasks/backlog.yaml` remain `backlog.v1 TaskEntry`-compatible. A WI item that passes the WMF validator must also remain loadable by `runtime/orchestration/coo/backlog.py`.
+
+Legacy `T-NNN` items remain valid and are not subject to WMF validation.
+
+### 8.2 Required WMF fields for active items
+
+The canonical schema must support these fields for active WI items:
+
+| Field | Requirement |
+|-------|-------------|
+| `id` | `WI-YYYY-NNN` |
+| `github_issue` | Required at `TRIAGED` or later |
+| `title` | Non-empty work title |
+| `status` | One of the v0.1 states |
+| `priority` | `P0`, `P1`, `P2`, or `P3` |
+| `priority_rationale` | Why the priority is appropriate; may be omitted only when obvious from linked context |
+| `workstream` | Key from `artifacts/workstreams.yaml` |
+| `owner` | Current responsible owner or executor, if assigned |
+| `blocked_by` | Blocking item/person/system when blocked |
+| `plan_mode` | `none`, `plan_lite`, or `formal` |
+| `plan_path` | Required for `plan_mode=formal` |
+| `acceptance_criteria` | Required at `READY`/`DISPATCHED` unless `acceptance_ref` is present |
+| `acceptance_ref` | Pointer to acceptance criteria; alternative to inline criteria |
+| `dispatch_ready` | Optional explicit readiness flag; status still controls lifecycle |
+| `closure_evidence` | Required at `CLOSED` |
+
+### 8.3 Optional fields
+
+WMF v0.1 may also use: `size`, `risk`, `created_at`, `updated_at`, `awaiting_decision_by`, `blocked_reason`, `unblock_condition`, `defer_until`, `defer_reason`, `duplicate_of`, `superseded_by`, `plan_followup_required`, `followup_backlog_item`, `related_prs`, `related_commits`, and `last_material_update_at`.
+
+`class` is explicitly **not** required at any stage. Its presence must not fail validation, and its absence must not fail validation.
+
+---
+
+## 9. Prioritisation rules
+
+| Priority | Meaning |
+|----------|---------|
+| `P0` | Critical: safety, authority, data-loss, blocked core operations, or urgent CEO-directed work |
+| `P1` | High: unblocks important programme work or completes active commitments |
+| `P2` | Normal: valuable but not immediately blocking |
+| `P3` | Low: cleanup, opportunistic improvement, or deferred polish |
+
+Use `priority_rationale` where the reason is not self-evident. Tie-breakers should be qualitative and evidence-based, not a hidden numeric scoring formula:
+
+1. Safety/authority risk.
+2. Work that unblocks multiple downstream items.
+3. Commitments already made to CEO or external parties.
+4. Small high-confidence closure wins.
+5. Cleanup only after active obligations are safe.
+
+---
+
+## 10. Stale item rules
+
+WMF v0.1 does not enforce stale windows mechanically, but the active COO must review stale items during backlog maintenance:
+
+| State | Stale signal | Expected action |
+|-------|--------------|-----------------|
+| `TRIAGED` | No material update or route to readiness | Clarify acceptance criteria, defer, or reject |
+| `READY` | Not dispatched after becoming ready | Dispatch, downgrade priority, or defer |
+| `DISPATCHED` | No executor progress/evidence | Ask for evidence, move to `BLOCKED`, or reassign |
+| `REVIEW` | Review not resolved | Accept/close or send fixes back to `DISPATCHED` |
+
+Use `last_material_update_at`, `blocked_reason`, `unblock_condition`, and comments/evidence refs where helpful. Avoid inventing state only in `BACKLOG.md` to compensate for stale data.
+
+---
+
+## 11. CEO attention queue
+
+CEO attention is represented in canonical queue state, not by ad hoc notes. Use fields such as:
+
+- `awaiting_decision_by: CEO`
+- `blocked_reason`
+- `unblock_condition`
+- `acceptance_ref`
+- `priority: P0` or `P1` when justified
+
+A CEO-facing summary may be rendered in `BACKLOG.md`, but the underlying decision/blocker state must exist in `config/tasks/backlog.yaml` or linked evidence.
+
+---
+
+## 12. Closure evidence
+
+Every item entering `CLOSED` must include a non-empty `closure_evidence` list. Each entry must contain:
 
 | Key | Type | Requirement |
 |-----|------|-------------|
-| `type` | `str` | Non-empty |
-| `ref` | `str` | Non-empty (commit SHA, PR number, artifact path, etc.) |
-| `note` | `str` | Non-empty |
+| `type` | `str` | Non-empty evidence type, such as `commit`, `pr`, `test`, `artifact`, or `receipt` |
+| `ref` | `str` | Non-empty commit SHA, PR URL/number, artifact path, command, or receipt ref |
+| `note` | `str` | Non-empty explanation of what the evidence proves |
 
 Example:
 
 ```yaml
 closure_evidence:
-  - type: commit
-    ref: abc1234
-    note: Framework doc and validator merged on build/work-management-framework-v0.1
+  - type: pr
+    ref: https://github.com/marcusglee11/LifeOS/pull/67
+    note: Framework doc, backlog annotations, validator, and tests landed.
 ```
 
 ---
 
-## Sole-Writer Rule
+## 13. Reconciliation invariants
 
-The active COO is the sole writer of operational state. Work item state transitions
-(changes to `status`, `closure_evidence`, `followup_backlog_item`, etc.) must be
-recorded in `config/tasks/backlog.yaml` by the COO, not by other agents writing
-directly to `docs/11_admin/BACKLOG.md`.
-
----
-
-## BACKLOG.md Derived Status
-
-`docs/11_admin/BACKLOG.md` is a **derived, view-only summary**. It is not canonical.
-The canonical queue state lives in `config/tasks/backlog.yaml`.
-
-All edits to work item state belong in `config/tasks/backlog.yaml`.
+- No canonical work-item state may exist only in `docs/11_admin/BACKLOG.md`.
+- GitHub issue status, PR status, and backlog status should be reconciled when work closes.
+- A merged PR alone does not prove closure unless closure evidence is recorded for the WMF item.
+- `BACKLOG.md` may summarize; it must not originate unique state transitions.
+- Workstream values come from `artifacts/workstreams.yaml`.
+- Broad architecture documents must not be rewritten as part of WMF v0.1 except for required index/corpus stewardship.
 
 ---
 
-## Notes
+## 14. BACKLOG.md derived status
 
-- `class` is not a required field at any stage.
-- T-NNN items coexist with WI-YYYY-NNN items in `config/tasks/backlog.yaml` and are not WMF-managed.
-- WMF validation applies only to items whose `id` starts with `WI-`.
-- The Phase 0 validator is at `scripts/validate_work_items.py`. Run with `python scripts/validate_work_items.py`.
+`docs/11_admin/BACKLOG.md` is a derived, view-only summary. It is not canonical. The canonical queue state lives in `config/tasks/backlog.yaml`.
+
+Phase 1 target: `BACKLOG.md` should either be generated from `config/tasks/backlog.yaml` or removed if the generated view is not useful.
+
+---
+
+## 15. Phase 0 validator requirements
+
+The Phase 0 validator lives at `scripts/validate_work_items.py` and runs locally with:
+
+```bash
+python scripts/validate_work_items.py --check
+```
+
+It must check:
+
+- Unique WMF IDs.
+- ID format `WI-YYYY-NNN`.
+- Valid status.
+- Valid priority.
+- `TRIAGED` or later items have `github_issue`.
+- Valid `workstream` values from `artifacts/workstreams.yaml`.
+- `READY` and `DISPATCHED` items have `acceptance_criteria` or `acceptance_ref`.
+- `plan_mode=formal` requires `plan_path`.
+- P0 expedited items cannot close without `followup_backlog_item`.
+- `CLOSED` items require `closure_evidence`.
+- Each `closure_evidence` entry contains `type`, `ref`, and `note`.
+- `BACKLOG.md` contains a derived/view-only header if retained.
+- `class` is not required.
+
+Implementation constraints:
+
+- Deterministic error ordering.
+- Clear file/path/item identifiers in errors.
+- Fail closed on malformed YAML.
+- No network or GitHub API access.
+- Narrow v0.1 scope; no dashboard or full transition enforcement.
+- Non-zero exit on blocking validation failures.
+
+---
+
+## 16. Deferred v0.2 work
+
+Defer the following until v0.1 has operational evidence:
+
+- `backlog.v2` or dedicated `WorkItemEntry` schema.
+- Auto-generated `BACKLOG.md`.
+- GitHub issue/backlog reconciliation.
+- Locked/transactional ID minting.
+- Full legal-transition enforcement.
+- WIP/capacity planning.
+- Runtime orchestration integration.
+- Dashboards or PM application views.

--- a/docs/11_admin/BACKLOG.md
+++ b/docs/11_admin/BACKLOG.md
@@ -2,7 +2,10 @@
 
 <!-- DERIVED VIEW: This file is a human-readable summary of config/tasks/backlog.yaml (canonical).
      Do not treat this file as authoritative. Canonical queue state lives in config/tasks/backlog.yaml.
-     Work item state transitions must be recorded in backlog.yaml, not here. -->
+     Work item status, priority, workstream assignment, dispatch readiness, and closure evidence
+     must be recorded in backlog.yaml, not here.
+     No canonical work-item state may exist only in docs/11_admin/BACKLOG.md.
+     Phase 1 target: generate this file from backlog.yaml or remove it if the generated view is not useful. -->
 
 <!-- markdownlint-disable MD012 MD013 -->
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD013 MD040 MD060 -->
 
-Last Updated: 2026-04-28 (rev24)
+Last Updated: 2026-04-28 (rev25)
 
 **Authority**: [LifeOS Constitution v2.0](./00_foundations/LifeOS_Constitution_v2.0.md)
 

--- a/docs/LifeOS_Strategic_Corpus.md
+++ b/docs/LifeOS_Strategic_Corpus.md
@@ -6633,141 +6633,96 @@ The following parameters are derived from the canonical schema YAML (no hardcodi
 **Status**: Active
 **Version**: 0.1
 **Effective**: 2026-04-27
-**Authority**: LifeOS Constitution v2.0 → Governance Protocol v1.0
+**Authority**: LifeOS Constitution v2.0 → Governance Protocol v1.0 → active COO execution order
 
 ---
 
-## Purpose
+## 1. Purpose
 
-Provides a lightweight repo-backed project management layer for COO-managed work. Uses existing repo surfaces to support intake, prioritisation, dispatch, review, and closure of work items without a PM app, dashboard, or runtime orchestration changes.
+The Work Management Framework (WMF) is the lightweight repo-backed project-management layer for COO-managed LifeOS work. It uses existing repository surfaces to support intake, prioritisation, dispatch, review, and closure without introducing a PM application or runtime orchestration changes.
 
----
-
-## Surfaces
-
-| Surface | Role |
-|---------|------|
-| GitHub issues | Intake and coordination bus |
-| `config/tasks/backlog.yaml` | Canonical queue state |
-| `docs/11_admin/BACKLOG.md` | Derived, view-only summary (non-canonical) |
-| `artifacts/workstreams.yaml` | Workstream taxonomy |
-| `docs/02_protocols/Project_Planning_Protocol_v1.0.md` | Planning protocol reference |
-| `execution_order.v1` | Dispatch authority |
-| Closure evidence | Completion proof |
+WMF v0.1 answers one operational question: what is the canonical state of each COO-managed work item, and what evidence is required to move it forward?
 
 ---
 
-## ID Model
+## 2. Non-goals
+
+WMF v0.1 does **not** implement:
+
+- PM dashboards or application UI.
+- GitHub API reconciliation.
+- Automated GitHub issue creation or closing.
+- WIP limits or capacity planning.
+- Full transition-matrix enforcement.
+- `BACKLOG.md` auto-generation.
+- Parallel COO locking or transactional ID services.
+- Runtime execution behavior changes.
+- Broad architecture normalization.
+
+---
+
+## 3. Operating model
+
+### 3.1 Role boundaries
+
+| Role | WMF responsibility |
+|------|--------------------|
+| CEO | Approves kickoff, answers judgment blockers, accepts or rejects final result |
+| Active COO | Sole operational coordinator; owns dispatch, scope control, backlog writes, evidence review, and escalation |
+| EA/build agent | Makes repo edits, runs validator/tests, and reports evidence |
+| Reviewer | Reviews PR/diff/evidence and returns accept or fixes-requested |
+| Standby COO | May review or advise; must not write operational state unless explicitly promoted |
+
+### 3.2 Active-COO substrate semantics
+
+Only the active COO writes WMF operational state. Standby COOs, reviewers, and build agents may propose changes, but state transitions are not canonical until the active COO records them in `config/tasks/backlog.yaml`.
+
+Current v0.1 limitation: WMF assumes one active writer. It does not provide concurrent ID minting, file locking, or transaction semantics. If parallel operational writers are introduced, v0.2 must add a locked or transactional mint/write mechanism before more than one writer can mutate WMF state.
+
+---
+
+## 4. Authority matrix
+
+| Surface | Role | Authority |
+|---------|------|-----------|
+| GitHub issues | Intake and coordination bus | Non-canonical coordination; useful for discussion, acceptance criteria, PR links, and external visibility |
+| `config/tasks/backlog.yaml` | Canonical queue state | Authoritative for work-item status, priority, workstream, dispatch readiness, blockers, and closure evidence |
+| `docs/11_admin/BACKLOG.md` | Derived, view-only human summary | Non-canonical; must not contain unique work-item state |
+| `artifacts/workstreams.yaml` | Workstream taxonomy | Authoritative source for valid `workstream` values |
+| `docs/02_protocols/Project_Planning_Protocol_v1.0.md` | Formal planning protocol | Authoritative for formal plan content and review expectations |
+| `execution_order.v1` | Dispatch authority | Authorizes an executor to perform bounded work |
+| `closure_evidence` | Completion proof | Required evidence bundle for `CLOSED` work |
+
+Conflict rule: if GitHub issues, `BACKLOG.md`, or status summaries disagree with `config/tasks/backlog.yaml`, `backlog.yaml` wins for WMF queue state.
+
+---
+
+## 5. ID model
 
 - WMF work items use `id: WI-YYYY-NNN` as the primary identifier.
-  - `YYYY` is the 4-digit calendar year.
-  - `NNN` is a 3-digit zero-padded sequence number within that year (e.g., `001`, `042`).
+  - `YYYY` is the four-digit calendar year.
+  - `NNN` is a three-digit zero-padded sequence number within that year.
   - Example: `WI-2026-001`.
-- IDs are minted at `TRIAGED` state, atomically with the backlog write.
-- Legacy COO tasks use `id: T-NNN` format and are not WMF-managed.
-- No separate `wi_id` field. The `id` field is the canonical WMF identifier.
+- IDs are minted at `TRIAGED`, not `INTAKE`.
+- ID minting is valid only when the new ID and item state are written atomically to `config/tasks/backlog.yaml` in the same operational update.
+- Legacy COO tasks use `id: T-NNN`; they coexist in `config/tasks/backlog.yaml` and are not WMF-managed.
+- No separate `wi_id` field exists. The `id` field is canonical.
 
 ---
 
-## backlog.v1 Compatibility
+## 6. State machine
 
-Until `backlog.v2` or a dedicated `WorkItemEntry` schema exists, WI-* records in
-`config/tasks/backlog.yaml` are stored as `backlog.v1 TaskEntry`-compatible records.
-They must include the existing `backlog.v1` required fields **in addition to** WMF fields:
+### 6.1 Active v0.1 states
 
-| Required legacy field | Allowed values |
-|-----------------------|----------------|
-| `id` | `WI-YYYY-NNN` |
-| `title` | non-empty string |
-| `priority` | `P0 \| P1 \| P2 \| P3` |
-| `risk` | `low \| med \| high` |
-| `status` | WMF state (see §State Machine) |
-| `task_type` | `build \| content \| hygiene` |
-| `objective_ref` | non-empty string |
-| `created_at` | ISO 8601 timestamp |
-| `scope_paths` | list (may be empty) |
-| `tags` | list (may be empty) |
-
-Do not omit required legacy fields or introduce hidden defaults. A WI item that passes
-the WMF validator must also be loadable by `runtime/orchestration/coo/backlog.py`
-without error.
-
----
-
-## WMF Field Schema
-
-Fields specific to WMF work items (`id: WI-YYYY-NNN`):
-
-| Field | Required | Type | Notes |
-|-------|----------|------|-------|
-| `github_issue` | at `TRIAGED`+ | `int` | GitHub issue number |
-| `workstream` | always | `str` | Key from `artifacts/workstreams.yaml` |
-| `acceptance_criteria` | at `READY`/`DISPATCHED` | `list[str]` or `str` | Or use `acceptance_ref` |
-| `acceptance_ref` | at `READY`/`DISPATCHED` | `str` | Pointer to external AC doc; alternative to `acceptance_criteria` |
-| `plan_mode` | always | `none \| plan_lite \| formal` | |
-| `plan_path` | if `formal` | `str` | Required when `plan_mode=formal` (no exceptions) |
-| `plan_followup_required` | no | `bool` | `true` = plan deferred; P0 expedited path |
-| `followup_backlog_item` | if P0 expedited | `WI-YYYY-NNN` | Required before `CLOSED` if P0 expedited |
-| `closure_evidence` | at `CLOSED` | `list[{type,ref,note}]` | All three keys required per entry |
-
-`class` is explicitly not required at any stage.
-
-`acceptance_criteria` accepts:
-
-- A non-empty string.
-- A non-empty `list[str]` (all entries non-empty). **Preferred format.**
-
----
-
-## State Machine
-
-Work items progress through the following states:
-
-| State | Meaning |
-|-------|---------|
-| `INTAKE` | Captured but not yet assessed |
-| `TRIAGED` | Assessed, ID minted, github_issue assigned |
-| `READY` | Acceptance criteria defined, ready to dispatch |
-| `DISPATCHED` | Assigned to an agent or executor |
-| `REVIEW` | Work complete, under review |
-| `CLOSED` | Accepted and closed; closure evidence recorded |
-| `BLOCKED` | Progress blocked; blocker documented in evidence |
-| `DEFERRED` | Intentionally deferred |
-| `REJECTED` | Rejected after assessment |
-| `DUPLICATE` | Duplicate of an existing item |
-| `SUPERSEDED` | Replaced by another item |
-
-### Legal Transitions
-
-```
-INTAKE       → TRIAGED | REJECTED | DUPLICATE
-TRIAGED      → READY | DEFERRED | REJECTED | BLOCKED
-READY        → DISPATCHED | BLOCKED | DEFERRED
-DISPATCHED   → REVIEW | BLOCKED
-REVIEW       → CLOSED | DISPATCHED  ← fixes-requested returns here
-CLOSED       → (terminal)
-BLOCKED      → READY | TRIAGED | DEFERRED
-DEFERRED     → TRIAGED | REJECTED
-REJECTED     → (terminal)
-DUPLICATE    → (terminal)
-SUPERSEDED   → (terminal)
-```
-
-`REVIEW` fixes-requested returns to `DISPATCHED` (not `READY`), as the executor
-must address the review findings before re-submitting.
-
----
-
-## Plan Mode Rules
-
-Every WMF item must declare a `plan_mode`. Allowed values:
-
-| Value | Meaning |
-|-------|---------|
-| `none` | No plan required |
-| `plan_lite` | Lightweight inline plan |
-| `formal` | Formal plan document required |
-
+| State | Meaning | Entry requirement | Exit requirement |
+|-------|---------|-------------------|------------------|
+| `INTAKE` | Captured but not yet assessed | Issue, note, or request exists | Triage decision |
+| `TRIAGED` | Assessed and accepted for tracking | `WI-YYYY-NNN` minted and `github_issue` recorded | Priority/workstream/next action clear |
+| `READY` | Ready to dispatch | Acceptance criteria or acceptance reference exists | Executor selected or blocker found |
+| `DISPATCHED` | Assigned to an executor | Dispatch authority exists, usually `execution_order.v1` | Work complete, blocked, or deferred |
+| `REVIEW` | Work submitted for review | Evidence or PR exists | Accepted/closed or fixes requested |
+| `CLOSED` | Accepted and complete | Closure evidence recorded | Terminal |
+| `BLOCKED` | Progress is blocked | `blocked_reason` or equivalent evidence exists | Unblocked, deferred, or re-triaged |
 
 > [!IMPORTANT]
 > **STRATEGIC TRUNCATION**: Content exceedes 5000 characters. Only strategic overview included. See full text in Universal Corpus.

--- a/scripts/validate_work_items.py
+++ b/scripts/validate_work_items.py
@@ -48,14 +48,61 @@ STATUSES_REQUIRING_ACCEPTANCE = {"READY", "DISPATCHED"}
 DERIVED_HEADER_MARKER = "DERIVED VIEW"
 
 
+def _infer_error_code(field: str, message: str) -> str:
+    """Map validator fields to stable Phase 0 error codes."""
+    if field == "id":
+        return "WM002_DUPLICATE_ID" if "duplicate" in message.lower() else "WM001_INVALID_ID_FORMAT"
+    if field == "status":
+        return "WM003_INVALID_STATUS"
+    if field == "priority":
+        return "WM004_INVALID_PRIORITY"
+    if field == "github_issue":
+        return "WM005_MISSING_GITHUB_ISSUE"
+    if field == "workstream":
+        return "WM006_INVALID_WORKSTREAM"
+    if field == "acceptance_criteria":
+        return "WM007_MISSING_ACCEPTANCE"
+    if field == "plan_path":
+        return "WM008_MISSING_PLAN_PATH"
+    if field == "followup_backlog_item":
+        return "WM009_MISSING_P0_FOLLOWUP"
+    if field == "closure_evidence":
+        return "WM010_MISSING_CLOSURE_EVIDENCE"
+    if field.startswith("closure_evidence["):
+        return "WM011_INVALID_CLOSURE_EVIDENCE"
+    if field == "header":
+        return "WM012_BACKLOG_MD_NOT_DERIVED"
+    if field in {"yaml", "backlog", "schema_version", "tasks", "workstreams"}:
+        return "WM013_INVALID_SOURCE_SHAPE"
+    return "WM014_INVALID_WMF_FIELD"
+
+
 @dataclass
 class WMFViolation:
     item_id: str
     field: str
     message: str
+    code: str = ""
+    severity: str = "error"
+    file_path: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.code:
+            self.code = _infer_error_code(self.field, self.message)
 
     def __str__(self) -> str:
-        return f"[{self.item_id}] {self.field}: {self.message}"
+        location = f"{self.file_path}:" if self.file_path else ""
+        return (
+            f"{self.severity.upper()} {self.code} "
+            f"{location}[{self.item_id}] {self.field}: {self.message}"
+        )
+
+
+def _sort_violations(violations: List[WMFViolation]) -> List[WMFViolation]:
+    return sorted(
+        violations,
+        key=lambda v: (v.file_path, v.item_id, v.field, v.code, v.message),
+    )
 
 
 def _find_repo_root() -> Optional[Path]:
@@ -135,11 +182,30 @@ def validate_backlog(
     """Validate all WMF candidates in backlog_path. Return list of violations."""
     violations: List[WMFViolation] = []
 
-    with open(backlog_path, "r", encoding="utf-8") as f:
-        raw = yaml.safe_load(f)
+    try:
+        with open(backlog_path, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f)
+    except yaml.YAMLError as exc:
+        return [
+            WMFViolation(
+                str(backlog_path),
+                "yaml",
+                f"malformed YAML: {exc}",
+                file_path=str(backlog_path),
+            )
+        ]
 
     if not isinstance(raw, dict):
-        return [WMFViolation(str(backlog_path), "backlog", "must be a YAML mapping")]
+        return _sort_violations(
+            [
+                WMFViolation(
+                    str(backlog_path),
+                    "backlog",
+                    "must be a YAML mapping",
+                    file_path=str(backlog_path),
+                )
+            ]
+        )
 
     schema_version = raw.get("schema_version")
     if schema_version != "backlog.v1":
@@ -155,15 +221,45 @@ def validate_backlog(
     if tasks is None:
         tasks = []
     elif not isinstance(tasks, list):
-        return violations + [WMFViolation(str(backlog_path), "tasks", "must be a list")]
+        return _sort_violations(
+            violations
+            + [
+                WMFViolation(
+                    str(backlog_path),
+                    "tasks",
+                    "must be a list",
+                    file_path=str(backlog_path),
+                )
+            ]
+        )
 
     # Load valid workstream slugs.
     valid_workstreams: set[str] = set()
     if workstreams_path.exists():
-        with open(workstreams_path, "r", encoding="utf-8") as f:
-            ws_raw = yaml.safe_load(f)
+        try:
+            with open(workstreams_path, "r", encoding="utf-8") as f:
+                ws_raw = yaml.safe_load(f)
+        except yaml.YAMLError as exc:
+            violations.append(
+                WMFViolation(
+                    str(workstreams_path),
+                    "yaml",
+                    f"malformed YAML: {exc}",
+                    file_path=str(workstreams_path),
+                )
+            )
+            ws_raw = None
         if isinstance(ws_raw, dict):
             valid_workstreams = set(ws_raw.keys())
+        elif ws_raw is not None:
+            violations.append(
+                WMFViolation(
+                    str(workstreams_path),
+                    "workstreams",
+                    "must be a YAML mapping of workstream slugs",
+                    file_path=str(workstreams_path),
+                )
+            )
 
     seen_ids: set[str] = set()
 
@@ -270,7 +366,16 @@ def validate_backlog(
                 )
 
         # Check 10: P0 expedited + CLOSED requires followup_backlog_item.
-        plan_followup_required = bool(item.get("plan_followup_required", False))
+        raw_plan_followup_required = item.get("plan_followup_required", False)
+        if "plan_followup_required" in item and not isinstance(raw_plan_followup_required, bool):
+            violations.append(
+                WMFViolation(
+                    item_id,
+                    "plan_followup_required",
+                    "must be boolean when present",
+                )
+            )
+        plan_followup_required = raw_plan_followup_required is True
         is_p0_expedited = (
             priority == "P0"
             and isinstance(plan_mode, str)
@@ -324,7 +429,7 @@ def validate_backlog(
                                 )
                             )
 
-    return violations
+    return _sort_violations(violations)
 
 
 def validate_backlog_md_header(backlog_md_path: Path) -> List[WMFViolation]:
@@ -346,6 +451,11 @@ def validate_backlog_md_header(backlog_md_path: Path) -> List[WMFViolation]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Run validation and exit (default behavior; retained for CI command clarity)",
+    )
     parser.add_argument(
         "--backlog", default=None, help="Path to backlog.yaml (default: auto-detect from repo root)"
     )

--- a/scripts/validate_work_items.py
+++ b/scripts/validate_work_items.py
@@ -263,8 +263,16 @@ def validate_backlog(
 
     seen_ids: set[str] = set()
 
-    for item in tasks:
+    for index, item in enumerate(tasks):
         if not isinstance(item, dict):
+            violations.append(
+                WMFViolation(
+                    f"tasks[{index}]",
+                    "tasks",
+                    "each tasks entry must be a YAML mapping",
+                    file_path=str(backlog_path),
+                )
+            )
             continue
         item_id = str(item.get("id", "")).strip()
 

--- a/tests_doc/test_work_management_validator.py
+++ b/tests_doc/test_work_management_validator.py
@@ -238,6 +238,13 @@ class TestBacklogV1Compat:
         violations = validate_backlog(backlog, ws)
         assert violations == []
 
+    def test_class_field_presence_does_not_fail(self, tmp_path: Path) -> None:
+        item = {**VALID_WMF_ITEM, "class": "build"}
+        backlog = _write_backlog(tmp_path, [item])
+        ws = _write_workstreams(tmp_path)
+        violations = validate_backlog(backlog, ws)
+        assert violations == []
+
 
 # ---------------------------------------------------------------------------
 # github_issue
@@ -362,6 +369,17 @@ class TestAcceptanceCriteria:
         violations = validate_backlog(backlog, ws)
         assert not any("acceptance_criteria" in v.field for v in violations)
 
+    def test_dispatched_without_ac_or_ar_flagged(self, tmp_path: Path) -> None:
+        item = {
+            k: v
+            for k, v in {**VALID_WMF_ITEM, "status": "DISPATCHED"}.items()
+            if k not in ("acceptance_criteria", "acceptance_ref")
+        }
+        backlog = _write_backlog(tmp_path, [item])
+        ws = _write_workstreams(tmp_path)
+        violations = validate_backlog(backlog, ws)
+        assert any("acceptance_criteria" in v.field for v in violations)
+
 
 # ---------------------------------------------------------------------------
 # plan_mode
@@ -451,6 +469,13 @@ class TestPlanMode:
         ws = _write_workstreams(tmp_path)
         violations = validate_backlog(backlog, ws)
         assert not any("plan_path" in v.field for v in violations)
+
+    def test_plan_followup_required_non_bool_flagged(self, tmp_path: Path) -> None:
+        item = {**VALID_WMF_ITEM, "plan_followup_required": "true"}
+        backlog = _write_backlog(tmp_path, [item])
+        ws = _write_workstreams(tmp_path)
+        violations = validate_backlog(backlog, ws)
+        assert any("plan_followup_required" in v.field for v in violations)
 
 
 # ---------------------------------------------------------------------------
@@ -575,6 +600,13 @@ class TestBacklogMdHeader:
 
 
 class TestBacklogYamlShape:
+    def test_malformed_yaml_flagged(self, tmp_path: Path) -> None:
+        backlog = tmp_path / "backlog.yaml"
+        backlog.write_text("tasks:\n  - id: [unterminated\n", encoding="utf-8")
+        ws = _write_workstreams(tmp_path)
+        violations = validate_backlog(backlog, ws)
+        assert any(v.code == "WM013_INVALID_SOURCE_SHAPE" and v.field == "yaml" for v in violations)
+
     def test_non_mapping_backlog_flagged(self, tmp_path: Path) -> None:
         backlog = tmp_path / "backlog.yaml"
         backlog.write_text("- not\n- a mapping\n", encoding="utf-8")
@@ -614,7 +646,7 @@ class TestRealRepo:
         import subprocess
 
         result = subprocess.run(
-            [sys.executable, "scripts/validate_work_items.py"],
+            [sys.executable, "scripts/validate_work_items.py", "--check"],
             capture_output=True,
             text=True,
             check=False,

--- a/tests_doc/test_work_management_validator.py
+++ b/tests_doc/test_work_management_validator.py
@@ -634,6 +634,12 @@ class TestBacklogYamlShape:
         violations = validate_backlog(backlog, ws)
         assert any("tasks" in v.field for v in violations)
 
+    def test_non_mapping_task_entry_flagged(self, tmp_path: Path) -> None:
+        backlog = _write_backlog(tmp_path, ["not a task mapping"])
+        ws = _write_workstreams(tmp_path)
+        violations = validate_backlog(backlog, ws)
+        assert any(v.item_id == "tasks[0]" and v.field == "tasks" for v in violations)
+
 
 # ---------------------------------------------------------------------------
 # Real-repo smoke test


### PR DESCRIPTION
## Summary
- Adds the canonical Work Management Framework v0.1 protocol for COO-managed work item intake, triage, dispatch, review, and closure.
- Updates backlog surfaces so `config/tasks/backlog.yaml` remains canonical while `docs/11_admin/BACKLOG.md` is explicitly derived/view-only.
- Adds CI-friendly `scripts/validate_work_items.py --check` behavior with stable validation output and focused tests.

## Test plan
- [x] `python3 scripts/validate_work_items.py --check`
- [x] `pytest tests_doc/test_work_management_validator.py -q`
- [x] `python3 -m ruff check scripts/validate_work_items.py tests_doc/test_work_management_validator.py`
- [x] `python3 scripts/claude_doc_stewardship_gate.py`
- [x] `git diff --check`
- [x] `pytest runtime/tests -q` — 3229 passed, 6 skipped, 7 warnings

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)