### PR TITLE
feat(wmf): wire work item validator into quality gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ Each phase produces a typed packet. See `runtime/orchestration/missions/` for im
 | What | Where |
 |------|-------|
 | Current state & WIP | `docs/11_admin/LIFEOS_STATE.md` |
-| Prioritized backlog | `docs/11_admin/BACKLOG.md` |
+| Canonical task queue | `config/tasks/backlog.yaml` |
+| Backlog summary view | `docs/11_admin/BACKLOG.md` |
 | Doc navigation | `docs/INDEX.md` |
 | Model config | `config/models.yaml` |
 | Role prompts | `config/agent_roles/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,9 @@ pytest runtime/tests -q
 # Run the canonical changed-file quality gate
 python3 scripts/workflow/quality_gate.py check --scope changed --json
 
+# Validate Work Management Framework backlog entries
+python3 scripts/validate_work_items.py --check
+
 # Apply only safe, deterministic quality fixes
 python3 scripts/workflow/quality_gate.py fix --scope changed --json
 
@@ -100,7 +103,10 @@ pytest
 # Check current project state
 cat docs/11_admin/LIFEOS_STATE.md
 
-# View backlog
+# View canonical task queue
+cat config/tasks/backlog.yaml
+
+# View derived backlog summary
 cat docs/11_admin/BACKLOG.md
 
 # Validate docs if you modified them
@@ -122,6 +128,13 @@ python -m doc_steward.cli dap-validate .
 7. **Match code style** - Follow conventions in the existing codebase
 8. **Always start builds in a worktree** - Use `/new-build <topic>` (runs `python3 scripts/workflow/start_build.py <topic> [--kind build|fix|hotfix|spike]`) to atomically create branch + isolated worktree. `build` is default; fixes use `--kind fix`. If work already started on a scoped branch in primary, recover it with `python3 scripts/workflow/start_build.py --recover-primary`. `/close-build` maps to `python3 scripts/workflow/close_build.py` and must be run from linked worktrees. Shared working tree + concurrent agents = Article XIX blocks, merge conflicts, and stash pop failures.
 9. **For dispatched build/content work, emit sprint-close before handoff** - write `artifacts/dispatch/closures/SC-<order_id>.yaml` using `sprint_close_packet.v1` before handoff. If packet emission or validation fails, treat the handoff as blocked.
+
+### COO-Managed Work Items
+
+- New COO-managed work defaults to a `WI-YYYY-NNN` entry in `config/tasks/backlog.yaml`.
+- `docs/11_admin/BACKLOG.md` is derived/view-only. Do not treat it as source of truth or place unique work-item state there.
+- Minimum manual loop: intake issue -> triage and mint WI -> update backlog state -> dispatch -> review -> close with evidence.
+- WMF validator is part of the quality gate for relevant changes; run `python3 scripts/validate_work_items.py --check` directly when touching backlog/workstream state.
 
 ### TODO & Documentation Discipline
 
@@ -218,7 +231,8 @@ When reviewing builds (from Codex, Claude Code, or any agent), **fix obvious iss
 | What | Where |
 |------|-------|
 | Current state & WIP | `docs/11_admin/LIFEOS_STATE.md` |
-| Prioritized backlog | `docs/11_admin/BACKLOG.md` |
+| Canonical task queue | `config/tasks/backlog.yaml` |
+| Backlog summary view | `docs/11_admin/BACKLOG.md` |
 | Doc navigation | `docs/INDEX.md` |
 | Constitution (deep context) | `docs/00_foundations/LifeOS_Constitution_v2.0.md` |
 | Strategic corpus | `docs/LifeOS_Strategic_Corpus.md` |

--- a/config/agent_roles/coo.md
+++ b/config/agent_roles/coo.md
@@ -25,14 +25,24 @@ Do this without asking permission.
 
 ### Orientation (LifeOS)
 
-1. `config/tasks/backlog.yaml` - current task queue.
+1. `config/tasks/backlog.yaml` - canonical current task queue.
 2. `config/governance/delegation_envelope.yaml` - authority envelope when available.
 3. `artifacts/coo/memory_seed_content.md` - project history, objectives, campaign state, agent patterns.
 4. `artifacts/dispatch/inbox/` - pending orders.
 5. `artifacts/dispatch/completed/` - recent outcomes.
 6. `docs/11_admin/LIFEOS_STATE.md` - broader project context.
+7. `docs/11_admin/BACKLOG.md` - derived human view only; not queue authority.
 
 If `delegation_envelope.yaml` is missing or unclear, fail closed and escalate unknown actions (L4).
+
+### Work Management Framework
+
+- Default new COO-managed work to `WI-YYYY-NNN` entries in `config/tasks/backlog.yaml`.
+- Mint `WI-*` only during triage, with linked `github_issue` at `TRIAGED` or later.
+- Keep all canonical status, priority, workstream, dispatch readiness, and closure evidence in `config/tasks/backlog.yaml`.
+- Treat `docs/11_admin/BACKLOG.md` as a derived/read-only summary. Do not write unique work-item state there.
+- Minimum manual loop: intake issue -> triage and mint WI -> update backlog state -> dispatch -> review -> close with evidence.
+- Run `python3 scripts/validate_work_items.py --check` before reporting WMF state as valid.
 
 ### Role References (Read, Do Not Inline)
 

--- a/config/quality/manifest.yaml
+++ b/config/quality/manifest.yaml
@@ -67,6 +67,12 @@ tools:
     scopes: ["changed", "repo"]
     autofix_allowed: false
     failure_class: agent_control_plane_pin_error
+  wmf_validator:
+    enabled: true
+    mode: blocking
+    scopes: ["changed", "repo"]
+    autofix_allowed: false
+    failure_class: wmf_validation_error
 
 waivers:
   - tool: markdownlint

--- a/docs/02_protocols/Work_Management_Framework_v0.1.md
+++ b/docs/02_protocols/Work_Management_Framework_v0.1.md
@@ -51,6 +51,21 @@ Only the active COO writes WMF operational state. Standby COOs, reviewers, and b
 
 Current v0.1 limitation: WMF assumes one active writer. It does not provide concurrent ID minting, file locking, or transaction semantics. If parallel operational writers are introduced, v0.2 must add a locked or transactional mint/write mechanism before more than one writer can mutate WMF state.
 
+### 3.3 Minimum manual loop
+
+New COO-managed work defaults to a `WI-YYYY-NNN` entry in `config/tasks/backlog.yaml`.
+
+The minimum manual operating loop is:
+
+1. Intake issue or request.
+2. Triage and mint `WI-YYYY-NNN`.
+3. Update `config/tasks/backlog.yaml` state.
+4. Dispatch through an execution order or approved manual handoff.
+5. Review diff, PR, receipt, or evidence.
+6. Close by recording `closure_evidence` in `config/tasks/backlog.yaml`.
+
+`docs/11_admin/BACKLOG.md` may summarize this loop but must not originate or uniquely store any step.
+
 ---
 
 ## 4. Authority matrix
@@ -318,7 +333,7 @@ Phase 1 target: `BACKLOG.md` should either be generated from `config/tasks/backl
 The Phase 0 validator lives at `scripts/validate_work_items.py` and runs locally with:
 
 ```bash
-python scripts/validate_work_items.py --check
+python3 scripts/validate_work_items.py --check
 ```
 
 It must check:
