### PR TITLE
Pin LifeOS to agent-control-plane contract

### DIFF
--- a/config/INDEX.md
+++ b/config/INDEX.md
@@ -2,6 +2,7 @@
 
 - [GEMINI.md](./GEMINI.md)
 - [INDEX_v1.0.md](./INDEX_v1.0.md)
+- [external_contracts/agent_control_plane_pin.yaml](./external_contracts/agent_control_plane_pin.yaml)
 - [backlog.yaml](./backlog.yaml)
 - [invariants.yaml](./invariants.yaml)
 - [recursive_kernel_config.yaml](./recursive_kernel_config.yaml)

--- a/config/INDEX_v1.0.md
+++ b/config/INDEX_v1.0.md
@@ -1,5 +1,6 @@
 # Config Index v1.0
 
 - [backlog.yaml](./backlog.yaml)
+- [external_contracts/agent_control_plane_pin.yaml](./external_contracts/agent_control_plane_pin.yaml)
 - [invariants.yaml](./invariants.yaml)
 - [recursive_kernel_config.yaml](./recursive_kernel_config.yaml)

--- a/config/external_contracts/agent_control_plane_pin.yaml
+++ b/config/external_contracts/agent_control_plane_pin.yaml
@@ -1,0 +1,76 @@
+schema_version: external_contract_pin.v1
+name: agent-control-plane
+status: active
+owner: LifeOS
+last_updated_utc: 2026-04-28T08:00:03Z
+
+source:
+  repo: marcusglee11/agent-control-plane
+  url: https://github.com/marcusglee11/agent-control-plane
+  visibility: private
+  branch: master
+  pinned_commit: df1c4411242c99d65b54775c50aa1fc179f22c0b
+  pinned_commit_url: https://github.com/marcusglee11/agent-control-plane/commit/df1c4411242c99d65b54775c50aa1fc179f22c0b
+
+relationship:
+  control_plane_repo_owns:
+    - reusable OpenClaw-Hermes delegated-authority protocol primitives
+    - GitHub bus wire protocol and label/state contracts
+    - shared machine schemas for authority, evidence, delegation, invocation, and receipts
+    - watcher behavior contracts and protocol probes
+  lifeos_repo_owns:
+    - LifeOS governance canon and constitutional authority
+    - LifeOS roadmap, backlog, and state
+    - LifeOS runtime/build-loop implementation
+    - LifeOS-specific architecture decisions
+  extraction_rule: LifeOS-specific decisions land in LifeOS first; reusable primitives are extracted to agent-control-plane and re-enter LifeOS through this pin.
+
+consumed_artifacts:
+  - source_path: docs/delegated-authority-protocol-v0.3-ratified.md
+    local_path: null
+    local_policy: referenced_not_mirrored
+    purpose: Delegated authority protocol for OpenClaw-Hermes execution authority, receipts, and channel discipline.
+  - source_path: docs/protocol.md
+    local_path: null
+    local_policy: referenced_not_mirrored
+    purpose: GitHub bus wire protocol and routing/status label semantics.
+  - source_path: docs/hermes-watcher-contract.md
+    local_path: null
+    local_policy: referenced_not_mirrored
+    purpose: Hermes watcher behavioral contract against the live bus.
+  - source_path: docs/lifeos-contract-pinning.md
+    local_path: null
+    local_policy: referenced_not_mirrored
+    purpose: Upstream consumer-rule statement for this pinned relationship.
+  - source_path: schemas/envelope-v1.json
+    local_path: null
+    local_policy: referenced_not_mirrored
+    purpose: Transport envelope schema.
+  - source_path: schemas/delegation-v1.json
+    local_path: null
+    local_policy: referenced_not_mirrored
+    purpose: Delegated execution authority schema.
+  - source_path: schemas/receipt-v1.json
+    local_path: null
+    local_policy: referenced_not_mirrored
+    purpose: Receipt chain schema.
+  - source_path: schemas/authority-assertion-v1.json
+    local_path: null
+    local_policy: referenced_not_mirrored
+    purpose: Machine-checkable authority assertion schema.
+  - source_path: schemas/evidence-meta-v1.json
+    local_path: null
+    local_policy: referenced_not_mirrored
+    purpose: Machine-checkable evidence metadata schema.
+
+update_policy:
+  required_steps:
+    - Inspect upstream diff between previous pin and candidate pin.
+    - Update this manifest with the candidate commit and changed artifact list.
+    - Update mirrored LifeOS artefacts if local_policy is mirrored.
+    - Run the compatibility check below.
+    - Record evidence in the LifeOS PR or issue.
+  compatibility_check:
+    command: python3 scripts/workflow/check_agent_control_plane_pin.py --manifest config/external_contracts/agent_control_plane_pin.yaml
+    optional_source_worktree_command: python3 scripts/workflow/check_agent_control_plane_pin.py --manifest config/external_contracts/agent_control_plane_pin.yaml --source-worktree /home/cabra/.openclaw/workspace/agent-control-plane
+  drift_rule: Missing or stale pin evidence is a dependency drift defect, not a runtime authority source.

