### PR TITLE
Add Autonomous Work Chain v0 final proof evidence

### DIFF
--- a/artifacts/ea_receipts/lifeos-78/README.md
+++ b/artifacts/ea_receipts/lifeos-78/README.md
@@ -1,0 +1,11 @@
+# LifeOS #78 Codex EA Evidence Receipt
+
+This directory contains the Codex EA evidence receipt for LifeOS issue #78 final
+proof.
+
+Completion truth remains GitHub issue, pull request, CI/check result, and a
+validated `ea_receipt.v0`. Wrapper exit status, OpenClaw, Telegram, and local TUI
+output are not completion truth.
+
+Hermes owns final closure readback after commit, PR, checks, merge, and
+`origin/main` verification.

--- a/artifacts/ea_receipts/lifeos-78/success.ea_receipt.v0.json
+++ b/artifacts/ea_receipts/lifeos-78/success.ea_receipt.v0.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "ea_receipt.v0",
+  "status": "success",
+  "commands_run": [
+    "python3 scripts/validate_work_items.py --check --repo-root .",
+    "python3 -m pytest runtime/tests/receipts/test_ea_receipt.py runtime/tests/orchestration/coo/test_ea_dispatch.py runtime/tests/orchestration/coo/test_followups.py -q",
+    "python3 scripts/workflow/quality_gate.py check --scope changed --json"
+  ],
+  "inner_exit_codes": [
+    0,
+    0,
+    0
+  ],
+  "files_changed": [
+    "config/tasks/backlog.yaml",
+    "artifacts/workstreams.yaml",
+    "artifacts/evidence/autonomous_work_chain_v0_final_proof.md",
+    "artifacts/ea_receipts/lifeos-78/success.ea_receipt.v0.json",
+    "artifacts/ea_receipts/lifeos-78/README.md"
+  ],
+  "tests_run": [
+    "scripts/validate_work_items.py",
+    "runtime/tests/receipts/test_ea_receipt.py",
+    "runtime/tests/orchestration/coo/test_ea_dispatch.py",
+    "runtime/tests/orchestration/coo/test_followups.py"
+  ],
+  "blockers": []
+}

--- a/artifacts/evidence/autonomous_work_chain_v0_final_proof.md
+++ b/artifacts/evidence/autonomous_work_chain_v0_final_proof.md
@@ -1,0 +1,45 @@
+# Autonomous Work Chain v0 Final Proof Evidence
+
+Issue: https://github.com/marcusglee11/LifeOS/issues/78
+Work item: `WI-2026-001`
+Branch: `build/final-proof-78`
+Base readback: `origin/main` at `1c33dd907374a37c6cb663530066d59f523d3455`
+
+Purpose: evidence-only packet for LifeOS #78 final proof. It does not create new
+infrastructure and does not claim PR, CI, or post-merge main readback before this
+branch is opened and merged.
+
+## Final Closure Values
+
+| Required value | Status |
+| --- | --- |
+| #78 PR URL | to be filled in #78 closure comment |
+| #78 CI/check run URL | to be filled in #78 closure comment |
+| #78 main readback SHA | to be filled in #78 closure comment |
+
+## Acceptance Mapping
+
+| #78 acceptance criterion | Live evidence | Proof status |
+| --- | --- | --- |
+| Roadmap thread exists and ties work chain together | Roadmap #74: https://github.com/marcusglee11/LifeOS/issues/74 | Linked |
+| Codex EA substrate proof exists | Dependency #75: https://github.com/marcusglee11/LifeOS/issues/75 and local receipt artifacts under `artifacts/ea_receipts/lifeos-75/` | Linked |
+| Codex lane authority exists | Dependency #69: https://github.com/marcusglee11/LifeOS/issues/69, `memory/workflows/coo-ea-dispatch-codex-only.md`, `memory/receipts/rcp-20260428-codex-ea-lane.md` | Linked |
+| Dispatch protocol exists | Dependency #62: https://github.com/marcusglee11/LifeOS/issues/62 and `docs/02_protocols/COO_EA_Dispatch_Pipeline_Protocol_v0.1.md` | Linked |
+| First executable dispatch verifier landed | Dependency #79: https://github.com/marcusglee11/LifeOS/issues/79, PR #97: https://github.com/marcusglee11/LifeOS/pull/97, commit `f2783a0` | Landed before #78 proof branch |
+| Fresh review closure gate landed | Dependency #76: https://github.com/marcusglee11/LifeOS/issues/76, PR #98: https://github.com/marcusglee11/LifeOS/pull/98, commit `1a5bccd` | Landed before #78 proof branch |
+| Follow-up planning and disposition support landed | Dependency #77: https://github.com/marcusglee11/LifeOS/issues/77, PR #99: https://github.com/marcusglee11/LifeOS/pull/99, commit `1c33dd9` | Landed on `origin/main` |
+| Active final proof issue remains source of closure truth | Active issue #78: https://github.com/marcusglee11/LifeOS/issues/78 | This packet supplies local evidence only |
+| Follow-up disposition remains linked | Follow-up #100: https://github.com/marcusglee11/LifeOS/issues/100 | Disposition tracked as linked follow-up outside #78 final proof |
+| Final evidence packet exists | `artifacts/evidence/autonomous_work_chain_v0_final_proof.md` | Present on this branch |
+| Valid `ea_receipt.v0` exists | `artifacts/ea_receipts/lifeos-78/success.ea_receipt.v0.json` | Present on this branch |
+| Missing or malformed receipt fails closed | `runtime/tests/receipts/test_ea_receipt.py::test_missing_receipt_fails_closed`, `runtime/tests/receipts/test_ea_receipt.py::test_malformed_json_fails_closed`, `runtime/tests/orchestration/coo/test_ea_dispatch.py::test_missing_receipt_fails_closed` | Covered by required validation command |
+
+## Completion Truth
+
+#78 completion truth is GitHub issue/PR/CI evidence plus a validated
+`ea_receipt.v0`. Wrapper exit status, OpenClaw, Telegram, and local TUI output are
+not completion truth.
+
+Hermes should fill the final closure comment with the #78 PR URL, the #78
+CI/check run URL, and the #78 main readback SHA after this branch is committed,
+opened as a PR, checked, merged, and read back from `origin/main`.