@@ -345,6 +360,14 @@ Implementation constraints:
 - No network or GitHub API access.
 - Narrow v0.1 scope; no dashboard or full transition enforcement.
 - Non-zero exit on blocking validation failures.
+
+The standard repo quality gate runs the same validator for relevant WMF changes:
+
+```bash
+python3 scripts/workflow/quality_gate.py check --scope changed --json
+```
+
+Relevant changes include `config/tasks/backlog.yaml`, `artifacts/workstreams.yaml`, `docs/11_admin/BACKLOG.md`, this framework document, and `scripts/validate_work_items.py`.
 
 ---
 

--- a/docs/11_admin/BACKLOG.md
+++ b/docs/11_admin/BACKLOG.md
@@ -13,7 +13,7 @@
 
 **"Done means" checklist:**
 
-- [ ] Update BACKLOG item status + evidence pointer (commit/packet)
+- [ ] Update `config/tasks/backlog.yaml` WI status + evidence pointer (commit/packet)
 - [ ] Update `LIFEOS_STATE.md` (Current Focus/Blockers/Recent Wins)
 - [ ] Refresh baseline pack pointer + sha (`artifacts/packets/status/Repo_Autonomy_Status_Pack__Main.zip`)
 

--- a/docs/11_admin/README.md
+++ b/docs/11_admin/README.md
@@ -2,7 +2,7 @@
 
 **Purpose:** Lightweight control plane for project state, backlog, and decisions.
 