--- a/config/quality/manifest.yaml
+++ b/config/quality/manifest.yaml
@@ -61,6 +61,12 @@ tools:
     scopes: ["changed", "repo"]
     autofix_allowed: false
     failure_class: shellcheck_error
+  agent_control_plane_pin:
+    enabled: true
+    mode: blocking
+    scopes: ["changed", "repo"]
+    autofix_allowed: false
+    failure_class: agent_control_plane_pin_error
 
 waivers:
   - tool: markdownlint

--- a/docs/02_protocols/Agent_Control_Plane_Pin_v1.0.md
+++ b/docs/02_protocols/Agent_Control_Plane_Pin_v1.0.md
@@ -1,0 +1,97 @@
+# Agent Control-Plane Pin v1.0
+
+Status: Active dependency contract
+Last updated: 2026-04-28
+
+## Purpose
+
+LifeOS treats `marcusglee11/agent-control-plane` as the shared external source for reusable
+OpenClaw ↔ Hermes control-plane contracts.
+
+This document defines the LifeOS-side pinning rule. The machine-readable pin is:
+
+```text
+config/external_contracts/agent_control_plane_pin.yaml
+```
+
+## Boundary
+
+`agent-control-plane` owns reusable protocol/control-plane primitives:
+
+- delegated-authority protocol text
+- GitHub bus wire protocol and label/state semantics
+- watcher behavior contracts
+- shared schemas for authority, evidence, delegation, invocation, and receipts
+- protocol probes and reusable operational-discipline standards
+
+LifeOS owns LifeOS-specific surfaces:
+
+- constitutional and governance canon
+- roadmap, backlog, and state
+- COO runtime and build-loop implementation
+- LifeOS-specific architecture decisions
+
+## Pin rule
+
+LifeOS must not depend on a floating branch of `agent-control-plane`.
+
+Every consumed control-plane contract must be represented by:
+
+1. source repo
+2. source URL
+3. source branch or tag
+4. pinned commit SHA
+5. consumed source artefact paths
+6. LifeOS local target paths, if mirrored
+7. compatibility check command
+8. PR/issue evidence for each pin bump
+
+## Current pin
+
+The active pin is recorded in `config/external_contracts/agent_control_plane_pin.yaml`.
+
+Current source commit at creation:
+
+```text
+df1c4411242c99d65b54775c50aa1fc179f22c0b
+```
+
+Source commit URL:
+
+```text
+https://github.com/marcusglee11/agent-control-plane/commit/df1c4411242c99d65b54775c50aa1fc179f22c0b
+```
+
+## Compatibility check
+
+Default structure-only check:
+
+```bash
+python3 scripts/workflow/check_agent_control_plane_pin.py --manifest config/external_contracts/agent_control_plane_pin.yaml
+```
+
+Local full check, when the private source repo is available:
+
+```bash
+python3 scripts/workflow/check_agent_control_plane_pin.py --manifest config/external_contracts/agent_control_plane_pin.yaml --source-worktree /home/cabra/.openclaw/workspace/agent-control-plane
+```
+
+The full check confirms every consumed upstream artefact exists at the pinned source commit.
+
+## Update procedure
+
+1. Inspect upstream diff between the old and candidate `agent-control-plane` commits.
+2. Update `config/external_contracts/agent_control_plane_pin.yaml`.
+3. Update any mirrored LifeOS artefacts if a consumed path is mirrored locally.
+4. Run the compatibility check.
+5. Record evidence in the LifeOS PR or issue.
+
+## Extraction procedure
+
+LifeOS-specific decisions land in LifeOS first.
+
+If a decision becomes reusable across Hermes/OpenClaw/other agent surfaces, extract the smallest stable
+primitive into `agent-control-plane`. LifeOS then re-consumes it through an explicit pin bump.
+
+Do not smuggle LifeOS governance changes into `agent-control-plane`; do not smuggle reusable protocol
+changes into LifeOS without a pin.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD013 MD040 MD060 -->
 
