### PR TITLE
ci: install nightly test tools

### DIFF
--- a/.github/workflows/recursive_kernel_nightly.yml
+++ b/.github/workflows/recursive_kernel_nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly Full Test Suite
 
 on:
-  # Schedule disabled after repeated infra-only nightly failures.
-  # Keep manual dispatch available until rg and markdownlint-cli are installed in this workflow.
+  schedule:
+    - cron: '0 3 * * *'  # Run nightly at 3 AM UTC
   workflow_dispatch:  # Allow manual trigger
 
 concurrency:
@@ -16,14 +16,23 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+          sudo npm install -g markdownlint-cli
+          pip install -r requirements-dev.txt
 
       - name: Full pytest suite
         run: pytest -v --tb=long
@@ -45,14 +54,23 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+          sudo npm install -g markdownlint-cli
+          pip install -r requirements-dev.txt
 
       - name: Run tests with coverage
         run: pytest --cov=runtime --cov-report=term-missing -v


### PR DESCRIPTION
## Summary
- Installs ripgrep and markdownlint-cli in both Nightly Full Test Suite jobs before pytest runs.
- Restores the daily `0 3 * * *` schedule now that the missing runner tools are installed.
- Keeps `workflow_dispatch` for manual runs.

## Verification
- [x] `python3 - <<'PY' ... yaml.safe_load(...) ... PY` → `workflow_yaml_and_dependency_checks_ok`
- [x] `git diff --check`
- [x] `python3 scripts/workflow/quality_gate.py check --scope changed --json` → passed; local `yamllint` unavailable but advisory only
- [x] `pytest runtime/tests -q` → 3237 passed, 6 skipped
- [x] `actionlint .github/workflows/recursive_kernel_nightly.yml` checked opportunistically; local actionlint not installed

Refs the GitHub Actions noise audit item 3: fix Nightly Full Test Suite dependencies.