-**Last Updated:** 2026-02-14 (consolidation v1.0)
+**Last Updated:** 2026-04-29 (WMF v0.1 alignment)
 
 ---
 
@@ -10,11 +10,11 @@
 
 When statements conflict, resolve by this precedence (highest → lowest):
 
-1. **`LIFEOS_STATE.md` + `BACKLOG.md`** (canonical, auto-updated)
+1. **`LIFEOS_STATE.md`** (canonical project state) and **`config/tasks/backlog.yaml`** (canonical task queue)
 2. **`DECISIONS.md`** (append-only; decisions override intent/spec drift)
 3. **`Plan_Supersession_Register.md` + referenced plan** (plan authority)
 4. **Specs in `docs/11_admin/`** (e.g., `Doc_Freshness_Gate_Spec_v1.0.md`)
-5. **Derived views** (e.g., `AUTONOMY_STATUS.md`) — must cite sources + derived-from timestamp
+5. **Derived views** (e.g., `BACKLOG.md`, `AUTONOMY_STATUS.md`) — must cite sources + derived-from timestamp
 6. **Strategic context** (e.g., `lifeos-master-operating-manual-v2.1.md`)
 7. **Archive** (historical reference only; no inbound links; immutable)
 
@@ -27,7 +27,7 @@ When statements conflict, resolve by this precedence (highest → lowest):
 These files **MUST** exist at `docs/11_admin/` root:
 
 - `LIFEOS_STATE.md` — Single source of truth for current focus, WIP, blockers (auto-updated)
-- `BACKLOG.md` — Actionable backlog (Now/Next/Later), target ≤40 items (auto-updated)
+- `BACKLOG.md` — Derived/view-only summary of `config/tasks/backlog.yaml`; not canonical queue state
 - `INBOX.md` — Raw capture scratchpad for triage
 - `DECISIONS.md` — Append-only decision log
 
@@ -61,15 +61,18 @@ Only these subdirectories are permitted under `docs/11_admin/`:
 ## Archive Policy
 
 **Archived files are immutable.** Only allowed modifications:
+
 - Typo fixes in the archive README itself
 - Mechanical path corrections if repo structure changes (rare)
 
 **Link hygiene:**
+
 - Active docs MUST NOT link to archived files
 - Exception: `docs/11_admin/README.md` (this file) may link to archive subdir READMEs only
 - Archive subdirectory READMEs may link to archived files within their own subdir
 
-See [archive/2026-02-14_consolidation/README.md](./archive/2026-02-14_consolidation/README.md) for the consolidation disposition table.
+See [archive/2026-02-14_consolidation/README.md](./archive/2026-02-14_consolidation/README.md)
+for the consolidation disposition table.
 
 ---
 
@@ -93,11 +96,13 @@ python3 -m doc_steward.cli link-check .
 ```
 
 **Freshness mode:**
+
 - `off` (default): No freshness checking
 - `warn`: Emit warnings but do not fail
 - `block`: Fail on violations
 
 Freshness checks:
+
 - `artifacts/status/runtime_status.json` must be <24h old
 - Structured contradictions field must be empty (or only "warn" severity in warn mode)
 
@@ -114,6 +119,7 @@ If you need to add a new admin doc (rare):
 4. **Run validation** to confirm structure is still valid
 
 **Default answer: Don't add new docs.** The admin directory is intentionally thin. Most content belongs in:
+
 - `docs/00_foundations/` (core principles)
 - `docs/01_governance/` (governance & contracts)
 - `docs/02_protocols/` (protocols & procedures)
@@ -124,9 +130,10 @@ If you need to add a new admin doc (rare):
 
 ## Maintenance Workflow
 
-### When modifying admin docs:
+### When modifying admin docs
 
 1. **Pre-flight:**
+
    ```bash
    git status
    python3 -m doc_steward.cli admin-structure-check .
@@ -135,6 +142,7 @@ If you need to add a new admin doc (rare):
 2. **Make changes** (following authority hierarchy)
 
 3. **Post-flight:**
+
    ```bash
    python3 -m doc_steward.cli admin-structure-check .
    python3 -m doc_steward.cli admin-archive-link-ban-check .
@@ -143,12 +151,33 @@ If you need to add a new admin doc (rare):
    git status --porcelain=v1
    ```
 