-Last Updated: 2026-04-28 (rev25)
+Last Updated: 2026-04-28 (rev26)
 
 **Authority**: [LifeOS Constitution v2.0](./00_foundations/LifeOS_Constitution_v2.0.md)
 
@@ -166,6 +166,7 @@ LifeOS Constitution v2.0 (Supreme)
 | [Project_Planning_Protocol_v1.0.md](./02_protocols/Project_Planning_Protocol_v1.0.md) | Build mission plan requirements, schema compliance, lifecycle, and review rubric |
 | [Work_Management_Framework_v0.1.md](./02_protocols/Work_Management_Framework_v0.1.md) | **NEW** — Work Management Framework v0.1: intake, prioritisation, dispatch, review, closure |
 | [OpenClaw_COO_Integration_v1.0.md](./02_protocols/OpenClaw_COO_Integration_v1.0.md) | OpenClaw gateway invocation, CLI wrappers, known constraints |
+| [Agent_Control_Plane_Pin_v1.0.md](./02_protocols/Agent_Control_Plane_Pin_v1.0.md) | **Dependency contract** — pins LifeOS to the external `agent-control-plane` protocol/control-plane source |
 
 ### Council Protocols
 

--- a/docs/LifeOS_Strategic_Corpus.md
+++ b/docs/LifeOS_Strategic_Corpus.md
@@ -3995,6 +3995,109 @@ This build is **approved for merge/activation within Phase 0–1**. Council sign
 
 ---
 
+# File: 02_protocols/Agent_Control_Plane_Pin_v1.0.md
+
+# Agent Control-Plane Pin v1.0
+
+Status: Active dependency contract
+Last updated: 2026-04-28
+
+## Purpose
+
+LifeOS treats `marcusglee11/agent-control-plane` as the shared external source for reusable
+OpenClaw ↔ Hermes control-plane contracts.
+
+This document defines the LifeOS-side pinning rule. The machine-readable pin is:
+
+```text
+config/external_contracts/agent_control_plane_pin.yaml
+```
+
+## Boundary
+
+`agent-control-plane` owns reusable protocol/control-plane primitives:
+
+- delegated-authority protocol text
+- GitHub bus wire protocol and label/state semantics
+- watcher behavior contracts
+- shared schemas for authority, evidence, delegation, invocation, and receipts
+- protocol probes and reusable operational-discipline standards
+
+LifeOS owns LifeOS-specific surfaces:
+
+- constitutional and governance canon
+- roadmap, backlog, and state
+- COO runtime and build-loop implementation
+- LifeOS-specific architecture decisions
+
+## Pin rule
+
+LifeOS must not depend on a floating branch of `agent-control-plane`.
+
+Every consumed control-plane contract must be represented by:
+
+1. source repo
+2. source URL
+3. source branch or tag
+4. pinned commit SHA
+5. consumed source artefact paths
+6. LifeOS local target paths, if mirrored
+7. compatibility check command
+8. PR/issue evidence for each pin bump
+
+## Current pin
+
+The active pin is recorded in `config/external_contracts/agent_control_plane_pin.yaml`.
+
+Current source commit at creation:
+
+```text
+df1c4411242c99d65b54775c50aa1fc179f22c0b
+```
+
+Source commit URL:
+
+```text
+https://github.com/marcusglee11/agent-control-plane/commit/df1c4411242c99d65b54775c50aa1fc179f22c0b
+```
+
+## Compatibility check
+
+Default structure-only check:
+
+```bash
+python3 scripts/workflow/check_agent_control_plane_pin.py --manifest config/external_contracts/agent_control_plane_pin.yaml
+```
+
+Local full check, when the private source repo is available:
+
+```bash
+python3 scripts/workflow/check_agent_control_plane_pin.py --manifest config/external_contracts/agent_control_plane_pin.yaml --source-worktree /home/cabra/.openclaw/workspace/agent-control-plane
+```
+
+The full check confirms every consumed upstream artefact exists at the pinned source commit.
+
+## Update procedure
+
+1. Inspect upstream diff between the old and candidate `agent-control-plane` commits.
+2. Update `config/external_contracts/agent_control_plane_pin.yaml`.
+3. Update any mirrored LifeOS artefacts if a consumed path is mirrored locally.
+4. Run the compatibility check.
+5. Record evidence in the LifeOS PR or issue.
+
+## Extraction procedure
+
+LifeOS-specific decisions land in LifeOS first.
+
+If a decision becomes reusable across Hermes/OpenClaw/other agent surfaces, extract the smallest stable
+primitive into `agent-control-plane`. LifeOS then re-consumes it through an explicit pin bump.
+
+Do not smuggle LifeOS governance changes into `agent-control-plane`; do not smuggle reusable protocol
+changes into LifeOS without a pin.
+
+
+---
+
 # File: 02_protocols/Build_Artifact_Protocol_v1.0.md
 
 # Build Artifact Protocol v1.0

