### PR TITLE
ci: disable scheduled nightly full test suite

### DIFF
--- a/.github/workflows/recursive_kernel_nightly.yml
+++ b/.github/workflows/recursive_kernel_nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly Full Test Suite
 
 on:
-  schedule:
-    - cron: '0 3 * * *'  # 3 AM UTC daily (2 PM AEDT)
+  # Schedule disabled after repeated infra-only nightly failures.
+  # Keep manual dispatch available until rg and markdownlint-cli are installed in this workflow.
   workflow_dispatch:  # Allow manual trigger
 
 concurrency:


### PR DESCRIPTION
## Summary
- Removes the daily `schedule` trigger from Nightly Full Test Suite.
- Keeps `workflow_dispatch` so the full suite remains manually runnable after dependencies are fixed.

## Verification
- `python3` YAML parse: PASS
- Trigger readback: `schedule` absent, `workflow_dispatch` present
- `python3 scripts/workflow/quality_gate.py check --scope changed --json`: PASS with yamllint advisory only because yamllint is unavailable locally

Refs: Actions-noise audit item 2.