-### When auto-update fails:
+### When auto-update fails
 
 If `LIFEOS_STATE.md` or `BACKLOG.md` auto-update fails, investigate:
+
 - Check `runtime/tools/workflow_pack.py` (`update_state_and_backlog()`)
 - Review recent commits for conflicts
-- Manually sync if needed, but preserve auto-update capability
+- Manually sync if needed, but keep canonical work-item state in `config/tasks/backlog.yaml`
+
+### Work Item Loop
+
+COO-managed work defaults to `WI-YYYY-NNN` entries in `config/tasks/backlog.yaml`.
+Use `docs/11_admin/BACKLOG.md` only as a derived human-readable summary.
+
+Minimum manual loop:
+
+1. Intake issue or request.
+2. Triage and mint `WI-YYYY-NNN`.
+3. Update `config/tasks/backlog.yaml` state.
+4. Dispatch through an execution order or approved manual handoff.
+5. Review diff, PR, receipt, or evidence.
+6. Close by recording `closure_evidence` in `config/tasks/backlog.yaml`.
+
+Validation:
+
+```bash
+python3 scripts/validate_work_items.py --check
+```
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 <!-- markdownlint-disable MD013 MD040 MD060 -->
 
-Last Updated: 2026-04-28 (rev26)
+Last Updated: 2026-04-29 (rev26)
 
 **Authority**: [LifeOS Constitution v2.0](./00_foundations/LifeOS_Constitution_v2.0.md)
 

--- a/docs/LifeOS_Strategic_Corpus.md
+++ b/docs/LifeOS_Strategic_Corpus.md
@@ -6782,6 +6782,21 @@ Only the active COO writes WMF operational state. Standby COOs, reviewers, and b
 
 Current v0.1 limitation: WMF assumes one active writer. It does not provide concurrent ID minting, file locking, or transaction semantics. If parallel operational writers are introduced, v0.2 must add a locked or transactional mint/write mechanism before more than one writer can mutate WMF state.
 
+### 3.3 Minimum manual loop
+
+New COO-managed work defaults to a `WI-YYYY-NNN` entry in `config/tasks/backlog.yaml`.
+
+The minimum manual operating loop is:
+
+1. Intake issue or request.
+2. Triage and mint `WI-YYYY-NNN`.
+3. Update `config/tasks/backlog.yaml` state.
+4. Dispatch through an execution order or approved manual handoff.
+5. Review diff, PR, receipt, or evidence.
+6. Close by recording `closure_evidence` in `config/tasks/backlog.yaml`.
+
+`docs/11_admin/BACKLOG.md` may summarize this loop but must not originate or uniquely store any step.
+
 ---
 
 ## 4. Authority matrix
@@ -6821,11 +6836,6 @@ Conflict rule: if GitHub issues, `BACKLOG.md`, or status summaries disagree with
 |-------|---------|-------------------|------------------|
 | `INTAKE` | Captured but not yet assessed | Issue, note, or request exists | Triage decision |
 | `TRIAGED` | Assessed and accepted for tracking | `WI-YYYY-NNN` minted and `github_issue` recorded | Priority/workstream/next action clear |
-| `READY` | Ready to dispatch | Acceptance criteria or acceptance reference exists | Executor selected or blocker found |
-| `DISPATCHED` | Assigned to an executor | Dispatch authority exists, usually `execution_order.v1` | Work complete, blocked, or deferred |
-| `REVIEW` | Work submitted for review | Evidence or PR exists | Accepted/closed or fixes requested |
-| `CLOSED` | Accepted and complete | Closure evidence recorded | Terminal |
-| `BLOCKED` | Progress is blocked | `blocked_reason` or equivalent evidence exists | Unblocked, deferred, or re-triaged |
 
 > [!IMPORTANT]
 > **STRATEGIC TRUNCATION**: Content exceedes 5000 characters. Only strategic overview included. See full text in Universal Corpus.

--- a/runtime/tests/test_quality_gate.py
+++ b/runtime/tests/test_quality_gate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -35,6 +36,16 @@ def test_route_quality_tools_agent_control_plane_pin_manifest() -> None:
     assert routed["agent_control_plane_pin"] == [
         "config/external_contracts/agent_control_plane_pin.yaml"
     ]