--- a/runtime/tests/test_quality_gate.py
+++ b/runtime/tests/test_quality_gate.py
@@ -28,6 +28,15 @@ def test_route_quality_tools_markdown_is_style_only() -> None:
     assert routed["mypy"] == []
 
 
+def test_route_quality_tools_agent_control_plane_pin_manifest() -> None:
+    routed = route_quality_tools(
+        Path("."), ["config/external_contracts/agent_control_plane_pin.yaml"], scope="changed"
+    )
+    assert routed["agent_control_plane_pin"] == [
+        "config/external_contracts/agent_control_plane_pin.yaml"
+    ]
+
+
 def test_route_quality_tools_config_only_markdown_change_no_fan_out(monkeypatch) -> None:
     monkeypatch.setattr(
         "runtime.tools.workflow_pack._git_tracked_files",
@@ -86,6 +95,26 @@ def test_run_quality_gates_allows_advisory_failure(monkeypatch) -> None:
     assert any(
         row["tool"] == "yamllint" and row["mode"] == "advisory" and not row["passed"]
         for row in result["results"]
+    )
+
+
+def test_run_quality_gates_runs_agent_control_plane_pin(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(*args, **kwargs):
+        cmd = args[0]
+        commands.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="OK", stderr="")
+
+    monkeypatch.setattr("runtime.tools.workflow_pack.subprocess.run", fake_run)
+    result = run_quality_gates(
+        Path("."), ["config/external_contracts/agent_control_plane_pin.yaml"], scope="changed"
+    )
+
+    assert result["passed"] is True
+    assert any(row["tool"] == "agent_control_plane_pin" for row in result["results"])
+    assert any(
+        "scripts/workflow/check_agent_control_plane_pin.py" in command for command in commands
     )
 
 

--- a/runtime/tools/workflow_pack.py
+++ b/runtime/tools/workflow_pack.py
@@ -50,12 +50,17 @@ QUALITY_TOOL_EXECUTABLES = {
     "markdownlint": "markdownlint",
     "yamllint": "yamllint",
     "shellcheck": "shellcheck",
+    "agent_control_plane_pin": "python3",
 }
 QUALITY_PYTHON_CONFIG_FILES = {"pyproject.toml", "requirements.txt", "requirements-dev.txt"}
 QUALITY_BIOME_EXTENSIONS = {".js", ".jsx", ".ts", ".tsx", ".json", ".jsonc"}
 QUALITY_BIOME_CONFIG_FILES = {"biome.json"}
 QUALITY_MARKDOWN_CONFIG_FILES = {".markdownlint.json", ".markdownlint.yaml", ".markdownlint.yml"}
 QUALITY_YAML_CONFIG_FILES = {".yamllint", ".yamllint.yml", ".yamllint.yaml"}
+QUALITY_AGENT_CONTROL_PLANE_PIN_FILES = {
+    "config/external_contracts/agent_control_plane_pin.yaml",
+    "scripts/workflow/check_agent_control_plane_pin.py",
+}
 BACKLOG_METADATA_CONTINUATION_PATTERN = re.compile(
     r"^\s+[—-]+\s*(?:DoD|Why\s*Now|Owner|Context):",
     re.IGNORECASE,
@@ -243,6 +248,8 @@ def route_quality_tools(
     yaml_files: list[str] = []
     yaml_trigger = False
     shell_files: list[str] = []
+    agent_control_plane_pin_files: list[str] = []
+    agent_control_plane_pin_trigger = False
 
     for file_path in files:
         path = Path(file_path)
@@ -277,6 +284,10 @@ def route_quality_tools(
         if suffix == ".sh":
             shell_files.append(file_path)
 
+        if file_path in QUALITY_AGENT_CONTROL_PLANE_PIN_FILES:
+            agent_control_plane_pin_files.append(file_path)
+            agent_control_plane_pin_trigger = True
+
     if python_trigger:
         routed["ruff_check"] = _unique_ordered(python_files)
         routed["ruff_format"] = _unique_ordered(python_files)
@@ -289,6 +300,8 @@ def route_quality_tools(
         routed["yamllint"] = _unique_ordered(yaml_files)
     if shell_files:
         routed["shellcheck"] = _unique_ordered(shell_files)
+    if agent_control_plane_pin_trigger and "agent_control_plane_pin" in routed:
+        routed["agent_control_plane_pin"] = _unique_ordered(agent_control_plane_pin_files)
 
     return routed
 
@@ -434,6 +447,17 @@ def _build_quality_command(
         if not files:
             return None
         return ["shellcheck", *files]
+
+    if tool_name == "agent_control_plane_pin":
+        manifest_path = Path("config/external_contracts/agent_control_plane_pin.yaml")
+        script_path = Path("scripts/workflow/check_agent_control_plane_pin.py")
+        if scope != "repo" and not files:
+            return None
+        if not (Path(repo_root) / manifest_path).exists():
+            return None
+        if not (Path(repo_root) / script_path).exists():
+            return None
+        return [sys.executable, str(script_path), "--manifest", str(manifest_path)]
 
     return None
 

--- a/scripts/workflow/check_agent_control_plane_pin.py
+++ b/scripts/workflow/check_agent_control_plane_pin.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Validate the LifeOS agent-control-plane external contract pin manifest."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REQUIRED_SOURCE = {
+    "repo": "marcusglee11/agent-control-plane",
+    "url": "https://github.com/marcusglee11/agent-control-plane",
+}
+PIN_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _fail(message: str) -> int:
+    print(f"FAIL: {message}", file=sys.stderr)
+    return 1
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError("manifest root must be a mapping")
+    return data
+
+
+def _git_cat_file(source_worktree: Path, commit: str, source_path: str) -> bool:
+    proc = subprocess.run(
+        ["git", "-C", str(source_worktree), "cat-file", "-e", f"{commit}:{source_path}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def validate_manifest(
+    manifest: dict[str, Any], repo_root: Path, source_worktree: Path | None = None
+) -> list[str]:
+    errors: list[str] = []
+
+    if manifest.get("schema_version") != "external_contract_pin.v1":
+        errors.append("schema_version must be external_contract_pin.v1")
+    if manifest.get("name") != "agent-control-plane":
+        errors.append("name must be agent-control-plane")
+    if manifest.get("status") != "active":
+        errors.append("status must be active")
+
+    source = manifest.get("source")
+    if not isinstance(source, dict):
+        errors.append("source must be a mapping")
+        source = {}
+
+    for key, expected in REQUIRED_SOURCE.items():
+        if source.get(key) != expected:
+            errors.append(f"source.{key} must be {expected}")
+
+    commit = source.get("pinned_commit")
+    if not isinstance(commit, str) or not PIN_RE.fullmatch(commit):
+        errors.append("source.pinned_commit must be a 40-character lowercase hex SHA")
+        commit = ""
+
+    branch = source.get("branch")
+    if not isinstance(branch, str) or not branch:
+        errors.append("source.branch must be set")
+
+    artifacts = manifest.get("consumed_artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        errors.append("consumed_artifacts must be a non-empty list")
+        artifacts = []
+
+    for idx, artifact in enumerate(artifacts):
+        prefix = f"consumed_artifacts[{idx}]"
+        if not isinstance(artifact, dict):
+            errors.append(f"{prefix} must be a mapping")
+            continue
+        source_path = artifact.get("source_path")
+        if not isinstance(source_path, str) or not source_path:
+            errors.append(f"{prefix}.source_path must be set")
+            continue
+        if source_path.startswith("/") or ".." in Path(source_path).parts:
+            errors.append(f"{prefix}.source_path must be repository-relative")
+        local_path = artifact.get("local_path")
+        if local_path not in (None, ""):
+            local = repo_root / str(local_path)
+            if not local.exists():
+                errors.append(f"{prefix}.local_path does not exist: {local_path}")
+        if source_worktree is not None and commit:
+            if not _git_cat_file(source_worktree, commit, source_path):
+                errors.append(f"{prefix}.source_path not found at pinned commit: {source_path}")
+
+    update_policy = manifest.get("update_policy")
+    if not isinstance(update_policy, dict):
+        errors.append("update_policy must be a mapping")
+    else:
+        compatibility = update_policy.get("compatibility_check")
+        if not isinstance(compatibility, dict) or not compatibility.get("command"):
+            errors.append("update_policy.compatibility_check.command must be set")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        default="config/external_contracts/agent_control_plane_pin.yaml",
+        help="Path to the external contract pin manifest.",
+    )
+    parser.add_argument(
+        "--source-worktree",
+        help=(
+            "Optional local agent-control-plane git worktree for pinned artifact existence checks."
+        ),
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    manifest_path = (repo_root / args.manifest).resolve()
+    source_worktree = Path(args.source_worktree).resolve() if args.source_worktree else None
+
+    try:
+        manifest = _load_manifest(manifest_path)
+    except Exception as exc:  # noqa: BLE001 - CLI should print parse failures tersely.
+        return _fail(f"could not load manifest: {exc}")
+
+    if source_worktree is not None and not (source_worktree / ".git").exists():
+        return _fail(f"source worktree is not a git checkout: {source_worktree}")
+
+    errors = validate_manifest(manifest, repo_root, source_worktree)
+    if errors:
+        for error in errors:
+            print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+
+    source = manifest["source"]
+    print(
+        "OK: agent-control-plane pin valid "
+        f"repo={source['repo']} branch={source['branch']} commit={source['pinned_commit']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a machine-readable LifeOS external contract pin for `marcusglee11/agent-control-plane` at commit `df1c4411242c99d65b54775c50aa1fc179f22c0b`.
- Documents the LifeOS/control-plane repo boundary and extraction rule in `docs/02_protocols/Agent_Control_Plane_Pin_v1.0.md`.
- Adds `scripts/workflow/check_agent_control_plane_pin.py`, regenerates/indexes the strategic corpus surface, and wires the pin check into the quality gate for changed pin manifests/checkers.

## Validation
- `python3 scripts/workflow/check_agent_control_plane_pin.py --manifest config/external_contracts/agent_control_plane_pin.yaml` ✅
- `python3 scripts/workflow/check_agent_control_plane_pin.py --manifest config/external_contracts/agent_control_plane_pin.yaml --source-worktree /home/cabra/.openclaw/workspace/agent-control-plane` ✅
- `python3 docs/scripts/generate_strategic_context.py && python3 scripts/claude_doc_stewardship_gate.py` ✅
- `python3 scripts/workflow/quality_gate.py check --scope changed --json` ✅ blocking checks pass; advisory only: local `mypy` and `yamllint` binaries unavailable
- `python3 scripts/workflow/quality_gate.py check --scope changed --changed-file config/external_contracts/agent_control_plane_pin.yaml --json` ✅ proves `agent_control_plane_pin` gate runs and passes
- `pytest -q runtime/tests/test_quality_gate.py` ✅ `13 passed`
- `pytest runtime/tests -q` ✅ `3231 passed, 6 skipped, 7 warnings`
- `git diff --check` ✅

## Fresh-context review
- Independent review found no blockers.
- Non-blocking note addressed: wired the pin validator into the quality gate so drift prevention is not purely manual.

Closes #71
Refs marcusglee11/agent-control-plane#135

🤖 Generated with Hermes Agent
