### PR TITLE
ci: disable unrequested nightly schedules

### DIFF
--- a/.github/workflows/build_loop_nightly.yml
+++ b/.github/workflows/build_loop_nightly.yml
@@ -1,8 +1,8 @@
 name: Build Loop Nightly
 
 on:
-  schedule:
-    - cron: '0 2 * * *'  # 02:00 UTC daily (1 PM AEDT)
+  # Scheduled runs disabled: CEO does not want unattended nightly build-loop runs.
+  # Keep manual dispatch for explicit, supervised use only.
   workflow_dispatch:
     inputs:
       task_spec:

--- a/.github/workflows/recursive_kernel_nightly.yml
+++ b/.github/workflows/recursive_kernel_nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly Full Test Suite
 
 on:
-  schedule:
-    - cron: '0 3 * * *'  # Run nightly at 3 AM UTC
+  # Scheduled runs disabled: CEO does not want unattended nightly test runs.
+  # Keep manual dispatch for explicit verification only.
   workflow_dispatch:  # Allow manual trigger
 
 concurrency:


### PR DESCRIPTION
## Summary
- Disables the scheduled trigger for Build Loop Nightly.
- Disables the scheduled trigger for Nightly Full Test Suite.
- Keeps both workflows manually runnable with `workflow_dispatch`.

## Why
Marcus does not want unattended nightly runs and does not remember requesting them. Manual dispatch preserves explicit verification without daily noise/churn.

## Verification
- [x] YAML parse for both workflows
- [x] Active trigger assertion: `workflow_dispatch` present, active `schedule:` absent
- [x] `git diff --check`
- [x] `python3 scripts/workflow/quality_gate.py check --scope changed --json` → passed; local `yamllint` unavailable but advisory only
- [x] `pytest runtime/tests -q` → 3237 passed, 6 skipped
- [x] `actionlint` checked opportunistically; not installed locally