+
+
+def test_route_quality_tools_wmf_backlog_change() -> None:
+    routed = route_quality_tools(Path("."), ["config/tasks/backlog.yaml"], scope="changed")
+    assert routed["wmf_validator"] == ["config/tasks/backlog.yaml"]
+
+
+def test_route_quality_tools_wmf_workstreams_change_bypasses_artifacts_exclusion() -> None:
+    routed = route_quality_tools(Path("."), ["artifacts/workstreams.yaml"], scope="changed")
+    assert routed["wmf_validator"] == ["artifacts/workstreams.yaml"]
 
 
 def test_route_quality_tools_config_only_markdown_change_no_fan_out(monkeypatch) -> None:
@@ -115,6 +126,74 @@ def test_run_quality_gates_runs_agent_control_plane_pin(monkeypatch) -> None:
     assert any(row["tool"] == "agent_control_plane_pin" for row in result["results"])
     assert any(
         "scripts/workflow/check_agent_control_plane_pin.py" in command for command in commands
+    )
+
+
+def test_run_quality_gates_blocks_on_broken_wmf_backlog(tmp_path: Path) -> None:
+    (tmp_path / "config" / "quality").mkdir(parents=True)
+    (tmp_path / "config" / "tasks").mkdir(parents=True)
+    (tmp_path / "docs" / "11_admin").mkdir(parents=True)
+    (tmp_path / "artifacts").mkdir()
+    (tmp_path / "scripts").mkdir()
+
+    shutil.copyfile(
+        Path("scripts/validate_work_items.py"),
+        tmp_path / "scripts" / "validate_work_items.py",
+    )
+    (tmp_path / "config" / "quality" / "manifest.yaml").write_text(
+        """
+version: 1
+repo:
+  exclude_prefixes: []
+  python_targets: []
+tools:
+  wmf_validator:
+    enabled: true
+    mode: blocking
+    scopes: ["changed", "repo"]
+    autofix_allowed: false
+    failure_class: wmf_validation_error
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "config" / "tasks" / "backlog.yaml").write_text(
+        """
+schema_version: backlog.v1
+tasks:
+- id: WI-2026-001
+  title: Broken WMF item
+  priority: P1
+  risk: low
+  status: BROKEN
+  task_type: build
+  objective_ref: test
+  created_at: test-created-at
+  workstream: test
+  plan_mode: none
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "artifacts" / "workstreams.yaml").write_text(
+        "test:\n  human_name: Test\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "docs" / "11_admin" / "BACKLOG.md").write_text(
+        "<!-- DERIVED VIEW -->\n",
+        encoding="utf-8",
+    )
+
+    result = run_quality_gates(tmp_path, ["config/tasks/backlog.yaml"], scope="changed")
+
+    assert result["passed"] is False
+    assert result["commands_run"] == [
+        "python3 scripts/validate_work_items.py --check --repo-root ."
+    ]
+    assert any(
+        row["tool"] == "wmf_validator"
+        and row["mode"] == "blocking"
+        and not row["passed"]
+        and "WM003_INVALID_STATUS" in str(row["details"])
+        for row in result["results"]
     )
 
 

--- a/runtime/tools/workflow_pack.py
+++ b/runtime/tools/workflow_pack.py
@@ -51,6 +51,7 @@ QUALITY_TOOL_EXECUTABLES = {
     "yamllint": "yamllint",
     "shellcheck": "shellcheck",
     "agent_control_plane_pin": "python3",
+    "wmf_validator": "python3",
 }
 QUALITY_PYTHON_CONFIG_FILES = {"pyproject.toml", "requirements.txt", "requirements-dev.txt"}
 QUALITY_BIOME_EXTENSIONS = {".js", ".jsx", ".ts", ".tsx", ".json", ".jsonc"}
