### PR TITLE
Add COO fresh review closure gate

### DIFF
--- a/runtime/orchestration/coo/ea_dispatch.py
+++ b/runtime/orchestration/coo/ea_dispatch.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from runtime.orchestration.coo.review_gate import build_review_packet, evaluate_review_gate
 from runtime.receipts.ea_receipt import validate_ea_receipt
 
 DISPATCH_REQUEST_SCHEMA_VERSION = "coo_ea_dispatch_request.v0"
@@ -669,6 +670,19 @@ def evaluate_attempt_result(
             evidence=evidence,
         )
 
+    review_gate = evaluate_review_gate(result, request=request)
+    if not review_gate["ok"]:
+        return _evaluation(
+            state=str(review_gate["state"]),
+            success=False,
+            reason=str(review_gate["reason"]),
+            blockers=tuple(str(blocker) for blocker in review_gate["blockers"]),
+            result_valid=True,
+            request=request,
+            result=result,
+            evidence=evidence,
+        )
+
     return _evaluation(
         state="succeeded",
         success=True,
@@ -690,6 +704,12 @@ def build_github_recovery_data(
     result = result if isinstance(result, dict) else {}
     receipt = result.get("receipt") if isinstance(result.get("receipt"), dict) else {}
     evidence_urls = tuple(result.get("evidence_urls") or ())
+    review_packet: dict[str, Any] | None = None
+    if result.get("review_result") is not None or result.get("review_not_required") is not None:
+        try:
+            review_packet = build_review_packet(request, result)
+        except ValueError as exc:
+            review_packet = {"error": str(exc)}
     return {
         "schema_version": RECOVERY_DATA_SCHEMA_VERSION,
         "control_plane": "github",
@@ -732,6 +752,11 @@ def build_github_recovery_data(
             "created_at": result.get("created_at"),
             "summary": result.get("summary"),
             "evidence_urls": list(evidence_urls),
+        },
+        "review": {
+            "review_packet": review_packet,
+            "review_result": result.get("review_result"),
+            "review_not_required": result.get("review_not_required"),
         },
         "recovery_policy": {
             "retry_requires_ceo_approval_v0": True,

--- a/runtime/orchestration/coo/review_gate.py
+++ b/runtime/orchestration/coo/review_gate.py
@@ -1,0 +1,506 @@
+"""Fresh-context review/fix closure gate for COO-managed EA work."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Sequence
+
+REVIEW_PACKET_SCHEMA_VERSION = "fresh_context_review_packet.v0"
+REVIEW_RESULT_SCHEMA_VERSION = "fresh_context_review_result.v0"
+REVIEW_GATE_DECISION_SCHEMA_VERSION = "fresh_context_review_gate_decision.v0"
+REVIEW_NOT_REQUIRED_SCHEMA_VERSION = "fresh_context_review_not_required.v0"
+
+REVIEW_RESULT_STATUSES = {"passed", "fixes_requested", "blocked"}
+REVIEW_REQUIRED_PREFIXES = (
+    ".github/",
+    "config/",
+    "runtime/",
+    "scripts/",
+    "tests/",
+    "docs/00_foundations/",
+    "docs/01_governance/",
+    "docs/02_protocols/",
+    "docs/03_runtime/",
+    "docs/11_admin/",
+)
+REVIEW_REQUIRED_MARKERS = (
+    "auth",
+    "closure",
+    "credential",
+    "cron",
+    "dispatch",
+    "receipt",
+    "review",
+    "secret",
+    "security",
+    "service",
+    "token",
+)
+
+_REVIEW_PACKET_REQUIRED_FIELDS = (
+    "schema_version",
+    "original_objective",
+    "issue",
+    "work_item",
+    "diff",
+    "tests_and_evidence",
+    "constraints",
+    "review_instruction",
+)
+_REVIEW_RESULT_REQUIRED_FIELDS = (
+    "schema_version",
+    "status",
+    "reviewer_identity",
+    "reviewer_session",
+    "issues_found",
+    "fixes_applied",
+    "verification",
+    "remaining_risks",
+    "risk_disposition",
+    "created_at",
+)
+
+
+def normalize_review_path(path: str) -> str:
+    return path.strip().replace("\\", "/")
+
+
+def classify_review_requirement(changed_paths: Sequence[str]) -> dict[str, Any]:
+    """Classify whether a changed-path set requires fresh-context review."""
+    normalized = []
+    seen: set[str] = set()
+    for raw_path in changed_paths:
+        path = normalize_review_path(str(raw_path))
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        normalized.append(path)
+
+    for path in normalized:
+        if path.startswith(REVIEW_REQUIRED_PREFIXES):
+            return {
+                "schema_version": REVIEW_GATE_DECISION_SCHEMA_VERSION,
+                "review_required": True,
+                "reason": f"review_required_path:{path}",
+                "changed_paths": normalized,
+            }
+        lowered = path.lower()
+        if any(marker in lowered for marker in REVIEW_REQUIRED_MARKERS):
+            return {
+                "schema_version": REVIEW_GATE_DECISION_SCHEMA_VERSION,
+                "review_required": True,
+                "reason": f"review_required_marker:{path}",
+                "changed_paths": normalized,
+            }
+
+    if normalized:
+        return {
+            "schema_version": REVIEW_GATE_DECISION_SCHEMA_VERSION,
+            "review_required": False,
+            "reason": "trivial_or_artifact_only",
+            "changed_paths": normalized,
+        }
+    return {
+        "schema_version": REVIEW_GATE_DECISION_SCHEMA_VERSION,
+        "review_required": True,
+        "reason": "unknown_changed_files",
+        "changed_paths": normalized,
+    }
+
+
+def build_review_packet(
+    request: dict[str, Any],
+    result: dict[str, Any],
+    *,
+    constraints: Sequence[str] | None = None,
+    review_instruction: str = (
+        "Fresh-context review: blockers only; verify acceptance and evidence; "
+        "request fixes when needed."
+    ),
+) -> dict[str, Any]:
+    """Build the deterministic review packet shape required before closure."""
+    receipt = result.get("receipt") if isinstance(result.get("receipt"), dict) else {}
+    packet_constraints = (
+        list(constraints) if constraints is not None else _review_constraints_from_request(request)
+    )
+    packet = {
+        "schema_version": REVIEW_PACKET_SCHEMA_VERSION,
+        "original_objective": {
+            "task_ref": request.get("task_ref"),
+            "acceptance_criteria": list(request.get("acceptance_criteria") or []),
+            "verification_commands": list(request.get("verification_commands") or []),
+        },
+        "issue": {
+            "repo": request.get("repo"),
+            "issue_number": request.get("issue_number"),
+            "issue_url": request.get("issue_url"),
+        },
+        "work_item": {
+            "command_id": request.get("command_id"),
+            "attempt_id": request.get("attempt_id"),
+            "executor": request.get("executor"),
+        },
+        "diff": {
+            "scope_paths": list(request.get("scope_paths") or []),
+            "files_touched": list(receipt.get("files_changed") or []),
+            "pr_url": result.get("pr_url"),
+            "head_sha": result.get("head_sha"),
+        },
+        "tests_and_evidence": {
+            "commands_run": list(receipt.get("commands_run") or []),
+            "tests_run": list(receipt.get("tests_run") or []),
+            "ci_url": result.get("ci_url"),
+            "ci_status": result.get("ci_status"),
+            "evidence_urls": list(result.get("evidence_urls") or []),
+        },
+        "constraints": packet_constraints,
+        "review_instruction": review_instruction,
+    }
+    errors = validate_review_packet(packet)
+    if errors:
+        raise ValueError("Invalid review packet: " + "; ".join(errors))
+    return packet
+
+
+def validate_review_packet(packet: Any) -> list[str]:
+    if not isinstance(packet, dict):
+        return ["review packet must be a JSON object"]
+    errors: list[str] = []
+    _require_fields(packet, _REVIEW_PACKET_REQUIRED_FIELDS, errors)
+    if errors:
+        return errors
+    if packet["schema_version"] != REVIEW_PACKET_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {REVIEW_PACKET_SCHEMA_VERSION}")
+    if not isinstance(packet["original_objective"], dict):
+        errors.append("original_objective must be an object")
+    else:
+        _non_empty_string(
+            packet["original_objective"].get("task_ref"), "original_objective.task_ref", errors
+        )
+        _string_list(
+            packet["original_objective"].get("acceptance_criteria"),
+            "original_objective.acceptance_criteria",
+            errors,
+        )
+        _string_list(
+            packet["original_objective"].get("verification_commands"),
+            "original_objective.verification_commands",
+            errors,
+        )
+    if not isinstance(packet["issue"], dict):
+        errors.append("issue must be an object")
+    else:
+        _non_empty_string(packet["issue"].get("repo"), "issue.repo", errors)
+        issue_number = packet["issue"].get("issue_number")
+        if not isinstance(issue_number, int) or isinstance(issue_number, bool):
+            errors.append("issue.issue_number must be an integer")
+        _non_empty_string(packet["issue"].get("issue_url"), "issue.issue_url", errors)
+    if not isinstance(packet["work_item"], dict):
+        errors.append("work_item must be an object")
+    else:
+        _non_empty_string(packet["work_item"].get("command_id"), "work_item.command_id", errors)
+        _non_empty_string(packet["work_item"].get("attempt_id"), "work_item.attempt_id", errors)
+        _non_empty_string(packet["work_item"].get("executor"), "work_item.executor", errors)
+    if not isinstance(packet["diff"], dict):
+        errors.append("diff must be an object")
+    else:
+        _string_list(packet["diff"].get("scope_paths"), "diff.scope_paths", errors)
+        _string_list(packet["diff"].get("files_touched"), "diff.files_touched", errors)
+        _optional_string(packet["diff"].get("pr_url"), "diff.pr_url", errors)
+        _optional_string(packet["diff"].get("head_sha"), "diff.head_sha", errors)
+    if not isinstance(packet["tests_and_evidence"], dict):
+        errors.append("tests_and_evidence must be an object")
+    else:
+        _string_list(
+            packet["tests_and_evidence"].get("commands_run"),
+            "tests_and_evidence.commands_run",
+            errors,
+        )
+        _string_list(
+            packet["tests_and_evidence"].get("tests_run"),
+            "tests_and_evidence.tests_run",
+            errors,
+        )
+        _optional_string(
+            packet["tests_and_evidence"].get("ci_url"), "tests_and_evidence.ci_url", errors
+        )
+        _optional_string(
+            packet["tests_and_evidence"].get("ci_status"),
+            "tests_and_evidence.ci_status",
+            errors,
+        )
+        _string_list(
+            packet["tests_and_evidence"].get("evidence_urls"),
+            "tests_and_evidence.evidence_urls",
+            errors,
+        )
+    _string_list(packet["constraints"], "constraints", errors)
+    _non_empty_string(packet["review_instruction"], "review_instruction", errors)
+    return errors
+
+
+def validate_review_result(review_result: Any) -> list[str]:
+    if not isinstance(review_result, dict):
+        return ["review_result must be a JSON object"]
+    errors: list[str] = []
+    _require_fields(review_result, _REVIEW_RESULT_REQUIRED_FIELDS, errors)
+    if errors:
+        return errors
+    if review_result["schema_version"] != REVIEW_RESULT_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {REVIEW_RESULT_SCHEMA_VERSION}")
+    if review_result["status"] not in REVIEW_RESULT_STATUSES:
+        errors.append("status must be one of: blocked, fixes_requested, passed")
+    _non_empty_string(review_result["reviewer_identity"], "reviewer_identity", errors)
+    _non_empty_string(review_result["reviewer_session"], "reviewer_session", errors)
+    _string_list(review_result["issues_found"], "issues_found", errors)
+    _string_list(review_result["fixes_applied"], "fixes_applied", errors)
+    _string_list(review_result["verification"], "verification", errors, require_non_empty=True)
+    _string_list(review_result["remaining_risks"], "remaining_risks", errors)
+    _non_empty_string(review_result["risk_disposition"], "risk_disposition", errors)
+    _utc_timestamp(review_result["created_at"], "created_at", errors)
+
+    if review_result.get("status") == "fixes_requested" and not review_result.get("issues_found"):
+        errors.append("fixes_requested status requires at least one issue_found")
+    if review_result.get("status") == "blocked" and not (
+        review_result.get("issues_found") or review_result.get("remaining_risks")
+    ):
+        errors.append("blocked status requires issues_found or remaining_risks")
+    if (
+        review_result.get("status") == "passed"
+        and review_result.get("remaining_risks")
+        and not str(review_result.get("risk_disposition", "")).strip()
+    ):
+        errors.append("passed review with remaining_risks requires risk_disposition")
+    return errors
+
+
+def validate_review_not_required(value: Any) -> list[str]:
+    if not isinstance(value, dict):
+        return ["review_not_required must be a JSON object"]
+    errors: list[str] = []
+    if value.get("schema_version") != REVIEW_NOT_REQUIRED_SCHEMA_VERSION:
+        errors.append(f"schema_version must be {REVIEW_NOT_REQUIRED_SCHEMA_VERSION}")
+    if value.get("classification") != "trivial":
+        errors.append("review_not_required classification must be trivial")
+    _non_empty_string(value.get("reason"), "review_not_required.reason", errors)
+    return errors
+
+
+def evaluate_review_gate(
+    result: dict[str, Any],
+    *,
+    request: dict[str, Any] | None = None,
+    constraints: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Evaluate the fresh-review closure gate for a validated COO EA result."""
+    receipt = result.get("receipt") if isinstance(result.get("receipt"), dict) else {}
+    changed_files = receipt.get("files_changed") if isinstance(receipt, dict) else []
+    if not isinstance(changed_files, list):
+        changed_files = []
+    scope_paths = request.get("scope_paths") if isinstance(request, dict) else []
+    if not isinstance(scope_paths, list):
+        scope_paths = []
+    classification = classify_review_requirement(
+        [str(path) for path in changed_files] + [str(path) for path in scope_paths]
+    )
+    review_result = result.get("review_result")
+    review_not_required = result.get("review_not_required")
+    review_packet: dict[str, Any] | None = None
+    if request is not None and (
+        classification["review_required"]
+        or review_result is not None
+        or review_not_required is not None
+    ):
+        try:
+            review_packet = build_review_packet(request, result, constraints=constraints)
+        except ValueError as exc:
+            return _gate_block(
+                state="needs_decision",
+                reason="malformed_review_packet",
+                blockers=(str(exc),),
+                classification=classification,
+            )
+
+    if not changed_files:
+        return _gate_block(
+            state="needs_decision",
+            reason="unknown_changed_files",
+            blockers=(
+                "closure needs receipt.files_changed evidence before review or "
+                "review-not-required disposition can authorize closure",
+            ),
+            classification=classification,
+        )
+
+    if classification["review_required"]:
+        if review_result is None:
+            if review_not_required is not None:
+                return _gate_block(
+                    state="needs_decision",
+                    reason="fresh_review_required_not_skippable",
+                    blockers=(
+                        "review_not_required cannot override review-required EA work "
+                        "touching code/tests/runtime/config/docs/security/closure surfaces",
+                    ),
+                    classification=classification,
+                )
+            return _gate_block(
+                state="needs_decision",
+                reason="missing_fresh_review",
+                blockers=("fresh-context review is required but review_result is absent",),
+                classification=classification,
+            )
+
+    if review_result is not None:
+        errors = validate_review_result(review_result)
+        if errors:
+            return _gate_block(
+                state="needs_decision",
+                reason="malformed_review_result",
+                blockers=tuple(errors),
+                classification=classification,
+            )
+        status = review_result["status"]
+        if status == "fixes_requested":
+            return _gate_block(
+                state="running",
+                reason="fresh_review_fixes_requested",
+                blockers=tuple(review_result["issues_found"]),
+                classification=classification,
+            )
+        if status == "blocked":
+            return _gate_block(
+                state="blocked",
+                reason="fresh_review_blocked",
+                blockers=tuple(review_result["issues_found"] or review_result["remaining_risks"]),
+                classification=classification,
+            )
+        return _gate_ok(classification, review_result=review_result, review_packet=review_packet)
+
+    if review_not_required is None:
+        return _gate_block(
+            state="needs_decision",
+            reason="missing_review_disposition",
+            blockers=(
+                "closure evidence must include review_result or policy-supported "
+                "review_not_required reason",
+            ),
+            classification=classification,
+        )
+
+    skip_errors = validate_review_not_required(review_not_required)
+    if skip_errors:
+        return _gate_block(
+            state="needs_decision",
+            reason="malformed_review_not_required",
+            blockers=tuple(skip_errors),
+            classification=classification,
+        )
+    return _gate_ok(
+        classification,
+        review_not_required=review_not_required,
+        review_packet=review_packet,
+    )
+
+
+def _gate_ok(
+    classification: dict[str, Any],
+    *,
+    review_result: dict[str, Any] | None = None,
+    review_not_required: dict[str, Any] | None = None,
+    review_packet: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": REVIEW_GATE_DECISION_SCHEMA_VERSION,
+        "ok": True,
+        "state": "succeeded",
+        "reason": "fresh_review_gate_satisfied",
+        "blockers": [],
+        "classification": classification,
+        "review_result": review_result,
+        "review_not_required": review_not_required,
+        "review_packet": review_packet,
+    }
+
+
+def _gate_block(
+    *,
+    state: str,
+    reason: str,
+    blockers: Sequence[str],
+    classification: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "schema_version": REVIEW_GATE_DECISION_SCHEMA_VERSION,
+        "ok": False,
+        "state": state,
+        "reason": reason,
+        "blockers": list(blockers),
+        "classification": classification,
+    }
+
+
+def _review_constraints_from_request(request: dict[str, Any]) -> list[str]:
+    constraints: list[str] = []
+    executor = request.get("executor")
+    if isinstance(executor, str) and executor.strip():
+        constraints.append(f"executor:{executor}")
+    base_ref = request.get("base_ref")
+    if isinstance(base_ref, str) and base_ref.strip():
+        constraints.append(f"base_ref:{base_ref}")
+    branch_name = request.get("branch_name")
+    if isinstance(branch_name, str) and branch_name.strip():
+        constraints.append(f"branch_name:{branch_name}")
+    scope_paths = request.get("scope_paths")
+    if isinstance(scope_paths, list):
+        constraints.extend(
+            f"scope_path:{path}" for path in scope_paths if isinstance(path, str) and path
+        )
+    required_evidence = request.get("required_evidence")
+    if isinstance(required_evidence, list):
+        constraints.extend(
+            f"required_evidence:{item}"
+            for item in required_evidence
+            if isinstance(item, str) and item
+        )
+    return constraints
+
+
+def _require_fields(payload: dict[str, Any], fields: Sequence[str], errors: list[str]) -> None:
+    for field in fields:
+        if field not in payload:
+            errors.append(f"missing required field: {field}")
+
+
+def _non_empty_string(value: Any, field: str, errors: list[str]) -> None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{field} must be a non-empty string")
+
+
+def _optional_string(value: Any, field: str, errors: list[str]) -> None:
+    if value is not None and not isinstance(value, str):
+        errors.append(f"{field} must be a string when present")
+
+
+def _string_list(
+    value: Any,
+    field: str,
+    errors: list[str],
+    *,
+    require_non_empty: bool = False,
+) -> None:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        errors.append(f"{field} must be a list of strings")
+        return
+    if require_non_empty and not value:
+        errors.append(f"{field} must not be empty")
+
+
+def _utc_timestamp(value: Any, field: str, errors: list[str]) -> None:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        errors.append(f"{field} must be an ISO-8601 UTC timestamp ending in Z")
+        return
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        errors.append(f"{field} must be a valid ISO-8601 UTC timestamp")

--- a/runtime/tests/orchestration/coo/test_ea_dispatch.py
+++ b/runtime/tests/orchestration/coo/test_ea_dispatch.py
@@ -15,6 +15,14 @@ from runtime.orchestration.coo.ea_dispatch import (
     utc_now_iso,
     validate_dispatch_request,
 )
+from runtime.orchestration.coo.review_gate import (
+    REVIEW_NOT_REQUIRED_SCHEMA_VERSION,
+    REVIEW_RESULT_SCHEMA_VERSION,
+    build_review_packet,
+    classify_review_requirement,
+    evaluate_review_gate,
+    validate_review_packet,
+)
 
 _REPO = "marcusglee11/LifeOS"
 _ISSUE_NUMBER = 79
@@ -64,15 +72,53 @@ def _receipt(
     status: str = "success",
     inner_exit_codes: list[int] | None = None,
     blockers: list[str] | None = None,
+    files_changed: list[str] | None = None,
 ) -> dict[str, object]:
     return {
         "schema_version": "ea_receipt.v0",
         "status": status,
         "commands_run": ["pytest runtime/tests/orchestration/coo/test_ea_dispatch.py -q"],
         "inner_exit_codes": inner_exit_codes if inner_exit_codes is not None else [0],
-        "files_changed": ["runtime/orchestration/coo/ea_dispatch.py"],
+        "files_changed": files_changed
+        if files_changed is not None
+        else ["runtime/orchestration/coo/ea_dispatch.py"],
         "tests_run": ["runtime/tests/orchestration/coo/test_ea_dispatch.py"],
         "blockers": blockers if blockers is not None else [],
+    }
+
+
+def _review_result(
+    *,
+    status: str = "passed",
+    issues_found: list[str] | None = None,
+    fixes_applied: list[str] | None = None,
+    verification: list[str] | None = None,
+    remaining_risks: list[str] | None = None,
+    risk_disposition: str = "none",
+) -> dict[str, object]:
+    return {
+        "schema_version": REVIEW_RESULT_SCHEMA_VERSION,
+        "status": status,
+        "reviewer_identity": "fresh-context-reviewer",
+        "reviewer_session": "review-session-001",
+        "issues_found": issues_found if issues_found is not None else [],
+        "fixes_applied": fixes_applied if fixes_applied is not None else [],
+        "verification": verification
+        if verification is not None
+        else ["pytest runtime/tests/orchestration/coo/test_ea_dispatch.py -q"],
+        "remaining_risks": remaining_risks if remaining_risks is not None else [],
+        "risk_disposition": risk_disposition,
+        "created_at": utc_now_iso(),
+    }
+
+
+def _review_not_required(
+    reason: str = "artifact-only typo fix; no code or governance surface touched",
+) -> dict[str, object]:
+    return {
+        "schema_version": REVIEW_NOT_REQUIRED_SCHEMA_VERSION,
+        "classification": "trivial",
+        "reason": reason,
     }
 
 
@@ -87,10 +133,13 @@ def _result(
     ci_status: str | None = "success",
     attempt_id: str = _ATTEMPT_ID,
     executor: str = "codex",
+    review_result: dict[str, object] | None = None,
+    review_not_required: dict[str, object] | None = None,
+    include_review: bool = True,
 ) -> dict[str, object]:
     if blockers is None:
         blockers = [] if status == "succeeded" else ["EA reported non-success"]
-    return {
+    payload: dict[str, object] = {
         "schema_version": "coo_ea_result.v0",
         "repo": _REPO,
         "issue_number": _ISSUE_NUMBER,
@@ -107,6 +156,11 @@ def _result(
         "blockers": blockers,
         "created_at": utc_now_iso(),
     }
+    if include_review:
+        payload["review_result"] = review_result if review_result is not None else _review_result()
+    if review_not_required is not None:
+        payload["review_not_required"] = review_not_required
+    return payload
 
 
 def _success_evidence(**overrides: object) -> GitHubDispatchEvidence:
@@ -326,3 +380,228 @@ def test_dispatch_request_validation_and_launch_plan(tmp_path: Path) -> None:
     assert plan["excluded_completion_truth"] == list(EXCLUDED_COMPLETION_TRUTH)
     assert any(command["argv"][:3] == ["git", "worktree", "add"] for command in plan["commands"])
     assert any(command["argv"][:2] == ["codex", "exec"] for command in plan["commands"])
+
+
+def test_review_required_classifier_flags_runtime_and_governance_paths() -> None:
+    runtime_decision = classify_review_requirement(["runtime/orchestration/coo/ea_dispatch.py"])
+    docs_decision = classify_review_requirement(["docs/02_protocols/example.md"])
+
+    assert runtime_decision["review_required"] is True
+    assert docs_decision["review_required"] is True
+
+
+def test_review_required_classifier_allows_artifacts_but_fails_unknown_scope() -> None:
+    artifact_decision = classify_review_requirement(["artifacts/evidence/typo-fix.json"])
+    unknown_decision = classify_review_requirement([])
+
+    assert artifact_decision["review_required"] is False
+    assert artifact_decision["reason"] == "trivial_or_artifact_only"
+    assert unknown_decision["review_required"] is True
+    assert unknown_decision["reason"] == "unknown_changed_files"
+
+
+def test_review_required_work_cannot_close_without_review_result() -> None:
+    evaluation = evaluate_attempt_result(
+        _request(),
+        _result(include_review=False),
+        evidence=_success_evidence(),
+    )
+
+    assert evaluation.success is False
+    assert evaluation.state == "needs_decision"
+    assert evaluation.reason == "missing_fresh_review"
+
+
+def test_review_requirement_uses_request_scope_when_receipt_underreports_files() -> None:
+    evaluation = evaluate_attempt_result(
+        _request(),
+        _result(receipt=_receipt(files_changed=[]), include_review=False),
+        evidence=_success_evidence(),
+    )
+
+    assert evaluation.success is False
+    assert evaluation.state == "needs_decision"
+    assert evaluation.reason == "unknown_changed_files"
+
+
+def test_passed_review_cannot_close_when_receipt_underreports_files() -> None:
+    evaluation = evaluate_attempt_result(
+        _request(),
+        _result(receipt=_receipt(files_changed=[]), review_result=_review_result(status="passed")),
+        evidence=_success_evidence(),
+    )
+
+    assert evaluation.success is False
+    assert evaluation.state == "needs_decision"
+    assert evaluation.reason == "unknown_changed_files"
+
+
+def test_artifact_scope_passed_review_cannot_close_without_changed_file_evidence() -> None:
+    request = _request()
+    request["scope_paths"] = ["artifacts/evidence/"]
+    decision = evaluate_review_gate(
+        _result(receipt=_receipt(files_changed=[]), review_result=_review_result(status="passed")),
+        request=request,
+    )
+
+    assert decision["ok"] is False
+    assert decision["state"] == "needs_decision"
+    assert decision["reason"] == "unknown_changed_files"
+
+
+def test_unknown_change_evidence_cannot_be_marked_trivial_to_skip_review() -> None:
+    decision = evaluate_review_gate(
+        _result(
+            receipt=_receipt(files_changed=[]),
+            include_review=False,
+            review_not_required=_review_not_required(),
+        )
+    )
+
+    assert decision["ok"] is False
+    assert decision["state"] == "needs_decision"
+    assert decision["reason"] == "unknown_changed_files"
+
+
+def test_review_required_work_cannot_be_marked_trivial_to_skip_review() -> None:
+    evaluation = evaluate_attempt_result(
+        _request(),
+        _result(include_review=False, review_not_required=_review_not_required()),
+        evidence=_success_evidence(),
+    )
+
+    assert evaluation.success is False
+    assert evaluation.reason == "fresh_review_required_not_skippable"
+
+
+def test_valid_passed_review_allows_closure_and_records_review_packet() -> None:
+    evaluation = evaluate_attempt_result(
+        _request(),
+        _result(review_result=_review_result(status="passed")),
+        evidence=_success_evidence(),
+    )
+
+    assert evaluation.success is True
+    assert evaluation.reason == "all_success_predicates_satisfied"
+    assert evaluation.recovery_data["review"]["review_result"]["status"] == "passed"
+    assert (
+        evaluation.recovery_data["review"]["review_packet"]["schema_version"]
+        == "fresh_context_review_packet.v0"
+    )
+    assert evaluation.recovery_data["review"]["review_packet"]["diff"]["files_touched"] == [
+        "runtime/orchestration/coo/ea_dispatch.py"
+    ]
+    assert (
+        "scope_path:runtime/orchestration/coo/"
+        in evaluation.recovery_data["review"]["review_packet"]["constraints"]
+    )
+
+
+def test_fixes_requested_returns_to_review_instead_of_closing() -> None:
+    evaluation = evaluate_attempt_result(
+        _request(),
+        _result(
+            review_result=_review_result(
+                status="fixes_requested",
+                issues_found=["closure evidence omits changed-file proof"],
+            )
+        ),
+        evidence=_success_evidence(),
+    )
+
+    assert evaluation.success is False
+    assert evaluation.state == "running"
+    assert evaluation.reason == "fresh_review_fixes_requested"
+
+
+def test_blocked_or_malformed_review_blocks_closure() -> None:
+    blocked = evaluate_attempt_result(
+        _request(),
+        _result(
+            review_result=_review_result(
+                status="blocked",
+                remaining_risks=["reviewer could not verify CI evidence"],
+            )
+        ),
+        evidence=_success_evidence(),
+    )
+    malformed = evaluate_attempt_result(
+        _request(),
+        _result(review_result={"schema_version": REVIEW_RESULT_SCHEMA_VERSION}),
+        evidence=_success_evidence(),
+    )
+
+    assert blocked.success is False
+    assert blocked.state == "blocked"
+    assert blocked.reason == "fresh_review_blocked"
+    assert malformed.success is False
+    assert malformed.reason == "malformed_review_result"
+
+
+def test_trivial_review_skip_requires_explicit_reason() -> None:
+    request = _request()
+    request["scope_paths"] = ["artifacts/evidence/"]
+    trivial_receipt = _receipt(files_changed=["artifacts/evidence/typo-fix.json"])
+    evaluation = evaluate_attempt_result(
+        request,
+        _result(
+            receipt=trivial_receipt,
+            include_review=False,
+            review_not_required=_review_not_required(),
+        ),
+        evidence=_success_evidence(),
+    )
+
+    assert evaluation.success is True
+    assert evaluation.recovery_data["review"]["review_not_required"]["reason"]
+
+
+def test_malformed_review_not_required_blocks_trivial_skip() -> None:
+    request = _request()
+    request["scope_paths"] = ["artifacts/evidence/"]
+    trivial_receipt = _receipt(files_changed=["artifacts/evidence/typo-fix.json"])
+    evaluation = evaluate_attempt_result(
+        request,
+        _result(
+            receipt=trivial_receipt,
+            include_review=False,
+            review_not_required={
+                "schema_version": REVIEW_NOT_REQUIRED_SCHEMA_VERSION,
+                "classification": "trivial",
+            },
+        ),
+        evidence=_success_evidence(),
+    )
+
+    assert evaluation.success is False
+    assert evaluation.reason == "malformed_review_not_required"
+
+
+def test_review_packet_validator_rejects_malformed_nested_shape() -> None:
+    packet = build_review_packet(
+        _request(),
+        _result(),
+        constraints=["blockers only"],
+    )
+    packet["diff"] = {"files_touched": "runtime/orchestration/coo/ea_dispatch.py"}
+
+    assert "diff.scope_paths must be a list of strings" in validate_review_packet(packet)
+    assert "diff.files_touched must be a list of strings" in validate_review_packet(packet)
+
+    packet = build_review_packet(_request(), _result())
+    packet["issue"]["issue_number"] = True
+    assert "issue.issue_number must be an integer" in validate_review_packet(packet)
+
+
+def test_review_packet_shape_includes_objective_diff_tests_and_constraints() -> None:
+    packet = build_review_packet(
+        _request(),
+        _result(),
+        constraints=["blockers only", "do not redesign"],
+    )
+
+    assert packet["original_objective"]["task_ref"] == "WI-2026-079"
+    assert packet["issue"]["issue_url"] == "https://github.com/marcusglee11/LifeOS/issues/79"
+    assert packet["diff"]["files_touched"] == ["runtime/orchestration/coo/ea_dispatch.py"]
+    assert packet["tests_and_evidence"]["ci_status"] == "success"
+    assert packet["constraints"] == ["blockers only", "do not redesign"]


### PR DESCRIPTION
## Summary
- Adds a COO EA review closure gate that fails closed when changed-file evidence is unknown.
- Persists fresh-review recovery data, including request-derived review packet constraints.
- Adds regression coverage for underreported files, unknown changed-file scope, and review packet scope context.

## Verification
- `git diff --cached --check` passed before commit.
- `python3 scripts/workflow/quality_gate.py check --scope changed --json` passed: 0 blocking failures; mypy advisory unavailable locally.
- `pytest runtime/tests/orchestration/coo/test_ea_dispatch.py runtime/tests/receipts/test_ea_receipt.py -q` passed: 45 passed.
- `pytest runtime/tests -q` passed: 3267 passed, 6 skipped.
- Fresh-context staged-diff review: PASS, no blockers found.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)