--- a/artifacts/workstreams.yaml
+++ b/artifacts/workstreams.yaml
@@ -39,3 +39,12 @@ opencode_integration:
   aliases:
     - "opencode"
     - "opencode ci"
+
+autonomous-work-chain-v0:
+  component_human_name: "Autonomous Work Chain v0"
+  status: PROVISIONAL
+  created_at: "2026-04-30"
+  description: "Evidence-only final proof lane for LifeOS autonomous work chain v0"
+  aliases:
+    - "autonomous work chain"
+    - "final proof"

--- a/config/tasks/backlog.yaml
+++ b/config/tasks/backlog.yaml
@@ -693,3 +693,34 @@ tasks:
   objective_ref: coo-coordination-loop
   created_at: '2026-04-05T12:04:26Z'
   completed_at: null
+- id: WI-2026-001
+  title: Autonomous Work Chain v0 final proof evidence packet
+  description: 'Evidence-only work item for LifeOS #78 final proof.'
+  dod: 'Final evidence packet and valid ea_receipt.v0 are committed; #78 closure
+    comment supplies final PR/CI/main readback URLs.'
+  priority: P1
+  risk: low
+  scope_paths:
+  - artifacts/evidence/
+  - artifacts/ea_receipts/lifeos-78/
+  status: DISPATCHED
+  requires_approval: false
+  decision_support_required: false
+  owner: codex
+  evidence: https://github.com/marcusglee11/LifeOS/issues/78
+  task_type: build
+  tags:
+  - coo
+  - autonomy
+  - proof
+  objective_ref: 'github:marcusglee11/LifeOS#78'
+  created_at: '2026-04-30T04:29:51Z'
+  completed_at: null
+  github_issue: 78
+  workstream: autonomous-work-chain-v0
+  plan_mode: plan_lite
+  acceptance_criteria:
+  - Final evidence packet maps #78 acceptance criteria to live evidence.
+  - Valid ea_receipt.v0 records intended validation commands and changed files.
+  - 'Follow-up #100 disposition is linked from final proof evidence.'
+  - Missing or malformed ea_receipt.v0 fails closed under receipt and dispatch tests.


### PR DESCRIPTION
## Summary
- Add `WI-2026-001` as the final #78 proof work item linked to the roadmap and issue.
- Add the #78 final proof evidence packet mapping acceptance criteria to live issue/PR/receipt evidence.
- Add a valid `ea_receipt.v0` plus receipt README for the Codex EA evidence run.

Closes #78.

## Verification
- Codex EA CLI executed the evidence edits on branch `build/final-proof-78`; Hermes independently inspected and verified the staged diff.
- `python3 scripts/validate_work_items.py --check --repo-root .` -> WMF validator OK (0 violations).
- `python3 -m pytest runtime/tests/receipts/test_ea_receipt.py runtime/tests/orchestration/coo/test_ea_dispatch.py runtime/tests/orchestration/coo/test_followups.py -q` -> 54 passed in 0.49s.
- `python3 scripts/workflow/quality_gate.py check --scope changed --json` -> passed with 0 blocking failures; `yamllint` advisory unavailable locally with waiver `tool_unavailable_locally`.
- `load_and_validate_ea_receipt('artifacts/ea_receipts/lifeos-78/success.ea_receipt.v0.json')` -> `ea_receipt.v0 success`.
- `git diff --cached --check` clean before commit.
- Fresh-context blocker review PASS.

## Completion truth
- GitHub issue/PR/CI, validated `ea_receipt.v0`, and `origin/main` readback only.
- OpenClaw, Telegram, local TUI, and wrapper exit status are not completion truth.

🤖 Generated with Hermes Agent