@@ -60,6 +61,13 @@ QUALITY_YAML_CONFIG_FILES = {".yamllint", ".yamllint.yml", ".yamllint.yaml"}
 QUALITY_AGENT_CONTROL_PLANE_PIN_FILES = {
     "config/external_contracts/agent_control_plane_pin.yaml",
     "scripts/workflow/check_agent_control_plane_pin.py",
+}
+QUALITY_WMF_VALIDATOR_FILES = {
+    "artifacts/workstreams.yaml",
+    "config/tasks/backlog.yaml",
+    "docs/02_protocols/Work_Management_Framework_v0.1.md",
+    "docs/11_admin/BACKLOG.md",
+    "scripts/validate_work_items.py",
 }
 BACKLOG_METADATA_CONTINUATION_PATTERN = re.compile(
     r"^\s+[—-]+\s*(?:DoD|Why\s*Now|Owner|Context):",
@@ -212,7 +220,9 @@ def _filter_quality_scope_files(files: Sequence[str], manifest: dict) -> list[st
     exclude_prefixes = manifest.get("repo", {}).get("exclude_prefixes", []) or []
     filtered = []
     for file_path in _unique_ordered(files):
-        if any(file_path.startswith(prefix) for prefix in exclude_prefixes):
+        if file_path not in QUALITY_WMF_VALIDATOR_FILES and any(
+            file_path.startswith(prefix) for prefix in exclude_prefixes
+        ):
             continue
         filtered.append(file_path)
     return filtered
@@ -250,6 +260,8 @@ def route_quality_tools(
     shell_files: list[str] = []
     agent_control_plane_pin_files: list[str] = []
     agent_control_plane_pin_trigger = False
+    wmf_validator_files: list[str] = []
+    wmf_validator_trigger = False
 
     for file_path in files:
         path = Path(file_path)
@@ -288,6 +300,10 @@ def route_quality_tools(
             agent_control_plane_pin_files.append(file_path)
             agent_control_plane_pin_trigger = True
 
+        if file_path in QUALITY_WMF_VALIDATOR_FILES:
+            wmf_validator_files.append(file_path)
+            wmf_validator_trigger = True
+
     if python_trigger:
         routed["ruff_check"] = _unique_ordered(python_files)
         routed["ruff_format"] = _unique_ordered(python_files)
@@ -302,6 +318,8 @@ def route_quality_tools(
         routed["shellcheck"] = _unique_ordered(shell_files)
     if agent_control_plane_pin_trigger and "agent_control_plane_pin" in routed:
         routed["agent_control_plane_pin"] = _unique_ordered(agent_control_plane_pin_files)
+    if wmf_validator_trigger and "wmf_validator" in routed:
+        routed["wmf_validator"] = _unique_ordered(wmf_validator_files)
 
     return routed
 
@@ -458,6 +476,14 @@ def _build_quality_command(
         if not (Path(repo_root) / script_path).exists():
             return None
         return [sys.executable, str(script_path), "--manifest", str(manifest_path)]
+
+    if tool_name == "wmf_validator":
+        script_path = Path("scripts/validate_work_items.py")
+        if scope != "repo" and not files:
+            return None
+        if not (Path(repo_root) / script_path).exists():
+            return None
+        return ["python3", str(script_path), "--check", "--repo-root", "."]
 
     return None
 


### PR DESCRIPTION
## Summary
- Wires `scripts/validate_work_items.py --check` into the manifest-driven repo quality gate as blocking `wmf_validator` coverage for WMF-relevant changes.
- Adds quality-gate tests for WMF routing, including `artifacts/workstreams.yaml` despite the default `artifacts/` exclusion, and deterministic failure on a broken `config/tasks/backlog.yaml` entry.
- Updates COO/developer workflow docs so COO-managed work defaults to `WI-YYYY-NNN` entries in `config/tasks/backlog.yaml`, with `docs/11_admin/BACKLOG.md` retained as derived/view-only.

## Verification
- [x] `python3 docs/scripts/generate_strategic_context.py`
- [x] `python3 scripts/claude_doc_stewardship_gate.py`
- [x] `python3 scripts/validate_work_items.py --check`
- [x] `pytest runtime/tests/test_quality_gate.py -q` — 16 passed
- [x] `python3 scripts/workflow/quality_gate.py check --scope changed --json` — passed; `wmf_validator` blocking pass; mypy/yamllint unavailable locally as advisory only
- [x] Direct broken-backlog proof: temp invalid `status: BROKEN` made `wmf_validator` blocking fail with `WM003_INVALID_STATUS`
- [x] Direct relevant-change proof: `route_quality_tools(..., ['artifacts/workstreams.yaml'])` returns `['artifacts/workstreams.yaml']` for `wmf_validator`
- [x] `git diff --check`

## Notes
- Codex was used as the COO-dispatched EA implementation lane from a writable temp clone: `/tmp/lifeos-69.ycD1X1`.
- A read-only Codex blocker review found that `artifacts/workstreams.yaml` was initially skipped by the gate due to the repo `artifacts/` exclusion; this PR fixes and tests that gap.
- No runtime orchestration behavior changes.
- References LifeOS issue 69. Leave the issue open until live PR/CI evidence is reviewed.
