### PR TITLE
feat: add inert Founder Intent Fidelity Gate v0.3 (#111)

### DIFF
--- a/artifacts/plans/2026-05-09-founder-intent-fidelity-gate-spec-and-plan-v0.3.md
+++ b/artifacts/plans/2026-05-09-founder-intent-fidelity-gate-spec-and-plan-v0.3.md
@@ -1,0 +1,561 @@
+---
+packet_type: PLAN_ARTIFACT
+version: 0.3
+mission_name: Founder Intent Fidelity Gate
+status: REVIEW_INTEGRATED_READY_FOR_IMPLEMENTATION_PLANNING
+date: 2026-05-09
+author: Hermes COO
+review_state:
+  openclaw: integrated
+  aa: integrated
+source_reviews:
+  openclaw: artifacts/reviews/2026-05-09-founder-intent-fidelity-openclaw-redteam.md
+  aa: artifacts/reviews/2026-05-09-founder-intent-fidelity-aa-redteam.md
+supersedes:
+  - artifacts/plans/2026-05-09-founder-feedback-fidelity-gate-spec-and-plan-v0.1.md
+  - artifacts/plans/2026-05-09-founder-intent-fidelity-gate-spec-and-plan-v0.2.md
+---
+
+# Founder Intent Fidelity Gate — Spec and Implementation Plan v0.3
+
+## 1. Raison d'être
+
+LifeOS exists to convert Marcus's CEO intent into execution without making Marcus act as middleware. The Hermes production benchmark exposed a control-plane failure: explicit destructive feedback was softened into preservation-biased implementation. The output polished instead of removed.
+
+The gate prevents a broader class of failures: active CEO intent being transformed before execution.
+
+Examples:
+
+- “remove/delete/start over” becomes “preserve/polish”;
+- “do not implement yet” becomes “start work”;
+- “ask me before changing channels” becomes “route automatically”;
+- “keep private” becomes “post externally”;
+- “minimum viable” becomes overbuilt;
+- “no automation” becomes unattended automation.
+
+## 2. Core thesis
+
+Model swaps do not fix source-fidelity failures. LifeOS needs an auditable pre-handoff gate proving that the brief handed to a worker/EA/build loop preserves active CEO intent.
+
+## 3. Authority clause
+
+A fidelity pass is not implementation approval. It only certifies that the checked brief preserves active source intent. Dispatch, repo mutation, runtime mutation, external/public sends, credentials, destructive actions, and CEO-gated actions still require their normal gates.
+
+Reviewer output is evidence only. OpenClaw, AA, and EAs do not create authority, override CEO intent, or verify their own work.
+
+## 4. Conductor identity and separation
+
+For this gate:
+
+- **Brief author:** actor/session/tool that produced the brief under check.
+- **Source collector:** actor/session/tool that collected source material.
+- **Deterministic checker:** local code that emits `intent_fidelity_report.v1`.
+- **Reviewer:** OpenClaw/AA/EA peer review; evidence only.
+- **Conductor verifier:** the session responsible for final LifeOS truth claim.
+
+Separation invariant:
+
+- The same actor/session that authored the brief cannot be the sole conductor verification for high-risk triggered work.
+- Marcus-solo fallback: Hermes may act as conductor only if verification is a separate turn/session from the brief-writing worker/EA, uses direct source readback, records source hashes, and explicitly states `brief_author_session != conductor_verification_session` or `human_verified: true`.
+- Worker self-attestation cannot set `handoff_candidate: true`.
+
+## 5. Scope and non-goals
+
+### In scope for v0.3 implementation
+
+- Inert/local source intent manifest.
+- Versioned intent lexicon.
+- Deterministic extraction against that lexicon.
+- Brief-vs-source fidelity report.
+- Conductor verification artifact with no implementation authority.
+- Dry-run CLI.
+- False-positive and false-negative fixtures.
+
+### Out of scope / deferred
+
+- Runtime handoff blocking.
+- Production model-routing changes.
+- Full compression quarantine implementation.
+- External/public writes.
+- Credentials or automation activation.
+- Governance doc ratification.
+
+Compression follow-on must consume the raw-source-hash interface defined here; it must not renegotiate source identity.
+
+## 6. Precedence order
+
+Highest first:
+
+1. Current explicit CEO/founder instruction in the active work item or named feedback source.
+2. Current issue/PR acceptance criteria and latest explicit owner/conductor comment.
+3. Ratified architecture/governance documents.
+4. Current implementation plan/build packet.
+5. Older lessons, memory, style guides, prior preferences.
+6. Model priors and generic “best practice”.
+
+Lower-precedence material may add constraints only when it does not weaken, invert, omit, or reframe higher-precedence intent.
+
+Stale-lesson enforcement is deferred unless a concrete lesson corpus path is supplied. v0.3 must not emit fake `stale_lessons_violating: []` as if lessons were checked.
+
+## 7. Trigger policy
+
+### Full gate required
+
+Run the full gate when any condition is true:
+
+- Current CEO/founder feedback is present and high-authority.
+- Feedback contains destructive, absence, privacy, approval, channel, automation, pause, or reversibility constraints.
+- A worker/EA/autonomous build loop will receive a summarised brief.
+- A compression or summary layer sits between source and execution.
+- The task follows prior bad output/correction.
+
+### Warning-only terms
+
+These are warning-only only when no blocking intent class appears in the same source set:
+
+- simplify
+- minimal
+- not this
+- whole surface
+
+These become blocking softening/inversion terms when any absence/destructive source intent exists in the same source set:
+
+- polish
+- clean up
+- rework
+- iterate
+- preserve
+- retain
+- maintain existing
+- keep most
+- leave structure
+
+Index-case rule: if source says remove/delete/hide/start over, any brief framing the work as polish/cleanup/iteration is a blocking inversion unless it explicitly preserves the absence requirement.
+
+### No gate required
+
+Skip for routine low-risk edits with no high-authority feedback transformation, no worker handoff, no summary/compression layer, and deterministic local verification.
+
+## 8. Intent classes v0.3
+
+1. **Absence/destructive:** remove, delete, hide, strip, eliminate, no longer show, start from scratch.
+2. **Pause/no-execution:** do not implement yet, wait, pause, hold, stop.
+3. **Approval-before-action:** ask me first, before changing X, needs approval.
+4. **Privacy/externality:** keep private, do not send, no public post, internal only.
+5. **Reversibility:** reversible only, no destructive cleanup, no irreversible action.
+6. **Automation boundary:** no automation, no unattended trigger, supervised only.
+7. **Channel/source authority:** use GitHub only, use this doc, do not create another channel.
+8. **Scope minimisation:** minimum viable, no overbuilding, only X.
+9. **Softening/inversion:** polish, clean up, iterate, retain, preserve, maintain, keep most, leave structure, when conflicting with a blocking class.
+
+## 9. Determinism and lexicon model
+
+v0.3 is deterministic only within a closed, versioned lexicon.
+
+Required data file:
+
+- `runtime/data/intent_lexicon_v1.json`
+
+It must define:
+
+- intent class;
+- phrase patterns;
+- blocking vs warning default;
+- inversion terms;
+- negation/quote guards;
+- examples;
+- version.
+
+Semantic paraphrase beyond the lexicon is out of scope for v0.3. If the checker detects low-confidence conflict or unsupported paraphrase, it must emit `requires_conductor_review`, not silently pass.
+
+Determinism invariant: running the extractor twice on the same source bytes and same lexicon version must produce identical `IntentSpan`s.
+
+## 10. Source discovery rules
+
+### GitHub work
+
+Canonical discovery command shape:
+
+```bash
+gh issue view <issue> --repo <owner/repo> --json number,title,body,comments,labels,state,url,updatedAt
+
+gh pr view <pr> --repo <owner/repo> --json number,title,body,reviews,comments,files,headRefOid,baseRefName,url,updatedAt
+```
+
+If linked PRs/issues are discovered, their readback commands must also be recorded.
+
+Manifest must record:
+
+- exact command(s);
+- command output sha256 hash;
+- cutoff timestamp;
+- actor/session;
+- which source classes were excluded and why.
+
+### Local/Obsidian/Drive work
+
+Canonical discovery must record:
+
+- exact path/URI;
+- retrieval method;
+- raw bytes/content hash;
+- last-modified timestamp if available;
+- source-of-source hash for transcripts or derived text.
+
+Named high-authority source missing = fail closed unless Marcus/conductor explicitly marks it non-required.
+
+Completeness invariant: triggered work must include at least one externally retrieved source (`retrieval_method != self`) unless the source is the current chat message from Marcus and that message hash is recorded.
+
+## 11. Brief target invariant
+
+The gate must name exactly what artifact is being checked.
+
+Allowed `brief_type` values:
+
+- `worker_prompt`
+- `dispatch_packet`
+- `build_packet`
+- `implementation_plan`
+- `pr_body`
+- `issue_comment`
+- `closure_packet`
+- `other`
+
+A pass for one brief does not transfer to another brief unless hashes match.
+
+## 12. Required artifacts
+
+### `intent_source_manifest.v1`
+
+```yaml
+schema_version: intent_source_manifest.v1
+work_item_id: string
+lexicon_version: string
+created_at: iso8601
+created_by: conductor|worker|ea|tool
+source_discovery:
+  mode: github|local_file|google_doc|obsidian|chat|mixed
+  commands_or_uris: []
+  command_output_hashes_sha256: []
+  cutoff_timestamp: iso8601
+  completeness_claimed_by: conductor|worker|ea|tool
+sources:
+  - source_id: string
+    source_type: issue_body|issue_comment|pr_review|pr_comment|local_file|google_doc|obsidian_note|chat|plan|ratified_doc|transcript
+    uri: string
+    retrieved_at: iso8601
+    retrieval_method: string
+    content_hash_sha256: string
+    source_of_source_hash_sha256: string|null
+    authority_tier: current_ceo_instruction|acceptance_criteria|ratified_doc|plan|lesson|memory|other
+    extracted_intents:
+      - intent_class: absence|pause|approval_before_action|privacy|reversibility|automation_boundary|channel_authority|scope_minimisation|softening_inversion|other
+        phrase: string
+        line_or_offset: string
+        surrounding_context: string
+        blocking_strength: blocking|warning|requires_conductor_review
+missing_sources:
+  - expected_source: string
+    reason_missing: string
+    disposition: fail_closed|not_required
+```
+
+### `intent_fidelity_report.v1`
+
+Deterministic/tool findings only.
+
+```yaml
+schema_version: intent_fidelity_report.v1
+work_item_id: string
+brief_type: worker_prompt|dispatch_packet|build_packet|implementation_plan|pr_body|issue_comment|closure_packet|other
+brief_uri: string
+brief_hash_sha256: string
+source_manifest_uri: string
+decision: pass|fail_closed|requires_ceo_clarification|requires_conductor_review|warning_only
+checks:
+  source_coverage:
+    status: pass|fail
+    missing_required_sources: []
+  verbatim_preservation:
+    status: pass|fail
+    source_intents_total: integer
+    source_intents_preserved_or_mapped: integer
+    missing_intents: []
+  intent_inversion:
+    status: pass|fail
+    inversions: []
+  hedge_or_softening:
+    status: pass|warn|fail
+    findings: []
+  contradiction_detection:
+    status: pass|fail|requires_ceo_clarification
+    contradictions: []
+  false_positive_fixtures_passed: integer
+  determinism_check:
+    status: pass|fail
+```
+
+### `intent_review_report.v1`
+
+Reviewer evidence only.
+
+```yaml
+schema_version: intent_review_report.v1
+work_item_id: string
+reviewer_surface: openclaw|aa|ea|other
+reviewer_session: string
+verdict: reject|amend|approve
+findings:
+  - severity: p0|p1|p2|note
+    title: string
+    recommendation: string
+authority_note: reviewer_output_is_evidence_only
+```
+
+### `conductor_fidelity_verification.v1`
+
+Only this artifact can mark the checked brief as a handoff candidate.
+
+```yaml
+schema_version: conductor_fidelity_verification.v1
+work_item_id: string
+brief_type: string
+brief_hash_sha256: string
+brief_author_session: string
+conductor_verification_session: string
+source_manifest_hash_sha256: string
+fidelity_report_hash_sha256: string
+conductor_independently_confirmed: true
+fidelity_status: preserved_intent|not_preserved|needs_clarification|requires_review|warning_only
+handoff_candidate: boolean
+implementation_authority_granted: false
+required_next_gate: none|dispatch_gate|ceo_clarification|ceo_approval|repo_gate|runtime_gate
+forbidden_next_steps:
+  - implementation_without_reload
+  - additive_or_polish_framing_if_source_requires_absence
+  - reviewer_output_as_authority
+  - compression_as_canonical_memory
+verified_by: conductor
+verified_at: iso8601
+```
+
+## 13. Brief construction requirements
+
+Triggered briefs must include:
+
+```markdown
+## Source Intent — Verbatim Requirements
+- `<exact phrase>` — source: `<source_id>` — intent class: `<class>` — implementation meaning: `<plain-language requirement>`
+
+## Absence / Boundary Requirements
+- Requirement: `<what must be absent/forbidden/not done>`
+- Verification: `<how absence or boundary will be checked>`
+
+## Explicit Non-Softening Clause
+- This brief does not convert removal/deletion/absence intent into polish, cleanup, iteration, preserve, retain, or additive-only work.
+
+## Contradictions / Ambiguities
+- `<none>` or exact contradiction requiring CEO clarification
+
+## Handoff Boundary
+- Fidelity pass does not grant implementation authority.
+- Required next gate: `<dispatch/repo/CEO/runtime/etc>`
+```
+
+## 14. Gate algorithm
+
+1. Discover active sources using canonical commands/URIs.
+2. Hash raw command output/source bytes.
+3. Load `intent_lexicon_v1.json`.
+4. Extract intent spans.
+5. Run determinism check: same bytes + lexicon => same spans.
+6. Classify spans as blocking, warning, or requires conductor review.
+7. Identify the exact `brief_type`, `brief_uri`, and brief hash.
+8. Check verbatim preservation or explicit intent mapping.
+9. Check inversion:
+   - preserve/additive-only/polish/cleanup/iteration against absence/destructive intent;
+   - implement/start against pause intent;
+   - external/public against privacy intent;
+   - autonomous/unattended against no-automation intent;
+   - new channel/source against channel-authority intent.
+10. Check negation, historical, hypothetical, and third-party quote guards to reduce false positives.
+11. Emit deterministic report.
+12. Conductor verifies source completeness and report decision independently from reviewer verdicts.
+13. Only conductor verification may mark `handoff_candidate: true`.
+
+## 15. Bypass policy
+
+Bypass is not allowed for privacy/externality, destructive/irreversible, automation-boundary, or approval-before-action blocking classes without CEO approval.
+
+Conductor-level bypass is limited to warning-only or known false-positive cases.
+
+```yaml
+schema_version: intent_fidelity_bypass.v1
+work_item_id: string
+requested_by: string
+authorized_by: conductor|ceo
+reason: string
+sources_skipped: []
+risk_accepted: string
+scope: string
+expires_at: iso8601 # must be <= 24h after created_at
+single_use: true
+not_authorized_for:
+  - external_send
+  - runtime_activation
+  - credential_change
+  - destructive_cleanup
+```
+
+Implementation must include a local bypass registry and expiry check before any bypass is honored.
+
+## 16. Audit-only graduation criteria
+
+Runtime blocking remains forbidden until an audit-only dogfood report shows:
+
+- at least 20 real brief/source pairs reviewed;
+- at least 3 destructive/absence cases;
+- at least 3 non-destructive boundary cases;
+- false-positive block rate ≤ 15%;
+- false-negative rate 0 on seeded known-bad cases;
+- at least one conductor-confirmed useful catch or a clear decision that the gate is too low-signal;
+- no unbounded CEO-clarification spam pattern.
+
+## 17. Implementation plan v0.3 — inert/local only
+
+### Task 1: Fixture corpus
+
+Create:
+
+- `runtime/tests/fixtures/intent_fidelity/v120_source.md`
+- `runtime/tests/fixtures/intent_fidelity/v120_bad_brief.md`
+- `runtime/tests/fixtures/intent_fidelity/v120_good_brief.md`
+- `runtime/tests/fixtures/intent_fidelity/non_destructive_source.md`
+- `runtime/tests/fixtures/intent_fidelity/non_destructive_bad_brief.md`
+- `runtime/tests/fixtures/intent_fidelity/false_positive_negation.md`
+- `runtime/tests/fixtures/intent_fidelity/false_positive_historical.md`
+- `runtime/tests/fixtures/intent_fidelity/false_positive_hypothetical.md`
+- `runtime/tests/fixtures/intent_fidelity/false_positive_third_party_quote.md`
+
+Verification: fixtures cover all intent classes and false-positive guards.
+
+### Task 2: Versioned lexicon
+
+Create:
+
+- `runtime/data/intent_lexicon_v1.json`
+- `runtime/tests/test_intent_lexicon.py`
+
+Verification:
+
+```bash
+pytest runtime/tests/test_intent_lexicon.py -q
+```
+
+Must include polish/cleanup/rework as blocking inversion terms when absence/destructive intent exists.
+
+### Task 3: JSON schemas
+
+Create:
+
+- `schemas/intent_source_manifest_v1.json`
+- `schemas/intent_fidelity_report_v1.json`
+- `schemas/intent_review_report_v1.json`
+- `schemas/conductor_fidelity_verification_v1.json`
+- `schemas/intent_fidelity_bypass_v1.json`
+
+Test:
+
+- `runtime/tests/test_intent_fidelity_schemas.py`
+
+Verification:
+
+```bash
+pytest runtime/tests/test_intent_fidelity_schemas.py -q
+```
+
+### Task 4: Extractor
+
+Create:
+
+- `runtime/orchestration/intent_fidelity.py`
+- `runtime/tests/test_intent_fidelity_extractor.py`
+
+Core API:
+
+```python
+def extract_intents(text: str, source_id: str, lexicon: IntentLexicon) -> list[IntentSpan]:
+    ...
+```
+
+Verification: boundary matching, case folding, deterministic rerun, false-positive guards.
+
+### Task 5: Manifest builder
+
+Modify/create:
+
+- `runtime/orchestration/intent_fidelity.py`
+- `runtime/tests/test_intent_source_manifest.py`
+
+Verification: missing named high-authority source fails closed; present source includes raw hash, retrieval method, source-of-source hash when derived, extracted intents.
+
+### Task 6: Fidelity checker
+
+Modify/create:
+
+- `runtime/orchestration/intent_fidelity.py`
+- `runtime/tests/test_intent_fidelity_checker.py`
+
+Verification:
+
+- v120 bad brief fails because polish/additive/preserve framing softens destructive intent;
+- v120 good brief passes;
+- non-destructive boundary inversions fail;
+- ambiguous broad terms warn only when no blocking class exists;
+- unsupported paraphrase emits `requires_conductor_review`.
+
+### Task 7: Conductor verification and bypass registry
+
+Create:
+
+- `runtime/receipts/intent_fidelity.py`
+- `runtime/tests/test_intent_fidelity_verification.py`
+- `runtime/tests/test_intent_fidelity_bypass.py`
+
+Verification:
+
+- `implementation_authority_granted` always false;
+- `handoff_candidate` true only with separate conductor verification;
+- bypass expires ≤24h and is single-use;
+- bypass cannot cover CEO-only classes without CEO approval ref.
+
+### Task 8: CLI dry-run
+
+Add after codebase discovery:
+
+```bash
+python3 -m lifeos intent-fidelity check --source <source.md> --brief <brief.md> --brief-type worker_prompt --json
+```
+
+Verification:
+
+- bad brief exits nonzero with JSON report;
+- good brief exits zero;
+- no repo/runtime mutation.
+
+## 18. Deferred sibling work
+
+1. Runtime handoff blocking after audit-only graduation.
+2. Compression quarantine consuming `source_of_source_hash_sha256` and source manifest hashes.
+3. Real-input model variance bench over LifeOS source/brief pairs.
+4. Governance/doc promotion after implementation evidence.
+
+## 19. Review integration summary
+
+OpenClaw found v0.1 over-fitted and too broad. v0.2 broadened to intent fidelity, separated authority, added source discovery, warning-only mode, and deferred compression/routing.
+
+AA found v0.2 still had P0s: polish warning-only reproduced v120, deterministic semantics were overstated, and conductor identity was undefined. v0.3 fixes those by promoting polish/cleanup/rework to blocking in destructive contexts, requiring a versioned lexicon with determinism tests, adding conductor/session separation, pinning discovery hashes, capping bypass, and adding audit-only graduation metrics.
+
+## 20. COO recommendation
+
+Implement only v0.3 inert/local tasks. Do not activate runtime blocking, compression quarantine, or model-routing changes until audit-only graduation criteria pass and a separate CEO/dispatch gate approves the next phase.

--- a/artifacts/reviews/2026-05-09-founder-intent-fidelity-aa-redteam.md
+++ b/artifacts/reviews/2026-05-09-founder-intent-fidelity-aa-redteam.md
@@ -1,0 +1,36 @@
+# AA Red-Team Review — Founder Intent Fidelity Gate v0.2
+
+Review target: `/home/cabra/LifeOS/artifacts/plans/2026-05-09-founder-intent-fidelity-gate-spec-and-plan-v0.2.md`
+Reviewer: Claude Code as AA reviewer, read-only
+Session: `779ea88a-c3a4-4018-b1d7-828dcea62f06`
+Model: `opus`
+Date: 2026-05-09
+Verdict: `amend` — architecture sound, P0 issues remain
+Cost observed: `$0.43519825`
+
+## P0 findings
+
+1. **“Polish” warning-only reproduces v120.** If destructive/absence feedback is present, polish/clean-up/rework language must be treated as blocking softening/inversion, not warning-only.
+2. **Deterministic extractor claim is overstated.** Inversion checks require semantic equivalence or a closed/tested lexicon. Paraphrases like “retain the structure” can bypass phrase tables.
+3. **Conductor identity is undefined in Marcus-solo loop.** Worker/self-attestation can collapse into conductor verification unless actor/session separation is specified.
+
+## P1 findings
+
+- Source discovery remains free-form; canonical commands and output hashes are needed.
+- Stale-lesson precedence has no defined lesson corpus/producer.
+- Brief artifact type is undefined.
+- Bypass expiry is schema-only and unenforced.
+- No audit-only dogfood graduation criteria.
+
+## Required amendments accepted into v0.3
+
+- Promote polish/clean-up/rework to blocking when co-occurring with absence/destructive intent.
+- Add closed versioned lexicon and state semantic paraphrase limits explicitly.
+- Add conductor identity/session separation rule.
+- Add canonical discovery commands and output byte hashes.
+- Define lesson corpus or remove stale lesson checker from v0.3 core.
+- Add exact `brief_type` and `brief_uri` requirements.
+- Cap bypass duration and require registry/sweep.
+- Add false-positive fixtures for negation, historical, hypothetical, third-party quote.
+- Add dogfood graduation metrics before runtime blocking.
+- Pull forward raw-source-hash interface for future compression quarantine.

--- a/artifacts/reviews/2026-05-09-founder-intent-fidelity-openclaw-redteam.md
+++ b/artifacts/reviews/2026-05-09-founder-intent-fidelity-openclaw-redteam.md
@@ -1,0 +1,29 @@
+# OpenClaw Red-Team Review — Founder Feedback Fidelity Gate v0.1
+
+Review target: `/home/cabra/LifeOS/artifacts/plans/2026-05-09-founder-feedback-fidelity-gate-spec-and-plan-v0.1.md`
+Reviewer: OpenClaw `main` via `openclaw agent --local --agent main`
+Session: `27a3ec94-23f8-4e13-9d66-8ecdf2a3e107`
+Model: `openai-codex/gpt-5.5`
+Date: 2026-05-09
+Verdict: `amend`
+
+## Top objections
+
+1. Spec is valid but over-fitted to remove/delete; LifeOS needs broader intent fidelity covering pause, ask-first, privacy, reversibility, no automation, no external send.
+2. Reload requirement can become theater without freshness windows, source-discovery rules, and canonical “latest source” definitions.
+3. Authority boundary leaks: reviewer/conductor/EA fields are mixed; deterministic output or worker could impersonate conductor verification.
+4. False positives can freeze useful work; broad terms like simplify/minimal/rework/not-this should not always trigger full ceremony.
+5. Compression and model-routing concerns are bundled into the same workstream; split them from the core fidelity gate.
+
+## Required amendments accepted into v0.2
+
+- Rename to Founder Intent Fidelity Gate.
+- Add explicit authority clause: fidelity pass is not implementation approval.
+- Split deterministic report, review report, and conductor verification.
+- Add source-discovery invariant for GitHub and named documents.
+- Add warning-only mode for ambiguous/broad phrases.
+- Narrow v0.2 implementation plan to inert/local tasks 1–7.
+- Move compression quarantine and model variance bench to sibling follow-on work.
+- Add bypass policy.
+- Add negative tests beyond destructive feedback.
+- Replace `allowed_next_step: implementation` with `handoff_candidate` and `implementation_authority_granted: false`.

--- a/artifacts/specs/Founder_Intent_Fidelity_Gate_v0.3.md
+++ b/artifacts/specs/Founder_Intent_Fidelity_Gate_v0.3.md
@@ -1,0 +1,561 @@
+---
+packet_type: PLAN_ARTIFACT
+version: 0.3
+mission_name: Founder Intent Fidelity Gate
+status: REVIEW_INTEGRATED_READY_FOR_IMPLEMENTATION_PLANNING
+date: 2026-05-09
+author: Hermes COO
+review_state:
+  openclaw: integrated
+  aa: integrated
+source_reviews:
+  openclaw: artifacts/reviews/2026-05-09-founder-intent-fidelity-openclaw-redteam.md
+  aa: artifacts/reviews/2026-05-09-founder-intent-fidelity-aa-redteam.md
+supersedes:
+  - artifacts/plans/2026-05-09-founder-feedback-fidelity-gate-spec-and-plan-v0.1.md
+  - artifacts/plans/2026-05-09-founder-intent-fidelity-gate-spec-and-plan-v0.2.md
+---
+
+# Founder Intent Fidelity Gate — Spec and Implementation Plan v0.3
+
+## 1. Raison d'être
+
+LifeOS exists to convert Marcus's CEO intent into execution without making Marcus act as middleware. The Hermes production benchmark exposed a control-plane failure: explicit destructive feedback was softened into preservation-biased implementation. The output polished instead of removed.
+
+The gate prevents a broader class of failures: active CEO intent being transformed before execution.
+
+Examples:
+
+- “remove/delete/start over” becomes “preserve/polish”;
+- “do not implement yet” becomes “start work”;
+- “ask me before changing channels” becomes “route automatically”;
+- “keep private” becomes “post externally”;
+- “minimum viable” becomes overbuilt;
+- “no automation” becomes unattended automation.
+
+## 2. Core thesis
+
+Model swaps do not fix source-fidelity failures. LifeOS needs an auditable pre-handoff gate proving that the brief handed to a worker/EA/build loop preserves active CEO intent.
+
+## 3. Authority clause
+
+A fidelity pass is not implementation approval. It only certifies that the checked brief preserves active source intent. Dispatch, repo mutation, runtime mutation, external/public sends, credentials, destructive actions, and CEO-gated actions still require their normal gates.
+
+Reviewer output is evidence only. OpenClaw, AA, and EAs do not create authority, override CEO intent, or verify their own work.
+
+## 4. Conductor identity and separation
+
+For this gate:
+
+- **Brief author:** actor/session/tool that produced the brief under check.
+- **Source collector:** actor/session/tool that collected source material.
+- **Deterministic checker:** local code that emits `intent_fidelity_report.v1`.
+- **Reviewer:** OpenClaw/AA/EA peer review; evidence only.
+- **Conductor verifier:** the session responsible for final LifeOS truth claim.
+
+Separation invariant:
+
+- The same actor/session that authored the brief cannot be the sole conductor verification for high-risk triggered work.
+- Marcus-solo fallback: Hermes may act as conductor only if verification is a separate turn/session from the brief-writing worker/EA, uses direct source readback, records source hashes, and explicitly states `brief_author_session != conductor_verification_session` or `human_verified: true`.
+- Worker self-attestation cannot set `handoff_candidate: true`.
+
+## 5. Scope and non-goals
+
+### In scope for v0.3 implementation
+
+- Inert/local source intent manifest.
+- Versioned intent lexicon.
+- Deterministic extraction against that lexicon.
+- Brief-vs-source fidelity report.
+- Conductor verification artifact with no implementation authority.
+- Dry-run CLI.
+- False-positive and false-negative fixtures.
+
+### Out of scope / deferred
+
+- Runtime handoff blocking.
+- Production model-routing changes.
+- Full compression quarantine implementation.
+- External/public writes.
+- Credentials or automation activation.
+- Governance doc ratification.
+
+Compression follow-on must consume the raw-source-hash interface defined here; it must not renegotiate source identity.
+
+## 6. Precedence order
+
+Highest first:
+
+1. Current explicit CEO/founder instruction in the active work item or named feedback source.
+2. Current issue/PR acceptance criteria and latest explicit owner/conductor comment.
+3. Ratified architecture/governance documents.
+4. Current implementation plan/build packet.
+5. Older lessons, memory, style guides, prior preferences.
+6. Model priors and generic “best practice”.
+
+Lower-precedence material may add constraints only when it does not weaken, invert, omit, or reframe higher-precedence intent.
+
+Stale-lesson enforcement is deferred unless a concrete lesson corpus path is supplied. v0.3 must not emit fake `stale_lessons_violating: []` as if lessons were checked.
+
+## 7. Trigger policy
+
+### Full gate required
+
+Run the full gate when any condition is true:
+
+- Current CEO/founder feedback is present and high-authority.
+- Feedback contains destructive, absence, privacy, approval, channel, automation, pause, or reversibility constraints.
+- A worker/EA/autonomous build loop will receive a summarised brief.
+- A compression or summary layer sits between source and execution.
+- The task follows prior bad output/correction.
+
+### Warning-only terms
+
+These are warning-only only when no blocking intent class appears in the same source set:
+
+- simplify
+- minimal
+- not this
+- whole surface
+
+These become blocking softening/inversion terms when any absence/destructive source intent exists in the same source set:
+
+- polish
+- clean up
+- rework
+- iterate
+- preserve
+- retain
+- maintain existing
+- keep most
+- leave structure
+
+Index-case rule: if source says remove/delete/hide/start over, any brief framing the work as polish/cleanup/iteration is a blocking inversion unless it explicitly preserves the absence requirement.
+
+### No gate required
+
+Skip for routine low-risk edits with no high-authority feedback transformation, no worker handoff, no summary/compression layer, and deterministic local verification.
+
+## 8. Intent classes v0.3
+
+1. **Absence/destructive:** remove, delete, hide, strip, eliminate, no longer show, start from scratch.
+2. **Pause/no-execution:** do not implement yet, wait, pause, hold, stop.
+3. **Approval-before-action:** ask me first, before changing X, needs approval.
+4. **Privacy/externality:** keep private, do not send, no public post, internal only.
+5. **Reversibility:** reversible only, no destructive cleanup, no irreversible action.
+6. **Automation boundary:** no automation, no unattended trigger, supervised only.
+7. **Channel/source authority:** use GitHub only, use this doc, do not create another channel.
+8. **Scope minimisation:** minimum viable, no overbuilding, only X.
+9. **Softening/inversion:** polish, clean up, iterate, retain, preserve, maintain, keep most, leave structure, when conflicting with a blocking class.
+
+## 9. Determinism and lexicon model
+
+v0.3 is deterministic only within a closed, versioned lexicon.
+
+Required data file:
+
+- `runtime/data/intent_lexicon_v1.json`
+
+It must define:
+
+- intent class;
+- phrase patterns;
+- blocking vs warning default;
+- inversion terms;
+- negation/quote guards;
+- examples;
+- version.
+
+Semantic paraphrase beyond the lexicon is out of scope for v0.3. If the checker detects low-confidence conflict or unsupported paraphrase, it must emit `requires_conductor_review`, not silently pass.
+
+Determinism invariant: running the extractor twice on the same source bytes and same lexicon version must produce identical `IntentSpan`s.
+
+## 10. Source discovery rules
+
+### GitHub work
+
+Canonical discovery command shape:
+
+```bash
+gh issue view <issue> --repo <owner/repo> --json number,title,body,comments,labels,state,url,updatedAt
+
+gh pr view <pr> --repo <owner/repo> --json number,title,body,reviews,comments,files,headRefOid,baseRefName,url,updatedAt
+```
+
+If linked PRs/issues are discovered, their readback commands must also be recorded.
+
+Manifest must record:
+
+- exact command(s);
+- command output sha256 hash;
+- cutoff timestamp;
+- actor/session;
+- which source classes were excluded and why.
+
+### Local/Obsidian/Drive work
+
+Canonical discovery must record:
+
+- exact path/URI;
+- retrieval method;
+- raw bytes/content hash;
+- last-modified timestamp if available;
+- source-of-source hash for transcripts or derived text.
+
+Named high-authority source missing = fail closed unless Marcus/conductor explicitly marks it non-required.
+
+Completeness invariant: triggered work must include at least one externally retrieved source (`retrieval_method != self`) unless the source is the current chat message from Marcus and that message hash is recorded.
+
+## 11. Brief target invariant
+
+The gate must name exactly what artifact is being checked.
+
+Allowed `brief_type` values:
+
+- `worker_prompt`
+- `dispatch_packet`
+- `build_packet`
+- `implementation_plan`
+- `pr_body`
+- `issue_comment`
+- `closure_packet`
+- `other`
+
+A pass for one brief does not transfer to another brief unless hashes match.
+
+## 12. Required artifacts
+
+### `intent_source_manifest.v1`
+
+```yaml
+schema_version: intent_source_manifest.v1
+work_item_id: string
+lexicon_version: string
+created_at: iso8601
+created_by: conductor|worker|ea|tool
+source_discovery:
+  mode: github|local_file|google_doc|obsidian|chat|mixed
+  commands_or_uris: []
+  command_output_hashes_sha256: []
+  cutoff_timestamp: iso8601
+  completeness_claimed_by: conductor|worker|ea|tool
+sources:
+  - source_id: string
+    source_type: issue_body|issue_comment|pr_review|pr_comment|local_file|google_doc|obsidian_note|chat|plan|ratified_doc|transcript
+    uri: string
+    retrieved_at: iso8601
+    retrieval_method: string
+    content_hash_sha256: string
+    source_of_source_hash_sha256: string|null
+    authority_tier: current_ceo_instruction|acceptance_criteria|ratified_doc|plan|lesson|memory|other
+    extracted_intents:
+      - intent_class: absence|pause|approval_before_action|privacy|reversibility|automation_boundary|channel_authority|scope_minimisation|softening_inversion|other
+        phrase: string
+        line_or_offset: string
+        surrounding_context: string
+        blocking_strength: blocking|warning|requires_conductor_review
+missing_sources:
+  - expected_source: string
+    reason_missing: string
+    disposition: fail_closed|not_required
+```
+
+### `intent_fidelity_report.v1`
+
+Deterministic/tool findings only.
+
+```yaml
+schema_version: intent_fidelity_report.v1
+work_item_id: string
+brief_type: worker_prompt|dispatch_packet|build_packet|implementation_plan|pr_body|issue_comment|closure_packet|other
+brief_uri: string
+brief_hash_sha256: string
+source_manifest_uri: string
+decision: pass|fail_closed|requires_ceo_clarification|requires_conductor_review|warning_only
+checks:
+  source_coverage:
+    status: pass|fail
+    missing_required_sources: []
+  verbatim_preservation:
+    status: pass|fail
+    source_intents_total: integer
+    source_intents_preserved_or_mapped: integer
+    missing_intents: []
+  intent_inversion:
+    status: pass|fail
+    inversions: []
+  hedge_or_softening:
+    status: pass|warn|fail
+    findings: []
+  contradiction_detection:
+    status: pass|fail|requires_ceo_clarification
+    contradictions: []
+  false_positive_fixtures_passed: integer
+  determinism_check:
+    status: pass|fail
+```
+
+### `intent_review_report.v1`
+
+Reviewer evidence only.
+
+```yaml
+schema_version: intent_review_report.v1
+work_item_id: string
+reviewer_surface: openclaw|aa|ea|other
+reviewer_session: string
+verdict: reject|amend|approve
+findings:
+  - severity: p0|p1|p2|note
+    title: string
+    recommendation: string
+authority_note: reviewer_output_is_evidence_only
+```
+
+### `conductor_fidelity_verification.v1`
+
+Only this artifact can mark the checked brief as a handoff candidate.
+
+```yaml
+schema_version: conductor_fidelity_verification.v1
+work_item_id: string
+brief_type: string
+brief_hash_sha256: string
+brief_author_session: string
+conductor_verification_session: string
+source_manifest_hash_sha256: string
+fidelity_report_hash_sha256: string
+conductor_independently_confirmed: true
+fidelity_status: preserved_intent|not_preserved|needs_clarification|requires_review|warning_only
+handoff_candidate: boolean
+implementation_authority_granted: false
+required_next_gate: none|dispatch_gate|ceo_clarification|ceo_approval|repo_gate|runtime_gate
+forbidden_next_steps:
+  - implementation_without_reload
+  - additive_or_polish_framing_if_source_requires_absence
+  - reviewer_output_as_authority
+  - compression_as_canonical_memory
+verified_by: conductor
+verified_at: iso8601
+```
+
+## 13. Brief construction requirements
+
+Triggered briefs must include:
+
+```markdown
+## Source Intent — Verbatim Requirements
+- `<exact phrase>` — source: `<source_id>` — intent class: `<class>` — implementation meaning: `<plain-language requirement>`
+
+## Absence / Boundary Requirements
+- Requirement: `<what must be absent/forbidden/not done>`
+- Verification: `<how absence or boundary will be checked>`
+
+## Explicit Non-Softening Clause
+- This brief does not convert removal/deletion/absence intent into polish, cleanup, iteration, preserve, retain, or additive-only work.
+
+## Contradictions / Ambiguities
+- `<none>` or exact contradiction requiring CEO clarification
+
+## Handoff Boundary
+- Fidelity pass does not grant implementation authority.
+- Required next gate: `<dispatch/repo/CEO/runtime/etc>`
+```
+
+## 14. Gate algorithm
+
+1. Discover active sources using canonical commands/URIs.
+2. Hash raw command output/source bytes.
+3. Load `intent_lexicon_v1.json`.
+4. Extract intent spans.
+5. Run determinism check: same bytes + lexicon => same spans.
+6. Classify spans as blocking, warning, or requires conductor review.
+7. Identify the exact `brief_type`, `brief_uri`, and brief hash.
+8. Check verbatim preservation or explicit intent mapping.
+9. Check inversion:
+   - preserve/additive-only/polish/cleanup/iteration against absence/destructive intent;
+   - implement/start against pause intent;
+   - external/public against privacy intent;
+   - autonomous/unattended against no-automation intent;
+   - new channel/source against channel-authority intent.
+10. Check negation, historical, hypothetical, and third-party quote guards to reduce false positives.
+11. Emit deterministic report.
+12. Conductor verifies source completeness and report decision independently from reviewer verdicts.
+13. Only conductor verification may mark `handoff_candidate: true`.
+
+## 15. Bypass policy
+
+Bypass is not allowed for privacy/externality, destructive/irreversible, automation-boundary, or approval-before-action blocking classes without CEO approval.
+
+Conductor-level bypass is limited to warning-only or known false-positive cases.
+
+```yaml
+schema_version: intent_fidelity_bypass.v1
+work_item_id: string
+requested_by: string
+authorized_by: conductor|ceo
+reason: string
+sources_skipped: []
+risk_accepted: string
+scope: string
+expires_at: iso8601 # must be <= 24h after created_at
+single_use: true
+not_authorized_for:
+  - external_send
+  - runtime_activation
+  - credential_change
+  - destructive_cleanup
+```
+
+Implementation must include a local bypass registry and expiry check before any bypass is honored.
+
+## 16. Audit-only graduation criteria
+
+Runtime blocking remains forbidden until an audit-only dogfood report shows:
+
+- at least 20 real brief/source pairs reviewed;
+- at least 3 destructive/absence cases;
+- at least 3 non-destructive boundary cases;
+- false-positive block rate ≤ 15%;
+- false-negative rate 0 on seeded known-bad cases;
+- at least one conductor-confirmed useful catch or a clear decision that the gate is too low-signal;
+- no unbounded CEO-clarification spam pattern.
+
+## 17. Implementation plan v0.3 — inert/local only
+
+### Task 1: Fixture corpus
+
+Create:
+
+- `runtime/tests/fixtures/intent_fidelity/v120_source.md`
+- `runtime/tests/fixtures/intent_fidelity/v120_bad_brief.md`
+- `runtime/tests/fixtures/intent_fidelity/v120_good_brief.md`
+- `runtime/tests/fixtures/intent_fidelity/non_destructive_source.md`
+- `runtime/tests/fixtures/intent_fidelity/non_destructive_bad_brief.md`
+- `runtime/tests/fixtures/intent_fidelity/false_positive_negation.md`
+- `runtime/tests/fixtures/intent_fidelity/false_positive_historical.md`
+- `runtime/tests/fixtures/intent_fidelity/false_positive_hypothetical.md`
+- `runtime/tests/fixtures/intent_fidelity/false_positive_third_party_quote.md`
+
+Verification: fixtures cover all intent classes and false-positive guards.
+
+### Task 2: Versioned lexicon
+
+Create:
+
+- `runtime/data/intent_lexicon_v1.json`
+- `runtime/tests/test_intent_lexicon.py`
+
+Verification:
+
+```bash
+pytest runtime/tests/test_intent_lexicon.py -q
+```
+
+Must include polish/cleanup/rework as blocking inversion terms when absence/destructive intent exists.
+
+### Task 3: JSON schemas
+
+Create:
+
+- `schemas/intent_source_manifest_v1.json`
+- `schemas/intent_fidelity_report_v1.json`
+- `schemas/intent_review_report_v1.json`
+- `schemas/conductor_fidelity_verification_v1.json`
+- `schemas/intent_fidelity_bypass_v1.json`
+
+Test:
+
+- `runtime/tests/test_intent_fidelity_schemas.py`
+
+Verification:
+
+```bash
+pytest runtime/tests/test_intent_fidelity_schemas.py -q
+```
+
+### Task 4: Extractor
+
+Create:
+
+- `runtime/orchestration/intent_fidelity.py`
+- `runtime/tests/test_intent_fidelity_extractor.py`
+
+Core API:
+
+```python
+def extract_intents(text: str, source_id: str, lexicon: IntentLexicon) -> list[IntentSpan]:
+    ...
+```
+
+Verification: boundary matching, case folding, deterministic rerun, false-positive guards.
+
+### Task 5: Manifest builder
+
+Modify/create:
+
+- `runtime/orchestration/intent_fidelity.py`
+- `runtime/tests/test_intent_source_manifest.py`
+
+Verification: missing named high-authority source fails closed; present source includes raw hash, retrieval method, source-of-source hash when derived, extracted intents.
+
+### Task 6: Fidelity checker
+
+Modify/create:
+
+- `runtime/orchestration/intent_fidelity.py`
+- `runtime/tests/test_intent_fidelity_checker.py`
+
+Verification:
+
+- v120 bad brief fails because polish/additive/preserve framing softens destructive intent;
+- v120 good brief passes;
+- non-destructive boundary inversions fail;
+- ambiguous broad terms warn only when no blocking class exists;
+- unsupported paraphrase emits `requires_conductor_review`.
+
+### Task 7: Conductor verification and bypass registry
+
+Create:
+
+- `runtime/receipts/intent_fidelity.py`
+- `runtime/tests/test_intent_fidelity_verification.py`
+- `runtime/tests/test_intent_fidelity_bypass.py`
+
+Verification:
+
+- `implementation_authority_granted` always false;
+- `handoff_candidate` true only with separate conductor verification;
+- bypass expires ≤24h and is single-use;
+- bypass cannot cover CEO-only classes without CEO approval ref.
+
+### Task 8: CLI dry-run
+
+Add after codebase discovery:
+
+```bash
+python3 -m lifeos intent-fidelity check --source <source.md> --brief <brief.md> --brief-type worker_prompt --json
+```
+
+Verification:
+
+- bad brief exits nonzero with JSON report;
+- good brief exits zero;
+- no repo/runtime mutation.
+
+## 18. Deferred sibling work
+
+1. Runtime handoff blocking after audit-only graduation.
+2. Compression quarantine consuming `source_of_source_hash_sha256` and source manifest hashes.
+3. Real-input model variance bench over LifeOS source/brief pairs.
+4. Governance/doc promotion after implementation evidence.
+
+## 19. Review integration summary
+
+OpenClaw found v0.1 over-fitted and too broad. v0.2 broadened to intent fidelity, separated authority, added source discovery, warning-only mode, and deferred compression/routing.
+
+AA found v0.2 still had P0s: polish warning-only reproduced v120, deterministic semantics were overstated, and conductor identity was undefined. v0.3 fixes those by promoting polish/cleanup/rework to blocking in destructive contexts, requiring a versioned lexicon with determinism tests, adding conductor/session separation, pinning discovery hashes, capping bypass, and adding audit-only graduation metrics.
+
+## 20. COO recommendation
+
+Implement only v0.3 inert/local tasks. Do not activate runtime blocking, compression quarantine, or model-routing changes until audit-only graduation criteria pass and a separate CEO/dispatch gate approves the next phase.

--- a/lifeos/__init__.py
+++ b/lifeos/__init__.py
@@ -1,0 +1,1 @@
+"""LifeOS module shim for `python -m lifeos`."""

--- a/lifeos/__main__.py
+++ b/lifeos/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from runtime.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,14 @@ requires-python = ">=3.11"
 lifeos = "runtime.cli:main"
 
 [tool.setuptools]
-packages = ["runtime", "recursive_kernel", "doc_steward", "opencode_governance", "project_builder"]
+packages = [
+    "lifeos",
+    "runtime",
+    "recursive_kernel",
+    "doc_steward",
+    "opencode_governance",
+    "project_builder",
+]
 
 [tool.pytest.ini_options]
 # Merged configuration from pytest.ini and doc_steward/scripts/pyproject.toml

--- a/runtime/cli.py
+++ b/runtime/cli.py
@@ -121,6 +121,101 @@ def cmd_certify_ops(args: argparse.Namespace, repo_root: Path) -> int:
     return result.returncode
 
 
+def cmd_intent_fidelity_check(args: argparse.Namespace, repo_root: Path) -> int:
+    """Run inert Founder Intent Fidelity dry-run check."""
+    from dataclasses import asdict
+
+    from runtime.orchestration.intent_fidelity import (
+        build_source_manifest,
+        check_fidelity,
+        fidelity_report_to_dict,
+        hash_text,
+        load_lexicon,
+        manifest_to_dict,
+    )
+    from runtime.receipts.intent_fidelity import build_conductor_verification
+
+    source_path = Path(args.source)
+    brief_path = Path(args.brief)
+    if not source_path.exists():
+        print(f"Error: source file not found: {source_path}", file=sys.stderr)
+        return 1
+    if not brief_path.exists():
+        print(f"Error: brief file not found: {brief_path}", file=sys.stderr)
+        return 1
+
+    source_text = source_path.read_text(encoding="utf-8")
+    brief_text = brief_path.read_text(encoding="utf-8")
+    lexicon = load_lexicon(repo_root / "runtime" / "data" / "intent_lexicon_v1.json")
+
+    manifest = build_source_manifest(
+        work_item_id=source_path.stem,
+        lexicon_version=lexicon.data["version"],
+        source_discovery={
+            "mode": "local_file",
+            "commands_or_uris": [str(source_path)],
+            "command_output_hashes_sha256": [hash_text(source_text)],
+            "completeness_claimed_by": "tool",
+        },
+        sources=[
+            {
+                "source_id": source_path.stem,
+                "source_type": "local_file",
+                "uri": str(source_path),
+                "retrieval_method": "local_file",
+                "authority_tier": "current_ceo_instruction",
+                "content": source_text,
+            }
+        ],
+    )
+    report = check_fidelity(brief_text, args.brief_type, manifest, lexicon)
+    manifest_payload = manifest_to_dict(manifest)
+    report_payload = fidelity_report_to_dict(report)
+    source_manifest_hash = hash_text(_canonical_json(manifest_payload))
+    fidelity_report_hash = hash_text(_canonical_json(report_payload))
+    fidelity_status = {
+        "pass": "preserved_intent",
+        "warning_only": "warning_only",
+        "fail_closed": "not_preserved",
+        "requires_ceo_clarification": "needs_clarification",
+        "requires_conductor_review": "requires_review",
+    }[report.decision]
+    verification = build_conductor_verification(
+        work_item_id=manifest.work_item_id,
+        brief_type=args.brief_type,
+        brief_hash=report.brief_hash_sha256,
+        brief_author_session="cli-brief-author",
+        conductor_session="cli-conductor-dry-run",
+        source_manifest_hash=source_manifest_hash,
+        fidelity_report_hash=fidelity_report_hash,
+        fidelity_status=fidelity_status,
+    )
+    verification_payload = asdict(verification)
+    payload = {
+        "schema_version": "intent_fidelity_cli_dry_run.v1",
+        "dry_run": True,
+        "implementation_authority_granted": False,
+        "source_manifest": manifest_payload,
+        "fidelity_report": report_payload,
+        "conductor_verification": verification_payload,
+    }
+
+    allowed = report.decision in {"pass", "warning_only"}
+    if args.json:
+        print(_canonical_json(payload))
+    else:
+        print(f"intent_fidelity_decision: {report.decision}")
+        print(f"brief_hash_sha256: {report.brief_hash_sha256}")
+        print(f"source_manifest_hash_sha256: {source_manifest_hash}")
+        print(f"handoff_candidate: {verification.handoff_candidate}")
+        print("implementation_authority_granted: false")
+        for name, check in report.checks.items():
+            print(f"{name}: {check.status}")
+            for detail in check.details:
+                print(f"  - {detail}")
+    return 0 if allowed else 1
+
+
 def _baseline_commit(repo_root: Path) -> str | None:
     try:
         result = subprocess.run(
@@ -1120,6 +1215,37 @@ def main() -> int:
     )
     p_certify_ops.add_argument("--profile", choices=("local", "ci", "live"), required=True)
 
+    # intent-fidelity group (Founder Intent Fidelity Gate v0.3 dry-run)
+    p_intent_fidelity = subparsers.add_parser(
+        "intent-fidelity",
+        help="Founder Intent Fidelity Gate dry-run commands",
+    )
+    intent_fidelity_subs = p_intent_fidelity.add_subparsers(
+        dest="intent_fidelity_cmd",
+        required=True,
+    )
+    p_intent_fidelity_check = intent_fidelity_subs.add_parser(
+        "check",
+        help="Check a brief against a source file without granting authority",
+    )
+    p_intent_fidelity_check.add_argument("--source", required=True, help="Path to source file")
+    p_intent_fidelity_check.add_argument("--brief", required=True, help="Path to brief file")
+    p_intent_fidelity_check.add_argument(
+        "--brief-type",
+        required=True,
+        choices=(
+            "worker_prompt",
+            "dispatch_packet",
+            "build_packet",
+            "implementation_plan",
+            "pr_body",
+            "issue_comment",
+            "closure_packet",
+            "other",
+        ),
+    )
+    p_intent_fidelity_check.add_argument("--json", action="store_true", help="Output as JSON")
+
     # coo group
     p_coo = subparsers.add_parser("coo", help="COO orchestration commands")
     coo_subs = p_coo.add_subparsers(dest="coo_cmd", required=True)
@@ -1360,6 +1486,10 @@ def main() -> int:
                 return cmd_certify_pipeline(args, repo_root)
             if args.certify_cmd == "ops":
                 return cmd_certify_ops(args, repo_root)
+
+        if args.subcommand == "intent-fidelity":
+            if args.intent_fidelity_cmd == "check":
+                return cmd_intent_fidelity_check(args, repo_root)
 
         if args.subcommand == "coo":
             from runtime.orchestration.coo import commands as coo_commands

--- a/runtime/data/intent_lexicon_v1.json
+++ b/runtime/data/intent_lexicon_v1.json
@@ -1,0 +1,237 @@
+{
+  "schema_version": "intent_lexicon_v1",
+  "version": "1.0.0",
+  "intent_classes": [
+    {
+      "class": "absence",
+      "phrases": [
+        "remove",
+        "delete",
+        "hide",
+        "strip",
+        "eliminate",
+        "no longer show",
+        "start from scratch",
+        "start over"
+      ],
+      "default_blocking": "blocking",
+      "inversion_terms": [
+        "polish",
+        "clean up",
+        "rework",
+        "iterate",
+        "preserve",
+        "retain",
+        "maintain existing",
+        "keep most",
+        "leave structure"
+      ],
+      "negation_guards": [
+        "do not remove",
+        "do not delete",
+        "do not hide",
+        "not remove",
+        "not delete"
+      ],
+      "examples": []
+    },
+    {
+      "class": "pause",
+      "phrases": [
+        "do not implement yet",
+        "wait",
+        "pause",
+        "hold",
+        "stop",
+        "not yet"
+      ],
+      "default_blocking": "blocking",
+      "inversion_terms": [
+        "implement",
+        "start",
+        "begin work",
+        "proceed",
+        "go ahead"
+      ],
+      "negation_guards": [
+        "not pausing",
+        "do not pause",
+        "not waiting"
+      ],
+      "examples": []
+    },
+    {
+      "class": "approval_before_action",
+      "phrases": [
+        "ask me first",
+        "before changing",
+        "needs approval",
+        "check with me",
+        "confirm first",
+        "must approve"
+      ],
+      "default_blocking": "blocking",
+      "inversion_terms": [
+        "proceed without asking",
+        "assume approval",
+        "go ahead"
+      ],
+      "negation_guards": [
+        "does not need approval",
+        "no approval needed",
+        "do not ask"
+      ],
+      "examples": []
+    },
+    {
+      "class": "privacy",
+      "phrases": [
+        "keep private",
+        "do not send",
+        "no public post",
+        "internal only",
+        "do not share externally",
+        "confidential"
+      ],
+      "default_blocking": "blocking",
+      "inversion_terms": [
+        "share publicly",
+        "post externally",
+        "publish",
+        "make public",
+        "send to"
+      ],
+      "negation_guards": [
+        "not private",
+        "can be shared",
+        "do not keep private"
+      ],
+      "examples": []
+    },
+    {
+      "class": "reversibility",
+      "phrases": [
+        "reversible only",
+        "no destructive cleanup",
+        "no irreversible action",
+        "must be undoable",
+        "safe to revert"
+      ],
+      "default_blocking": "blocking",
+      "inversion_terms": [
+        "irreversible",
+        "permanent",
+        "destructive cleanup",
+        "cannot be undone"
+      ],
+      "negation_guards": [
+        "not required to be reversible",
+        "irreversible ok"
+      ],
+      "examples": []
+    },
+    {
+      "class": "automation_boundary",
+      "phrases": [
+        "no automation",
+        "no unattended trigger",
+        "supervised only",
+        "do not automate",
+        "manual only"
+      ],
+      "default_blocking": "blocking",
+      "inversion_terms": [
+        "automate",
+        "unattended",
+        "schedule automatically",
+        "trigger without check"
+      ],
+      "negation_guards": [
+        "allow automation",
+        "automation ok",
+        "automation is fine"
+      ],
+      "examples": []
+    },
+    {
+      "class": "channel_authority",
+      "phrases": [
+        "use github only",
+        "use this doc",
+        "do not create another channel",
+        "stick to",
+        "only use"
+      ],
+      "default_blocking": "warning",
+      "inversion_terms": [
+        "new channel",
+        "different platform",
+        "another tool"
+      ],
+      "negation_guards": [],
+      "examples": []
+    },
+    {
+      "class": "scope_minimisation",
+      "phrases": [
+        "minimum viable",
+        "no overbuilding",
+        "only x",
+        "just the basics",
+        "smallest possible",
+        "simplest"
+      ],
+      "default_blocking": "warning",
+      "inversion_terms": [
+        "full featured",
+        "comprehensive",
+        "all the bells",
+        "complete rewrite",
+        "robust"
+      ],
+      "negation_guards": [
+        "not minimal",
+        "do more than minimal",
+        "expand scope"
+      ],
+      "examples": []
+    },
+    {
+      "class": "softening_inversion",
+      "phrases": [
+        "polish",
+        "clean up",
+        "iterate",
+        "retain",
+        "preserve",
+        "maintain existing",
+        "keep most",
+        "leave structure",
+        "rework"
+      ],
+      "default_blocking": "warning",
+      "inversion_terms": [],
+      "negation_guards": [],
+      "context_becomes_blocking_when": "absence intent exists in same source set",
+      "examples": []
+    }
+  ],
+  "false_positive_guards": {
+    "negation": {
+      "enabled": true,
+      "description": "Skip phrase match if immediately preceded by 'not', 'no', 'never', 'don't', 'do not', 'does not', 'did not', 'won't' within 5 characters before the phrase."
+    },
+    "historical": {
+      "enabled": true,
+      "description": "Skip phrase match if preceded by 'previously', 'before', 'used to', 'was', 'were', 'had', 'past', 'originally', 'earlier', 'once', 'former' within 15 characters before the phrase."
+    },
+    "hypothetical": {
+      "enabled": true,
+      "description": "Skip phrase match if preceded by 'if', 'what if', 'suppose', 'imagine', 'might', 'could', 'would', 'maybe', 'perhaps', 'consider', 'option' within 20 characters before the phrase."
+    },
+    "third_party_quote": {
+      "enabled": true,
+      "description": "Skip phrase match if the match falls within a quotation block (text between matching \"...\" or '...' delimiters) and the surrounding context does not indicate adoption of the quoted intent."
+    }
+  }
+}

--- a/runtime/data/intent_lexicon_v1.json
+++ b/runtime/data/intent_lexicon_v1.json
@@ -53,11 +53,7 @@
         "proceed",
         "go ahead"
       ],
-      "negation_guards": [
-        "not pausing",
-        "do not pause",
-        "not waiting"
-      ],
+      "negation_guards": ["not pausing", "do not pause", "not waiting"],
       "examples": []
     },
     {
@@ -124,10 +120,7 @@
         "destructive cleanup",
         "cannot be undone"
       ],
-      "negation_guards": [
-        "not required to be reversible",
-        "irreversible ok"
-      ],
+      "negation_guards": ["not required to be reversible", "irreversible ok"],
       "examples": []
     },
     {
@@ -163,11 +156,7 @@
         "only use"
       ],
       "default_blocking": "warning",
-      "inversion_terms": [
-        "new channel",
-        "different platform",
-        "another tool"
-      ],
+      "inversion_terms": ["new channel", "different platform", "another tool"],
       "negation_guards": [],
       "examples": []
     },

--- a/runtime/orchestration/intent_fidelity.py
+++ b/runtime/orchestration/intent_fidelity.py
@@ -1,0 +1,682 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+VALID_BLOCKING_STRENGTHS = {"blocking", "warning", "requires_conductor_review"}
+VALID_BRIEF_TYPES = {
+    "worker_prompt",
+    "dispatch_packet",
+    "build_packet",
+    "implementation_plan",
+    "pr_body",
+    "issue_comment",
+    "closure_packet",
+    "other",
+}
+DEFAULT_LEXICON_PATH = Path(__file__).resolve().parents[1] / "data" / "intent_lexicon_v1.json"
+NON_DESTRUCTIVE_SOURCE_TERMS = ("add", "improve", "keep", "intact")
+NON_DESTRUCTIVE_INVERSION_TERMS = (
+    "gut",
+    "rewrite",
+    "replace",
+    "from scratch",
+    "start from scratch",
+    "start over",
+)
+
+
+@dataclass
+class IntentSpan:
+    intent_class: str
+    phrase: str
+    source_id: str
+    line_or_offset: str
+    surrounding_context: str
+    blocking_strength: str
+    guard_triggered: Optional[str] = None
+
+
+@dataclass
+class IntentLexicon:
+    data: dict
+
+    @classmethod
+    def load(cls, path: str | Path) -> "IntentLexicon":
+        """Load and validate the lexicon JSON file."""
+        lexicon_path = Path(path)
+        data = json.loads(lexicon_path.read_text(encoding="utf-8"))
+        if data.get("schema_version") != "intent_lexicon_v1":
+            raise ValueError("lexicon schema_version must be intent_lexicon_v1")
+        if not data.get("version"):
+            raise ValueError("lexicon version is required")
+        intent_classes = data.get("intent_classes")
+        if not isinstance(intent_classes, list) or not intent_classes:
+            raise ValueError("lexicon intent_classes must be a non-empty list")
+
+        required = {
+            "class",
+            "phrases",
+            "default_blocking",
+            "inversion_terms",
+            "negation_guards",
+        }
+        seen: set[str] = set()
+        for item in intent_classes:
+            missing = required - set(item)
+            if missing:
+                raise ValueError(f"intent class missing required fields: {sorted(missing)}")
+            if item["class"] in seen:
+                raise ValueError(f"duplicate intent class: {item['class']}")
+            seen.add(item["class"])
+            if item["default_blocking"] not in VALID_BLOCKING_STRENGTHS:
+                raise ValueError(f"invalid default_blocking: {item['default_blocking']}")
+            for list_field in ("phrases", "inversion_terms", "negation_guards"):
+                if not isinstance(item[list_field], list):
+                    raise ValueError(f"{item['class']}.{list_field} must be a list")
+        return cls(data=data)
+
+    def get_class(self, class_name: str) -> dict | None:
+        """Get an intent class definition by name."""
+        for item in self.data.get("intent_classes", []):
+            if item.get("class") == class_name:
+                return item
+        return None
+
+
+def load_lexicon(path: str | Path) -> IntentLexicon:
+    """Convenience wrapper for IntentLexicon.load()."""
+    return IntentLexicon.load(path)
+
+
+def _phrase_pattern(phrase: str) -> re.Pattern[str]:
+    escaped_parts = [re.escape(part) for part in phrase.split()]
+    body = r"\s+".join(escaped_parts)
+    return re.compile(rf"(?<![\w-]){body}(?![\w-])", re.IGNORECASE)
+
+
+def _line_or_offset(text: str, start: int) -> str:
+    line = text.count("\n", 0, start) + 1
+    previous_newline = text.rfind("\n", 0, start)
+    column = start + 1 if previous_newline == -1 else start - previous_newline
+    return f"line {line}, offset {column}"
+
+
+def _context(text: str, start: int, end: int, radius: int = 60) -> str:
+    return text[max(0, start - radius) : min(len(text), end + radius)].strip()
+
+
+def _indicator_before(text: str, start: int, indicators: tuple[str, ...], window: int) -> bool:
+    prefix = text[max(0, start - window) : start].lower()
+    prefix = re.sub(r"\s+", " ", prefix)
+    for indicator in indicators:
+        pattern = rf"(^|[\s,.;:!?]){re.escape(indicator)}([\s,.;:!?]|$)"
+        if re.search(pattern, prefix):
+            return True
+    return False
+
+
+def _guard_phrase_before_match(text: str, start: int, end: int, guard_phrases: list[str]) -> bool:
+    window = text[max(0, start - 40) : end].lower()
+    normalized = re.sub(r"\s+", " ", window)
+    return any(guard.lower() in normalized for guard in guard_phrases)
+
+
+def _inside_quote(text: str, position: int) -> bool:
+    active_quote: str | None = None
+    escaped = False
+    for index, char in enumerate(text[:position]):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char not in {"'", '"'}:
+            continue
+        if char == "'" and 0 < index < len(text) - 1:
+            if text[index - 1].isalnum() and text[index + 1].isalnum():
+                continue
+        if active_quote == char:
+            active_quote = None
+        elif active_quote is None:
+            active_quote = char
+    return active_quote is not None
+
+
+def _triggered_guard(
+    text: str,
+    start: int,
+    end: int,
+    class_def: dict,
+) -> str | None:
+    if _guard_phrase_before_match(text, start, end, class_def.get("negation_guards", [])):
+        return "negation"
+    if _indicator_before(
+        text,
+        start,
+        ("not", "no", "never", "don't", "do not", "does not", "did not", "won't"),
+        24,
+    ):
+        return "negation"
+    if _indicator_before(
+        text,
+        start,
+        (
+            "previously",
+            "before",
+            "used to",
+            "was",
+            "were",
+            "had",
+            "past",
+            "originally",
+            "earlier",
+            "once",
+            "former",
+        ),
+        32,
+    ):
+        return "historical"
+    if _indicator_before(
+        text,
+        start,
+        (
+            "if",
+            "what if",
+            "suppose",
+            "imagine",
+            "might",
+            "could",
+            "would",
+            "maybe",
+            "perhaps",
+            "consider",
+            "option",
+        ),
+        32,
+    ):
+        return "hypothetical"
+    if _inside_quote(text, start):
+        return "third_party_quote"
+    return None
+
+
+def extract_intents(text: str, source_id: str, lexicon: IntentLexicon) -> list[IntentSpan]:
+    """
+    Extract intent spans from text using the given lexicon.
+
+    Guarded matches are suppressed from output. Same text and lexicon version produce
+    identical span lists.
+    """
+    if not text:
+        return []
+
+    collected: list[tuple[int, str, str, IntentSpan]] = []
+    for class_def in lexicon.data.get("intent_classes", []):
+        intent_class = class_def["class"]
+        for phrase in class_def["phrases"]:
+            for match in _phrase_pattern(phrase).finditer(text):
+                guard = _triggered_guard(text, match.start(), match.end(), class_def)
+                if guard:
+                    continue
+                span = IntentSpan(
+                    intent_class=intent_class,
+                    phrase=phrase,
+                    source_id=source_id,
+                    line_or_offset=_line_or_offset(text, match.start()),
+                    surrounding_context=_context(text, match.start(), match.end()),
+                    blocking_strength=class_def["default_blocking"],
+                    guard_triggered=None,
+                )
+                collected.append((match.start(), intent_class, phrase, span))
+
+    collected.sort(key=lambda item: (item[0], item[1], item[2]))
+    spans = [item[3] for item in collected]
+    absence_exists = any(span.intent_class == "absence" for span in spans)
+    if absence_exists:
+        for span in spans:
+            if span.intent_class == "softening_inversion":
+                span.blocking_strength = "blocking"
+    return spans
+
+
+def hash_text(text: str) -> str:
+    """SHA-256 hash of text content."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def determinism_check(text: str, lexicon: IntentLexicon) -> bool:
+    """Run extraction twice on same input and verify results match."""
+    first = [asdict(span) for span in extract_intents(text, "determinism", lexicon)]
+    second = [asdict(span) for span in extract_intents(text, "determinism", lexicon)]
+    return first == second
+
+
+@dataclass
+class SourceManifest:
+    schema_version: str
+    work_item_id: str
+    lexicon_version: str
+    created_at: str
+    created_by: str
+    source_discovery: dict
+    sources: list[dict]
+    missing_sources: list[dict]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _validate_sha256(value: str, field_name: str) -> None:
+    if not re.fullmatch(r"[0-9a-f]{64}", value):
+        raise ValueError(f"{field_name} must be a SHA-256 hex string")
+
+
+def _intent_to_dict(intent: IntentSpan | dict) -> dict:
+    if isinstance(intent, IntentSpan):
+        return asdict(intent)
+    return {
+        "intent_class": intent["intent_class"],
+        "phrase": intent["phrase"],
+        "source_id": intent.get("source_id"),
+        "line_or_offset": intent["line_or_offset"],
+        "surrounding_context": intent["surrounding_context"],
+        "blocking_strength": intent["blocking_strength"],
+        "guard_triggered": intent.get("guard_triggered"),
+    }
+
+
+def _normalise_source_discovery(source_discovery: dict, created_at: str) -> dict:
+    return {
+        "mode": source_discovery.get("mode", "local_file"),
+        "commands_or_uris": list(source_discovery.get("commands_or_uris", [])),
+        "command_output_hashes_sha256": list(
+            source_discovery.get("command_output_hashes_sha256", [])
+        ),
+        "cutoff_timestamp": source_discovery.get("cutoff_timestamp", created_at),
+        "completeness_claimed_by": source_discovery.get("completeness_claimed_by", "tool"),
+    }
+
+
+def build_source_manifest(
+    work_item_id: str,
+    lexicon_version: str,
+    source_discovery: dict,
+    sources: list[dict],
+    missing_sources: list[dict] | None = None,
+    created_by: str = "tool",
+) -> SourceManifest:
+    """
+    Build a source manifest from discovered sources and extracted intents.
+
+    Source dictionaries may include private `content` or `text` keys for local extraction.
+    Those bytes are hashed and retained only in-memory as `_content`; serialization strips
+    private keys.
+    """
+    created_at = _now_iso()
+    lexicon = load_lexicon(DEFAULT_LEXICON_PATH)
+    normalised_sources: list[dict] = []
+
+    for index, source in enumerate(sources, start=1):
+        source_id = source.get("source_id", f"source-{index}")
+        content = str(source.get("content", source.get("text", "")))
+        content_hash = source.get("content_hash_sha256") or hash_text(content)
+        _validate_sha256(content_hash, "content_hash_sha256")
+
+        source_of_source_hash = source.get("source_of_source_hash_sha256")
+        if source_of_source_hash is not None:
+            _validate_sha256(source_of_source_hash, "source_of_source_hash_sha256")
+        if source.get("retrieval_method") == "primary" and source_of_source_hash is not None:
+            raise ValueError("source_of_source_hash_sha256 must be null for primary sources")
+
+        extracted = source.get("extracted_intents")
+        if extracted is None and content:
+            extracted = extract_intents(content, source_id, lexicon)
+        extracted_dicts = [_intent_to_dict(intent) for intent in extracted or []]
+
+        normalised = {
+            "source_id": source_id,
+            "source_type": source.get("source_type", "local_file"),
+            "uri": source.get("uri", source_id),
+            "retrieved_at": source.get("retrieved_at", created_at),
+            "retrieval_method": source.get("retrieval_method", "local_file"),
+            "content_hash_sha256": content_hash,
+            "source_of_source_hash_sha256": source_of_source_hash,
+            "authority_tier": source.get("authority_tier", "current_ceo_instruction"),
+            "extracted_intents": extracted_dicts,
+        }
+        if content:
+            normalised["_content"] = content
+        normalised_sources.append(normalised)
+
+    return SourceManifest(
+        schema_version="intent_source_manifest.v1",
+        work_item_id=work_item_id,
+        lexicon_version=lexicon_version,
+        created_at=created_at,
+        created_by=created_by,
+        source_discovery=_normalise_source_discovery(source_discovery, created_at),
+        sources=normalised_sources,
+        missing_sources=list(missing_sources or []),
+    )
+
+
+def manifest_to_dict(manifest: SourceManifest) -> dict:
+    """Convert manifest to serializable dict."""
+    payload = asdict(manifest)
+    payload["sources"] = [
+        {key: value for key, value in source.items() if not key.startswith("_")}
+        for source in payload["sources"]
+    ]
+    return payload
+
+
+def validate_manifest_completeness(manifest: SourceManifest) -> tuple[bool, list[str]]:
+    """
+    Validate source completeness.
+    Returns (is_complete, issues_list).
+    Fails closed if any missing_source has disposition "fail_closed".
+    """
+    issues: list[str] = []
+    for missing in manifest.missing_sources:
+        if missing.get("disposition") == "fail_closed":
+            expected = missing.get("expected_source", "unknown source")
+            reason = missing.get("reason_missing", "missing")
+            issues.append(f"missing required source: {expected} ({reason})")
+    return not issues, issues
+
+
+@dataclass
+class FidelityCheck:
+    """Result of a single check within the fidelity report."""
+
+    status: str
+    details: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FidelityReport:
+    schema_version: str
+    work_item_id: str
+    brief_type: str
+    brief_hash_sha256: str
+    source_manifest_uri: str
+    decision: str
+    checks: dict
+    false_positive_fixtures_passed: int = 0
+
+
+def _span_from_dict(payload: dict) -> IntentSpan:
+    return IntentSpan(
+        intent_class=payload["intent_class"],
+        phrase=payload["phrase"],
+        source_id=payload.get("source_id") or "",
+        line_or_offset=payload["line_or_offset"],
+        surrounding_context=payload["surrounding_context"],
+        blocking_strength=payload["blocking_strength"],
+        guard_triggered=payload.get("guard_triggered"),
+    )
+
+
+def _source_intents(manifest: SourceManifest) -> list[IntentSpan]:
+    spans: list[IntentSpan] = []
+    for source in manifest.sources:
+        for intent in source.get("extracted_intents", []):
+            spans.append(_span_from_dict(intent))
+    return spans
+
+
+def _source_text(manifest: SourceManifest) -> str:
+    return "\n".join(source.get("_content", "") for source in manifest.sources)
+
+
+def _contains_any(text: str, terms: list[str] | tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(term in lowered for term in terms)
+
+
+def _inversion_term_spans(
+    brief_text: str,
+    source_intents: list[IntentSpan],
+    lexicon: IntentLexicon,
+) -> list[IntentSpan]:
+    terms: set[str] = set(NON_DESTRUCTIVE_INVERSION_TERMS)
+    for source_intent in source_intents:
+        class_def = lexicon.get_class(source_intent.intent_class)
+        if class_def:
+            terms.update(class_def.get("inversion_terms", []))
+
+    spans: list[IntentSpan] = []
+    for term in sorted(terms):
+        if term and term in brief_text.lower():
+            start = brief_text.lower().find(term)
+            spans.append(
+                IntentSpan(
+                    intent_class="inversion_term",
+                    phrase=term,
+                    source_id="brief",
+                    line_or_offset=_line_or_offset(brief_text, start),
+                    surrounding_context=_context(brief_text, start, start + len(term)),
+                    blocking_strength="requires_conductor_review",
+                )
+            )
+    return spans
+
+
+def check_inversion(
+    source_intents: list[IntentSpan],
+    brief_intents: list[IntentSpan],
+    lexicon: IntentLexicon,
+) -> FidelityCheck:
+    """
+    Check if the brief inverts any source intents.
+
+    If source says remove/delete/hide/start over, polish/cleanup/iteration framing is a
+    blocking inversion unless the brief explicitly preserves the absence requirement.
+    """
+    details: list[str] = []
+    brief_classes = {span.intent_class for span in brief_intents}
+    brief_terms = " ".join(
+        f"{span.phrase} {span.surrounding_context}" for span in brief_intents
+    ).lower()
+
+    for source_intent in source_intents:
+        if source_intent.blocking_strength != "blocking":
+            continue
+        class_def = lexicon.get_class(source_intent.intent_class)
+        if not class_def:
+            continue
+        inversion_terms = class_def.get("inversion_terms", [])
+        inverted_terms = [term for term in inversion_terms if term in brief_terms]
+        if not inverted_terms:
+            continue
+        if source_intent.intent_class == "absence" and "absence" in brief_classes:
+            continue
+        details.append(
+            "blocking inversion: "
+            f"{source_intent.intent_class} source intent '{source_intent.phrase}' "
+            f"reframed by {sorted(inverted_terms)}"
+        )
+
+    return FidelityCheck(status="fail" if details else "pass", details=details)
+
+
+def _verbatim_preservation_check(
+    source_intents: list[IntentSpan],
+    brief_text: str,
+    brief_intents: list[IntentSpan],
+) -> FidelityCheck:
+    brief_lower = brief_text.lower()
+    brief_classes = {intent.intent_class for intent in brief_intents}
+    details: list[str] = []
+    preserved = 0
+    relevant = [
+        span for span in source_intents if span.blocking_strength in VALID_BLOCKING_STRENGTHS
+    ]
+
+    for source_intent in relevant:
+        phrase_preserved = source_intent.phrase.lower() in brief_lower
+        class_mapped = source_intent.intent_class in brief_classes
+        if phrase_preserved or class_mapped:
+            preserved += 1
+            continue
+        details.append(
+            f"missing mapped source intent: {source_intent.intent_class}:{source_intent.phrase}"
+        )
+
+    if not details:
+        return FidelityCheck(
+            status="pass",
+            details=[f"{preserved}/{len(relevant)} source intents preserved or mapped"],
+        )
+    if any(span.blocking_strength == "blocking" for span in relevant):
+        return FidelityCheck(status="requires_conductor_review", details=details)
+    return FidelityCheck(status="warn", details=details)
+
+
+def _hedge_or_softening_check(
+    source_intents: list[IntentSpan],
+    brief_intents: list[IntentSpan],
+) -> FidelityCheck:
+    softening = [
+        span.phrase for span in brief_intents if span.intent_class == "softening_inversion"
+    ]
+    if not softening:
+        return FidelityCheck(status="pass", details=[])
+    has_blocking_source = any(span.blocking_strength == "blocking" for span in source_intents)
+    status = "warn" if not has_blocking_source else "fail"
+    return FidelityCheck(status=status, details=[f"softening terms present: {sorted(softening)}"])
+
+
+def _contradiction_check(brief_text: str) -> FidelityCheck:
+    lowered = brief_text.lower()
+    if "do not remove" in lowered and re.search(r"(?<!do not )\bremove\b", lowered):
+        return FidelityCheck(
+            status="requires_ceo_clarification",
+            details=["brief contains both removal and do-not-remove language"],
+        )
+    return FidelityCheck(status="pass", details=[])
+
+
+def _false_positive_fixture_count(lexicon: IntentLexicon) -> int:
+    samples = {
+        "negation": "Do not remove the export button.",
+        "historical": "We previously remove the staging banner.",
+        "hypothetical": "If we remove the analytics tab, would it break?",
+        "third_party_quote": 'The reviewer said "they should delete this panel".',
+    }
+    count = 0
+    for name, sample in samples.items():
+        spans = extract_intents(sample, name, lexicon)
+        if not any(span.intent_class == "absence" for span in spans):
+            count += 1
+    return count
+
+
+def _decision_from_checks(checks: dict[str, FidelityCheck]) -> str:
+    statuses = {check.status for check in checks.values()}
+    if "fail" in statuses:
+        return "fail_closed"
+    if "requires_ceo_clarification" in statuses:
+        return "requires_ceo_clarification"
+    if "requires_conductor_review" in statuses:
+        return "requires_conductor_review"
+    if "warn" in statuses:
+        return "warning_only"
+    return "pass"
+
+
+def _non_destructive_boundary_check(
+    source_text_value: str,
+    brief_text: str,
+    source_intents: list[IntentSpan],
+) -> FidelityCheck:
+    if source_intents:
+        return FidelityCheck(status="pass", details=[])
+    if not _contains_any(source_text_value, NON_DESTRUCTIVE_SOURCE_TERMS):
+        return FidelityCheck(status="pass", details=[])
+    if _contains_any(brief_text, NON_DESTRUCTIVE_INVERSION_TERMS):
+        return FidelityCheck(
+            status="fail",
+            details=["non-destructive source reframed as gut/rewrite/from-scratch work"],
+        )
+    return FidelityCheck(status="pass", details=[])
+
+
+def check_fidelity(
+    brief_text: str,
+    brief_type: str,
+    source_manifest: SourceManifest,
+    lexicon: IntentLexicon,
+) -> FidelityReport:
+    """
+    Compare a brief against source intents.
+
+    This is a deterministic dry-run report. It does not grant implementation authority.
+    """
+    if brief_type not in VALID_BRIEF_TYPES:
+        raise ValueError(f"invalid brief_type: {brief_type}")
+
+    source_intents = _source_intents(source_manifest)
+    brief_intents = extract_intents(brief_text, "brief", lexicon)
+    brief_intents_for_inversion = brief_intents + _inversion_term_spans(
+        brief_text,
+        source_intents,
+        lexicon,
+    )
+
+    coverage_ok, coverage_issues = validate_manifest_completeness(source_manifest)
+    checks: dict[str, FidelityCheck] = {
+        "source_coverage": FidelityCheck(
+            status="pass" if coverage_ok else "fail",
+            details=coverage_issues,
+        ),
+        "verbatim_preservation": _verbatim_preservation_check(
+            source_intents,
+            brief_text,
+            brief_intents,
+        ),
+        "intent_inversion": check_inversion(
+            source_intents,
+            brief_intents_for_inversion,
+            lexicon,
+        ),
+        "hedge_or_softening": _hedge_or_softening_check(source_intents, brief_intents),
+        "contradiction_detection": _contradiction_check(brief_text),
+        "determinism_check": FidelityCheck(
+            status="pass" if determinism_check(brief_text, lexicon) else "fail",
+            details=[],
+        ),
+        "non_destructive_boundary": _non_destructive_boundary_check(
+            _source_text(source_manifest),
+            brief_text,
+            source_intents,
+        ),
+    }
+    decision = _decision_from_checks(checks)
+    return FidelityReport(
+        schema_version="intent_fidelity_report.v1",
+        work_item_id=source_manifest.work_item_id,
+        brief_type=brief_type,
+        brief_hash_sha256=hash_text(brief_text),
+        source_manifest_uri="in_memory",
+        decision=decision,
+        checks=checks,
+        false_positive_fixtures_passed=_false_positive_fixture_count(lexicon),
+    )
+
+
+def fidelity_report_to_dict(report: FidelityReport) -> dict:
+    payload = asdict(report)
+    payload["checks"] = {
+        name: asdict(check) if isinstance(check, FidelityCheck) else check
+        for name, check in report.checks.items()
+    }
+    return payload

--- a/runtime/receipts/intent_fidelity.py
+++ b/runtime/receipts/intent_fidelity.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+
+FORBIDDEN_NEXT_STEPS = [
+    "implementation_without_reload",
+    "additive_or_polish_framing_if_source_requires_absence",
+    "reviewer_output_as_authority",
+    "compression_as_canonical_memory",
+]
+NOT_AUTHORIZED_FOR = [
+    "external_send",
+    "runtime_activation",
+    "credential_change",
+    "destructive_cleanup",
+]
+CEO_ONLY_BYPASS_TERMS = {
+    "absence",
+    "destructive",
+    "irreversible",
+    "reversibility",
+    "privacy",
+    "externality",
+    "automation_boundary",
+    "approval_before_action",
+}
+
+
+@dataclass
+class ConductorVerification:
+    schema_version: str
+    work_item_id: str
+    brief_type: str
+    brief_hash_sha256: str
+    brief_author_session: str
+    conductor_verification_session: str
+    source_manifest_hash_sha256: str
+    fidelity_report_hash_sha256: str
+    conductor_independently_confirmed: bool
+    fidelity_status: str
+    handoff_candidate: bool
+    implementation_authority_granted: bool
+    required_next_gate: str
+    forbidden_next_steps: list[str]
+    verified_by: str
+    verified_at: str
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _now_iso() -> str:
+    return _now().isoformat()
+
+
+def _required_next_gate(fidelity_status: str) -> str:
+    if fidelity_status == "preserved_intent":
+        return "dispatch_gate"
+    if fidelity_status == "warning_only":
+        return "dispatch_gate"
+    if fidelity_status == "needs_clarification":
+        return "ceo_clarification"
+    if fidelity_status == "not_preserved":
+        return "ceo_clarification"
+    if fidelity_status == "requires_review":
+        return "ceo_approval"
+    return "none"
+
+
+def build_conductor_verification(
+    work_item_id: str,
+    brief_type: str,
+    brief_hash: str,
+    brief_author_session: str,
+    conductor_session: str,
+    source_manifest_hash: str,
+    fidelity_report_hash: str,
+    fidelity_status: str,
+    conductor_independently_confirmed: bool = True,
+) -> ConductorVerification:
+    """
+    Build a conductor verification artifact.
+
+    v0.3 never grants implementation authority.
+    """
+    handoff_candidate = (
+        brief_author_session != conductor_session
+        and conductor_independently_confirmed
+        and fidelity_status in {"preserved_intent", "warning_only"}
+    )
+    return ConductorVerification(
+        schema_version="conductor_fidelity_verification.v1",
+        work_item_id=work_item_id,
+        brief_type=brief_type,
+        brief_hash_sha256=brief_hash,
+        brief_author_session=brief_author_session,
+        conductor_verification_session=conductor_session,
+        source_manifest_hash_sha256=source_manifest_hash,
+        fidelity_report_hash_sha256=fidelity_report_hash,
+        conductor_independently_confirmed=conductor_independently_confirmed,
+        fidelity_status=fidelity_status,
+        handoff_candidate=handoff_candidate,
+        implementation_authority_granted=False,
+        required_next_gate=_required_next_gate(fidelity_status),
+        forbidden_next_steps=list(FORBIDDEN_NEXT_STEPS),
+        verified_by="conductor",
+        verified_at=_now_iso(),
+    )
+
+
+_bypass_registry: dict[str, dict] = {}
+
+
+@dataclass
+class BypassRecord:
+    schema_version: str
+    work_item_id: str
+    requested_by: str
+    authorized_by: str
+    reason: str
+    sources_skipped: list[str]
+    risk_accepted: str
+    scope: str
+    expires_at: str
+    single_use: bool
+    not_authorized_for: list[str]
+    _used: bool = False
+
+
+def _record_to_public_dict(record: BypassRecord) -> dict:
+    payload = asdict(record)
+    payload.pop("_used", None)
+    return payload
+
+
+def _bypass_id(record: BypassRecord) -> str:
+    payload = json.dumps(_record_to_public_dict(record), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _requires_ceo_authorization(scope: str, admissible_missing_policy: str | None) -> bool:
+    material = f"{scope} {admissible_missing_policy or ''}".lower()
+    return any(term in material for term in CEO_ONLY_BYPASS_TERMS)
+
+
+def create_bypass(
+    work_item_id: str,
+    requested_by: str,
+    authorized_by: str,
+    reason: str,
+    scope: str,
+    admissible_missing_policy: str | None = None,
+) -> str:
+    """
+    Create a bypass record.
+
+    Bypass is local, single-use, and capped at 24 hours. CEO-only classes require
+    `authorized_by="ceo"`.
+    """
+    if authorized_by not in {"conductor", "ceo"}:
+        raise ValueError("authorized_by must be conductor or ceo")
+    if authorized_by != "ceo" and _requires_ceo_authorization(scope, admissible_missing_policy):
+        raise ValueError("CEO approval required for this bypass scope")
+
+    expires_at = (_now() + timedelta(hours=24)).isoformat()
+    record = BypassRecord(
+        schema_version="intent_fidelity_bypass.v1",
+        work_item_id=work_item_id,
+        requested_by=requested_by,
+        authorized_by=authorized_by,
+        reason=reason,
+        sources_skipped=[],
+        risk_accepted=admissible_missing_policy or "warning-only or known false-positive risk",
+        scope=scope,
+        expires_at=expires_at,
+        single_use=True,
+        not_authorized_for=list(NOT_AUTHORIZED_FOR),
+    )
+    bypass_id = _bypass_id(record)
+    _bypass_registry[bypass_id] = asdict(record)
+    return bypass_id
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def check_bypass_valid(bypass_id: str) -> tuple[bool, str]:
+    """
+    Check if a bypass is valid at the current time.
+    Returns (is_valid, reason).
+    Fails if expired, already used, or not found.
+    """
+    record = _bypass_registry.get(bypass_id)
+    if record is None:
+        return False, "not_found"
+    if record.get("_used"):
+        return False, "already_used"
+    if _parse_iso(record["expires_at"]) <= _now():
+        return False, "expired"
+    return True, "valid"
+
+
+def use_bypass(bypass_id: str) -> tuple[bool, str]:
+    """
+    Mark a bypass as used (consumes single_use).
+    Returns (success, message).
+    """
+    valid, reason = check_bypass_valid(bypass_id)
+    if not valid:
+        return False, reason
+    _bypass_registry[bypass_id]["_used"] = True
+    return True, "used"
+
+
+def get_active_bypasses() -> list[dict]:
+    """Get all currently valid (non-expired, non-used) bypass records."""
+    active: list[dict] = []
+    for bypass_id, record in _bypass_registry.items():
+        valid, _reason = check_bypass_valid(bypass_id)
+        if valid:
+            active.append({key: value for key, value in record.items() if key != "_used"})
+    return active

--- a/runtime/tests/fixtures/intent_fidelity/false_positive_historical.md
+++ b/runtime/tests/fixtures/intent_fidelity/false_positive_historical.md
@@ -1,0 +1,4 @@
+CEO instruction:
+
+We previously remove the staging banner during an older cleanup. That past decision is
+not a new instruction for this task.

--- a/runtime/tests/fixtures/intent_fidelity/false_positive_hypothetical.md
+++ b/runtime/tests/fixtures/intent_fidelity/false_positive_hypothetical.md
@@ -1,0 +1,4 @@
+CEO instruction:
+
+If we remove the analytics tab, would the dashboard still make sense? Treat this as a
+question only, not a work instruction.

--- a/runtime/tests/fixtures/intent_fidelity/false_positive_negation.md
+++ b/runtime/tests/fixtures/intent_fidelity/false_positive_negation.md
@@ -1,0 +1,4 @@
+CEO instruction:
+
+Do NOT remove the existing export button. Keep it visible while adding the new loading
+copy.

--- a/runtime/tests/fixtures/intent_fidelity/false_positive_third_party_quote.md
+++ b/runtime/tests/fixtures/intent_fidelity/false_positive_third_party_quote.md
@@ -1,0 +1,4 @@
+CEO instruction:
+
+The reviewer said "they should delete this panel" during critique. I am quoting their
+view only; do not treat it as my implementation instruction.

--- a/runtime/tests/fixtures/intent_fidelity/non_destructive_bad_brief.md
+++ b/runtime/tests/fixtures/intent_fidelity/non_destructive_bad_brief.md
@@ -1,0 +1,4 @@
+Worker brief:
+
+Gut and rewrite the report page from scratch. Replace the current report flow instead of
+adding the lightweight export button.

--- a/runtime/tests/fixtures/intent_fidelity/non_destructive_source.md
+++ b/runtime/tests/fixtures/intent_fidelity/non_destructive_source.md
@@ -1,0 +1,4 @@
+CEO instruction:
+
+Add a lightweight export button to the existing report page and improve the loading
+copy. Keep the current report flow intact.

--- a/runtime/tests/fixtures/intent_fidelity/v120_bad_brief.md
+++ b/runtime/tests/fixtures/intent_fidelity/v120_bad_brief.md
@@ -1,0 +1,5 @@
+Worker brief:
+
+Polish the welcome surface. Clean up the secondary onboarding card while preserving the
+existing structure. Keep most of the current layout and retain the preservation prompt
+unless it gets in the way.

--- a/runtime/tests/fixtures/intent_fidelity/v120_good_brief.md
+++ b/runtime/tests/fixtures/intent_fidelity/v120_good_brief.md
@@ -1,0 +1,5 @@
+Worker brief:
+
+Remove the legacy welcome panel entirely. Delete the secondary onboarding card and hide
+the preservation prompt. Start from scratch for this surface and verify the removed
+elements are absent.

--- a/runtime/tests/fixtures/intent_fidelity/v120_source.md
+++ b/runtime/tests/fixtures/intent_fidelity/v120_source.md
@@ -1,0 +1,5 @@
+CEO instruction:
+
+Remove the legacy welcome panel entirely. Delete the secondary onboarding card and hide
+the preservation prompt. Start from scratch for this surface; no existing structure should
+survive.

--- a/runtime/tests/test_intent_fidelity_bypass.py
+++ b/runtime/tests/test_intent_fidelity_bypass.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from runtime.receipts.intent_fidelity import (
+    NOT_AUTHORIZED_FOR,
+    _bypass_registry,
+    check_bypass_valid,
+    create_bypass,
+    get_active_bypasses,
+    use_bypass,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_registry():
+    _bypass_registry.clear()
+    yield
+    _bypass_registry.clear()
+
+
+def test_bypass_expires_within_24h():
+    before = datetime.now(timezone.utc)
+    bypass_id = create_bypass("W-1", "tool", "conductor", "known false positive", "warning-only")
+    expires_at = datetime.fromisoformat(_bypass_registry[bypass_id]["expires_at"])
+    assert expires_at - before <= timedelta(hours=24, seconds=1)
+
+
+def test_bypass_is_single_use():
+    bypass_id = create_bypass("W-1", "tool", "conductor", "known false positive", "warning-only")
+    assert use_bypass(bypass_id) == (True, "used")
+    assert check_bypass_valid(bypass_id) == (False, "already_used")
+
+
+def test_bypass_cannot_cover_ceo_only_classes_without_ceo_authorization():
+    with pytest.raises(ValueError, match="CEO approval required"):
+        create_bypass(
+            "W-1",
+            "tool",
+            "conductor",
+            "missing source",
+            "privacy blocking class",
+        )
+
+
+def test_expired_bypass_is_invalid():
+    bypass_id = create_bypass("W-1", "tool", "conductor", "known false positive", "warning-only")
+    _bypass_registry[bypass_id]["expires_at"] = (
+        datetime.now(timezone.utc) - timedelta(seconds=1)
+    ).isoformat()
+    assert check_bypass_valid(bypass_id) == (False, "expired")
+
+
+def test_used_bypass_is_invalid():
+    bypass_id = create_bypass("W-1", "tool", "conductor", "known false positive", "warning-only")
+    _bypass_registry[bypass_id]["_used"] = True
+    assert check_bypass_valid(bypass_id) == (False, "already_used")
+
+
+def test_non_ceo_authorized_bypass_for_destructive_class_fails():
+    with pytest.raises(ValueError, match="CEO approval required"):
+        create_bypass(
+            "W-1",
+            "tool",
+            "conductor",
+            "missing source",
+            "absence destructive class",
+            admissible_missing_policy="destructive cleanup",
+        )
+
+
+def test_active_bypasses_omit_used_and_include_forbidden_scope():
+    bypass_id = create_bypass("W-1", "tool", "conductor", "known false positive", "warning-only")
+    active = get_active_bypasses()
+    assert len(active) == 1
+    assert active[0]["not_authorized_for"] == NOT_AUTHORIZED_FOR
+    use_bypass(bypass_id)
+    assert get_active_bypasses() == []

--- a/runtime/tests/test_intent_fidelity_checker.py
+++ b/runtime/tests/test_intent_fidelity_checker.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+
+from runtime.orchestration.intent_fidelity import (
+    build_source_manifest,
+    check_fidelity,
+    hash_text,
+    load_lexicon,
+)
+
+FIXTURE_DIR = Path("runtime/tests/fixtures/intent_fidelity")
+LEXICON_PATH = Path("runtime/data/intent_lexicon_v1.json")
+
+
+def _read(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def _manifest(source_text: str):
+    return build_source_manifest(
+        work_item_id="W-1",
+        lexicon_version="1.0.0",
+        source_discovery={
+            "mode": "local_file",
+            "commands_or_uris": ["source.md"],
+            "command_output_hashes_sha256": [hash_text(source_text)],
+            "completeness_claimed_by": "tool",
+        },
+        sources=[
+            {
+                "source_id": "source-1",
+                "source_type": "local_file",
+                "uri": "source.md",
+                "retrieval_method": "local_file",
+                "authority_tier": "current_ceo_instruction",
+                "content": source_text,
+            }
+        ],
+    )
+
+
+def _report(source: str, brief: str):
+    return check_fidelity(brief, "worker_prompt", _manifest(source), load_lexicon(LEXICON_PATH))
+
+
+def test_v120_bad_brief_polish_framing_of_destructive_intent_fails():
+    report = _report(_read("v120_source.md"), _read("v120_bad_brief.md"))
+    assert report.decision == "fail_closed"
+    assert report.checks["intent_inversion"].status == "fail"
+
+
+def test_v120_good_brief_faithful_preservation_passes():
+    report = _report(_read("v120_source.md"), _read("v120_good_brief.md"))
+    assert report.decision == "pass"
+
+
+def test_non_destructive_boundary_inversions_fail():
+    report = _report(
+        _read("non_destructive_source.md"),
+        _read("non_destructive_bad_brief.md"),
+    )
+    assert report.decision == "fail_closed"
+    assert report.checks["non_destructive_boundary"].status == "fail"
+
+
+def test_ambiguous_broad_terms_warn_only_when_no_blocking_class_exists():
+    report = _report(_read("non_destructive_source.md"), "Polish and clean up the copy.")
+    assert report.decision == "warning_only"
+    assert report.checks["hedge_or_softening"].status == "warn"
+
+
+def test_unsupported_paraphrase_emits_requires_conductor_review():
+    report = _report(_read("v120_source.md"), "Make the legacy panel less prominent.")
+    assert report.decision == "requires_conductor_review"
+    assert report.checks["verbatim_preservation"].status == "requires_conductor_review"
+
+
+def test_not_yet_implemented_placeholder():
+    pytest.skip("placeholder for semantic paraphrase model review outside v0.3 lexicon scope")

--- a/runtime/tests/test_intent_fidelity_cli.py
+++ b/runtime/tests/test_intent_fidelity_cli.py
@@ -1,0 +1,45 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+FIXTURE_DIR = Path("runtime/tests/fixtures/intent_fidelity")
+
+
+def _run_cli(source: str, brief: str):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "lifeos",
+            "intent-fidelity",
+            "check",
+            "--source",
+            str(FIXTURE_DIR / source),
+            "--brief",
+            str(FIXTURE_DIR / brief),
+            "--brief-type",
+            "worker_prompt",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_intent_fidelity_cli_good_brief_exits_zero_with_json_report():
+    result = _run_cli("v120_source.md", "v120_good_brief.md")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["dry_run"] is True
+    assert payload["implementation_authority_granted"] is False
+    assert payload["fidelity_report"]["decision"] == "pass"
+
+
+def test_intent_fidelity_cli_bad_brief_exits_nonzero_with_json_report():
+    result = _run_cli("v120_source.md", "v120_bad_brief.md")
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["fidelity_report"]["decision"] == "fail_closed"
+    assert payload["conductor_verification"]["implementation_authority_granted"] is False

--- a/runtime/tests/test_intent_fidelity_extractor.py
+++ b/runtime/tests/test_intent_fidelity_extractor.py
@@ -1,0 +1,85 @@
+from dataclasses import asdict
+from pathlib import Path
+
+from runtime.orchestration.intent_fidelity import (
+    determinism_check,
+    extract_intents,
+    load_lexicon,
+)
+
+FIXTURE_DIR = Path("runtime/tests/fixtures/intent_fidelity")
+LEXICON_PATH = Path("runtime/data/intent_lexicon_v1.json")
+
+
+def _lexicon():
+    return load_lexicon(LEXICON_PATH)
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def test_extract_intents_finds_absence_phrases():
+    spans = extract_intents(_fixture("v120_source.md"), "v120", _lexicon())
+    assert any(span.intent_class == "absence" and span.phrase == "remove" for span in spans)
+    assert any(span.intent_class == "absence" and span.phrase == "delete" for span in spans)
+    assert any(span.blocking_strength == "blocking" for span in spans)
+
+
+def test_negation_guard_prevents_false_positive():
+    spans = extract_intents(_fixture("false_positive_negation.md"), "negation", _lexicon())
+    assert not [span for span in spans if span.intent_class == "absence"]
+
+
+def test_historical_guard_prevents_false_positive():
+    spans = extract_intents(_fixture("false_positive_historical.md"), "historical", _lexicon())
+    assert not [span for span in spans if span.intent_class == "absence"]
+
+
+def test_hypothetical_guard_prevents_false_positive():
+    spans = extract_intents(_fixture("false_positive_hypothetical.md"), "hypothetical", _lexicon())
+    assert not [span for span in spans if span.intent_class == "absence"]
+
+
+def test_third_party_quote_guard_prevents_false_positive():
+    spans = extract_intents(_fixture("false_positive_third_party_quote.md"), "quote", _lexicon())
+    assert not [span for span in spans if span.intent_class == "absence"]
+
+
+def test_softening_inversion_warning_alone_becomes_blocking_with_absence():
+    lexicon = _lexicon()
+    warning_only = extract_intents("Polish and clean up the report.", "brief", lexicon)
+    assert {span.blocking_strength for span in warning_only} == {"warning"}
+
+    with_absence = extract_intents(
+        "Remove the panel, then polish any remaining copy.",
+        "source",
+        lexicon,
+    )
+    softening = [span for span in with_absence if span.intent_class == "softening_inversion"]
+    assert softening
+    assert {span.blocking_strength for span in softening} == {"blocking"}
+
+
+def test_deterministic_rerun_produces_identical_results():
+    text = _fixture("v120_source.md")
+    lexicon = _lexicon()
+    first = [asdict(span) for span in extract_intents(text, "v120", lexicon)]
+    second = [asdict(span) for span in extract_intents(text, "v120", lexicon)]
+    assert first == second
+    assert determinism_check(text, lexicon)
+
+
+def test_case_folding_works():
+    spans = extract_intents("REMOVE the old banner and DELETE the card.", "case", _lexicon())
+    assert [span.phrase for span in spans] == ["remove", "delete"]
+
+
+def test_empty_text_produces_empty_results():
+    assert extract_intents("", "empty", _lexicon()) == []
+
+
+def test_multi_line_text_reports_line_offsets():
+    spans = extract_intents("Keep this.\nRemove that panel.", "multi", _lexicon())
+    assert len(spans) == 1
+    assert spans[0].line_or_offset.startswith("line 2")

--- a/runtime/tests/test_intent_fidelity_schemas.py
+++ b/runtime/tests/test_intent_fidelity_schemas.py
@@ -1,0 +1,159 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+SCHEMAS = [
+    Path("schemas/intent_source_manifest_v1.json"),
+    Path("schemas/intent_fidelity_report_v1.json"),
+    Path("schemas/intent_review_report_v1.json"),
+    Path("schemas/conductor_fidelity_verification_v1.json"),
+    Path("schemas/intent_fidelity_bypass_v1.json"),
+]
+SHA = "a" * 64
+ISO = "2026-05-10T00:00:00+00:00"
+
+
+def _load_schema(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _valid_examples() -> dict[str, dict]:
+    return {
+        "intent_source_manifest_v1": {
+            "schema_version": "intent_source_manifest.v1",
+            "work_item_id": "W-1",
+            "lexicon_version": "1.0.0",
+            "created_at": ISO,
+            "created_by": "tool",
+            "source_discovery": {
+                "mode": "local_file",
+                "commands_or_uris": ["fixtures/source.md"],
+                "command_output_hashes_sha256": [SHA],
+                "cutoff_timestamp": ISO,
+                "completeness_claimed_by": "tool",
+            },
+            "sources": [
+                {
+                    "source_id": "source-1",
+                    "source_type": "local_file",
+                    "uri": "fixtures/source.md",
+                    "retrieved_at": ISO,
+                    "retrieval_method": "local_file",
+                    "content_hash_sha256": SHA,
+                    "source_of_source_hash_sha256": None,
+                    "authority_tier": "current_ceo_instruction",
+                    "extracted_intents": [
+                        {
+                            "intent_class": "absence",
+                            "phrase": "remove",
+                            "source_id": "source-1",
+                            "line_or_offset": "line 1",
+                            "surrounding_context": "remove this",
+                            "blocking_strength": "blocking",
+                            "guard_triggered": None,
+                        }
+                    ],
+                }
+            ],
+            "missing_sources": [],
+        },
+        "intent_fidelity_report_v1": {
+            "schema_version": "intent_fidelity_report.v1",
+            "work_item_id": "W-1",
+            "brief_type": "worker_prompt",
+            "brief_uri": "brief.md",
+            "brief_hash_sha256": SHA,
+            "source_manifest_uri": "manifest.json",
+            "decision": "pass",
+            "checks": {
+                "source_coverage": {"status": "pass", "details": []},
+                "determinism_check": {"status": "pass", "details": []},
+            },
+            "false_positive_fixtures_passed": 4,
+        },
+        "intent_review_report_v1": {
+            "schema_version": "intent_review_report.v1",
+            "work_item_id": "W-1",
+            "reviewer_surface": "openclaw",
+            "reviewer_session": "review-1",
+            "verdict": "approve",
+            "findings": [
+                {
+                    "severity": "note",
+                    "title": "Evidence only",
+                    "recommendation": "No authority granted.",
+                }
+            ],
+            "authority_note": "reviewer_output_is_evidence_only",
+        },
+        "conductor_fidelity_verification_v1": {
+            "schema_version": "conductor_fidelity_verification.v1",
+            "work_item_id": "W-1",
+            "brief_type": "worker_prompt",
+            "brief_hash_sha256": SHA,
+            "brief_author_session": "brief-1",
+            "conductor_verification_session": "conductor-1",
+            "source_manifest_hash_sha256": SHA,
+            "fidelity_report_hash_sha256": SHA,
+            "conductor_independently_confirmed": True,
+            "fidelity_status": "preserved_intent",
+            "handoff_candidate": True,
+            "implementation_authority_granted": False,
+            "required_next_gate": "dispatch_gate",
+            "forbidden_next_steps": [
+                "implementation_without_reload",
+                "additive_or_polish_framing_if_source_requires_absence",
+                "reviewer_output_as_authority",
+                "compression_as_canonical_memory",
+            ],
+            "verified_by": "conductor",
+            "verified_at": ISO,
+        },
+        "intent_fidelity_bypass_v1": {
+            "schema_version": "intent_fidelity_bypass.v1",
+            "work_item_id": "W-1",
+            "requested_by": "tool",
+            "authorized_by": "conductor",
+            "reason": "known false positive",
+            "sources_skipped": [],
+            "risk_accepted": "warning-only audit risk",
+            "scope": "warning-only fixture",
+            "expires_at": ISO,
+            "single_use": True,
+            "not_authorized_for": [
+                "external_send",
+                "runtime_activation",
+                "credential_change",
+                "destructive_cleanup",
+            ],
+        },
+    }
+
+
+@pytest.mark.parametrize("schema_path", SCHEMAS)
+def test_schema_file_exists_and_is_valid_json_schema(schema_path):
+    assert schema_path.exists()
+    Draft202012Validator.check_schema(_load_schema(schema_path))
+
+
+@pytest.mark.parametrize("schema_path", SCHEMAS)
+def test_schema_version_metadata_matches_filename(schema_path):
+    schema = _load_schema(schema_path)
+    assert schema["schema_version"] == schema_path.stem
+
+
+@pytest.mark.parametrize("schema_path", SCHEMAS)
+def test_valid_example_data_passes_validation(schema_path):
+    schema = _load_schema(schema_path)
+    Draft202012Validator(schema).validate(_valid_examples()[schema_path.stem])
+
+
+@pytest.mark.parametrize("schema_path", SCHEMAS)
+def test_invalid_malformed_data_fails_validation(schema_path):
+    schema = _load_schema(schema_path)
+    example = dict(_valid_examples()[schema_path.stem])
+    example.pop("schema_version")
+    errors = list(Draft202012Validator(schema).iter_errors(example))
+    assert errors

--- a/runtime/tests/test_intent_fidelity_verification.py
+++ b/runtime/tests/test_intent_fidelity_verification.py
@@ -1,0 +1,48 @@
+from dataclasses import asdict
+
+from runtime.receipts.intent_fidelity import (
+    FORBIDDEN_NEXT_STEPS,
+    build_conductor_verification,
+)
+
+SHA = "b" * 64
+
+
+def _verification(**overrides):
+    payload = {
+        "work_item_id": "W-1",
+        "brief_type": "worker_prompt",
+        "brief_hash": SHA,
+        "brief_author_session": "brief-session",
+        "conductor_session": "conductor-session",
+        "source_manifest_hash": SHA,
+        "fidelity_report_hash": SHA,
+        "fidelity_status": "preserved_intent",
+    }
+    payload.update(overrides)
+    return build_conductor_verification(**payload)
+
+
+def test_implementation_authority_granted_is_always_false():
+    verification = _verification()
+    assert verification.implementation_authority_granted is False
+
+
+def test_handoff_candidate_true_only_with_separate_session_and_independent_confirmation():
+    verification = _verification(conductor_independently_confirmed=True)
+    assert verification.handoff_candidate is True
+
+    not_independent = _verification(conductor_independently_confirmed=False)
+    assert not_independent.handoff_candidate is False
+
+
+def test_handoff_candidate_false_when_brief_author_equals_conductor():
+    verification = _verification(conductor_session="brief-session")
+    assert verification.handoff_candidate is False
+
+
+def test_forbidden_next_steps_are_set_correctly():
+    verification = _verification()
+    payload = asdict(verification)
+    assert payload["forbidden_next_steps"] == FORBIDDEN_NEXT_STEPS
+    assert "reviewer_output_as_authority" in payload["forbidden_next_steps"]

--- a/runtime/tests/test_intent_lexicon.py
+++ b/runtime/tests/test_intent_lexicon.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+LEXICON_PATH = Path("runtime/data/intent_lexicon_v1.json")
+REQUIRED_CLASSES = {
+    "absence",
+    "pause",
+    "approval_before_action",
+    "privacy",
+    "reversibility",
+    "automation_boundary",
+    "channel_authority",
+    "scope_minimisation",
+    "softening_inversion",
+}
+REQUIRED_FIELDS = {
+    "class",
+    "phrases",
+    "default_blocking",
+    "inversion_terms",
+    "negation_guards",
+}
+VALID_BLOCKING = {"blocking", "warning", "requires_conductor_review"}
+
+
+def _load() -> dict:
+    return json.loads(LEXICON_PATH.read_text(encoding="utf-8"))
+
+
+def test_intent_lexicon_exists_and_is_valid_json():
+    assert LEXICON_PATH.exists()
+    data = _load()
+    assert data["schema_version"] == "intent_lexicon_v1"
+    assert data["version"] == "1.0.0"
+
+
+def test_all_required_intent_classes_present():
+    classes = {item["class"] for item in _load()["intent_classes"]}
+    assert REQUIRED_CLASSES <= classes
+
+
+def test_each_class_has_required_fields():
+    for item in _load()["intent_classes"]:
+        assert REQUIRED_FIELDS <= set(item)
+        assert isinstance(item["phrases"], list)
+        assert isinstance(item["inversion_terms"], list)
+        assert isinstance(item["negation_guards"], list)
+
+
+def test_default_blocking_values_are_valid():
+    for item in _load()["intent_classes"]:
+        assert item["default_blocking"] in VALID_BLOCKING
+
+
+def test_deterministic_load_twice_is_identical():
+    assert _load() == _load()

--- a/runtime/tests/test_intent_source_manifest.py
+++ b/runtime/tests/test_intent_source_manifest.py
@@ -1,0 +1,94 @@
+import json
+from datetime import datetime
+
+from runtime.orchestration.intent_fidelity import (
+    build_source_manifest,
+    hash_text,
+    manifest_to_dict,
+    validate_manifest_completeness,
+)
+
+SOURCE_TEXT = "Remove the legacy panel."
+
+
+def _source(content: str = SOURCE_TEXT) -> dict:
+    return {
+        "source_id": "source-1",
+        "source_type": "local_file",
+        "uri": "runtime/tests/fixtures/intent_fidelity/v120_source.md",
+        "retrieval_method": "local_file",
+        "authority_tier": "current_ceo_instruction",
+        "content": content,
+    }
+
+
+def _discovery() -> dict:
+    return {
+        "mode": "local_file",
+        "commands_or_uris": ["runtime/tests/fixtures/intent_fidelity/v120_source.md"],
+        "command_output_hashes_sha256": [hash_text(SOURCE_TEXT)],
+        "completeness_claimed_by": "tool",
+    }
+
+
+def test_basic_manifest_creation_with_required_fields():
+    manifest = build_source_manifest("W-1", "1.0.0", _discovery(), [_source()])
+    payload = manifest_to_dict(manifest)
+    assert payload["schema_version"] == "intent_source_manifest.v1"
+    assert payload["work_item_id"] == "W-1"
+    assert payload["sources"][0]["source_id"] == "source-1"
+    assert payload["sources"][0]["extracted_intents"][0]["intent_class"] == "absence"
+
+
+def test_missing_fail_closed_source_causes_validation_failure():
+    manifest = build_source_manifest(
+        "W-1",
+        "1.0.0",
+        _discovery(),
+        [_source()],
+        missing_sources=[
+            {
+                "expected_source": "CEO issue comment",
+                "reason_missing": "not found",
+                "disposition": "fail_closed",
+            }
+        ],
+    )
+    complete, issues = validate_manifest_completeness(manifest)
+    assert not complete
+    assert "CEO issue comment" in issues[0]
+
+
+def test_missing_not_required_source_passes_validation():
+    manifest = build_source_manifest(
+        "W-1",
+        "1.0.0",
+        _discovery(),
+        [_source()],
+        missing_sources=[
+            {
+                "expected_source": "optional transcript",
+                "reason_missing": "not applicable",
+                "disposition": "not_required",
+            }
+        ],
+    )
+    assert validate_manifest_completeness(manifest) == (True, [])
+
+
+def test_content_hash_is_populated_correctly():
+    manifest = build_source_manifest("W-1", "1.0.0", _discovery(), [_source()])
+    assert manifest.sources[0]["content_hash_sha256"] == hash_text(SOURCE_TEXT)
+
+
+def test_timestamp_format():
+    manifest = build_source_manifest("W-1", "1.0.0", _discovery(), [_source()])
+    parsed = datetime.fromisoformat(manifest.created_at)
+    assert parsed.tzinfo is not None
+
+
+def test_serialization_round_trip():
+    manifest = build_source_manifest("W-1", "1.0.0", _discovery(), [_source()])
+    payload = manifest_to_dict(manifest)
+    assert "_content" not in payload["sources"][0]
+    assert json.loads(json.dumps(payload, sort_keys=True)) == payload

--- a/schemas/conductor_fidelity_verification_v1.json
+++ b/schemas/conductor_fidelity_verification_v1.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lifeos.local/schemas/conductor_fidelity_verification_v1.json",
+  "title": "Conductor Fidelity Verification v1",
+  "schema_version": "conductor_fidelity_verification_v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_item_id",
+    "brief_type",
+    "brief_hash_sha256",
+    "brief_author_session",
+    "conductor_verification_session",
+    "source_manifest_hash_sha256",
+    "fidelity_report_hash_sha256",
+    "conductor_independently_confirmed",
+    "fidelity_status",
+    "handoff_candidate",
+    "implementation_authority_granted",
+    "required_next_gate",
+    "forbidden_next_steps",
+    "verified_by",
+    "verified_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": [
+        "conductor_fidelity_verification.v1",
+        "conductor_fidelity_verification_v1"
+      ]
+    },
+    "work_item_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "brief_type": {
+      "type": "string"
+    },
+    "brief_hash_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "brief_author_session": {
+      "type": "string",
+      "minLength": 1
+    },
+    "conductor_verification_session": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_manifest_hash_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "fidelity_report_hash_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "conductor_independently_confirmed": {
+      "type": "boolean"
+    },
+    "fidelity_status": {
+      "type": "string",
+      "enum": [
+        "preserved_intent",
+        "not_preserved",
+        "needs_clarification",
+        "requires_review",
+        "warning_only"
+      ]
+    },
+    "handoff_candidate": {
+      "type": "boolean"
+    },
+    "implementation_authority_granted": {
+      "type": "boolean",
+      "const": false
+    },
+    "required_next_gate": {
+      "type": "string",
+      "enum": [
+        "none",
+        "dispatch_gate",
+        "ceo_clarification",
+        "ceo_approval",
+        "repo_gate",
+        "runtime_gate"
+      ]
+    },
+    "forbidden_next_steps": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "contains": {
+        "const": "implementation_without_reload"
+      }
+    },
+    "verified_by": {
+      "type": "string"
+    },
+    "verified_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  }
+}

--- a/schemas/intent_fidelity_bypass_v1.json
+++ b/schemas/intent_fidelity_bypass_v1.json
@@ -1,0 +1,99 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lifeos.local/schemas/intent_fidelity_bypass_v1.json",
+  "title": "Intent Fidelity Bypass v1",
+  "schema_version": "intent_fidelity_bypass_v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_item_id",
+    "requested_by",
+    "authorized_by",
+    "reason",
+    "sources_skipped",
+    "risk_accepted",
+    "scope",
+    "expires_at",
+    "single_use",
+    "not_authorized_for"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": [
+        "intent_fidelity_bypass.v1",
+        "intent_fidelity_bypass_v1"
+      ]
+    },
+    "work_item_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "requested_by": {
+      "type": "string",
+      "minLength": 1
+    },
+    "authorized_by": {
+      "type": "string",
+      "enum": [
+        "conductor",
+        "ceo"
+      ]
+    },
+    "reason": {
+      "type": "string",
+      "minLength": 1
+    },
+    "sources_skipped": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "risk_accepted": {
+      "type": "string",
+      "minLength": 1
+    },
+    "scope": {
+      "type": "string",
+      "minLength": 1
+    },
+    "expires_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "single_use": {
+      "type": "boolean",
+      "const": true
+    },
+    "not_authorized_for": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "allOf": [
+        {
+          "contains": {
+            "const": "external_send"
+          }
+        },
+        {
+          "contains": {
+            "const": "runtime_activation"
+          }
+        },
+        {
+          "contains": {
+            "const": "credential_change"
+          }
+        },
+        {
+          "contains": {
+            "const": "destructive_cleanup"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/intent_fidelity_bypass_v1.json
+++ b/schemas/intent_fidelity_bypass_v1.json
@@ -21,10 +21,7 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "enum": [
-        "intent_fidelity_bypass.v1",
-        "intent_fidelity_bypass_v1"
-      ]
+      "enum": ["intent_fidelity_bypass.v1", "intent_fidelity_bypass_v1"]
     },
     "work_item_id": {
       "type": "string",
@@ -36,10 +33,7 @@
     },
     "authorized_by": {
       "type": "string",
-      "enum": [
-        "conductor",
-        "ceo"
-      ]
+      "enum": ["conductor", "ceo"]
     },
     "reason": {
       "type": "string",

--- a/schemas/intent_fidelity_report_v1.json
+++ b/schemas/intent_fidelity_report_v1.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lifeos.local/schemas/intent_fidelity_report_v1.json",
+  "title": "Intent Fidelity Report v1",
+  "schema_version": "intent_fidelity_report_v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_item_id",
+    "brief_type",
+    "brief_hash_sha256",
+    "source_manifest_uri",
+    "decision",
+    "checks",
+    "false_positive_fixtures_passed"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": [
+        "intent_fidelity_report.v1",
+        "intent_fidelity_report_v1"
+      ]
+    },
+    "work_item_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "brief_type": {
+      "$ref": "#/$defs/brief_type"
+    },
+    "brief_uri": {
+      "type": "string"
+    },
+    "brief_hash_sha256": {
+      "$ref": "#/$defs/sha256"
+    },
+    "source_manifest_uri": {
+      "type": "string"
+    },
+    "decision": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "fail_closed",
+        "requires_ceo_clarification",
+        "requires_conductor_review",
+        "warning_only"
+      ]
+    },
+    "checks": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/check"
+      }
+    },
+    "false_positive_fixtures_passed": {
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "brief_type": {
+      "type": "string",
+      "enum": [
+        "worker_prompt",
+        "dispatch_packet",
+        "build_packet",
+        "implementation_plan",
+        "pr_body",
+        "issue_comment",
+        "closure_packet",
+        "other"
+      ]
+    },
+    "check": {
+      "type": "object",
+      "required": [
+        "status",
+        "details"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "warn",
+            "fail",
+            "requires_conductor_review",
+            "requires_ceo_clarification"
+          ]
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/intent_fidelity_report_v1.json
+++ b/schemas/intent_fidelity_report_v1.json
@@ -18,10 +18,7 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "enum": [
-        "intent_fidelity_report.v1",
-        "intent_fidelity_report_v1"
-      ]
+      "enum": ["intent_fidelity_report.v1", "intent_fidelity_report_v1"]
     },
     "work_item_id": {
       "type": "string",
@@ -80,10 +77,7 @@
     },
     "check": {
       "type": "object",
-      "required": [
-        "status",
-        "details"
-      ],
+      "required": ["status", "details"],
       "additionalProperties": true,
       "properties": {
         "status": {

--- a/schemas/intent_review_report_v1.json
+++ b/schemas/intent_review_report_v1.json
@@ -17,10 +17,7 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "enum": [
-        "intent_review_report.v1",
-        "intent_review_report_v1"
-      ]
+      "enum": ["intent_review_report.v1", "intent_review_report_v1"]
     },
     "work_item_id": {
       "type": "string",
@@ -28,12 +25,7 @@
     },
     "reviewer_surface": {
       "type": "string",
-      "enum": [
-        "openclaw",
-        "aa",
-        "ea",
-        "other"
-      ]
+      "enum": ["openclaw", "aa", "ea", "other"]
     },
     "reviewer_session": {
       "type": "string",
@@ -41,31 +33,18 @@
     },
     "verdict": {
       "type": "string",
-      "enum": [
-        "reject",
-        "amend",
-        "approve"
-      ]
+      "enum": ["reject", "amend", "approve"]
     },
     "findings": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": [
-          "severity",
-          "title",
-          "recommendation"
-        ],
+        "required": ["severity", "title", "recommendation"],
         "additionalProperties": false,
         "properties": {
           "severity": {
             "type": "string",
-            "enum": [
-              "p0",
-              "p1",
-              "p2",
-              "note"
-            ]
+            "enum": ["p0", "p1", "p2", "note"]
           },
           "title": {
             "type": "string"

--- a/schemas/intent_review_report_v1.json
+++ b/schemas/intent_review_report_v1.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lifeos.local/schemas/intent_review_report_v1.json",
+  "title": "Intent Review Report v1",
+  "schema_version": "intent_review_report_v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_item_id",
+    "reviewer_surface",
+    "reviewer_session",
+    "verdict",
+    "findings",
+    "authority_note"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": [
+        "intent_review_report.v1",
+        "intent_review_report_v1"
+      ]
+    },
+    "work_item_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reviewer_surface": {
+      "type": "string",
+      "enum": [
+        "openclaw",
+        "aa",
+        "ea",
+        "other"
+      ]
+    },
+    "reviewer_session": {
+      "type": "string",
+      "minLength": 1
+    },
+    "verdict": {
+      "type": "string",
+      "enum": [
+        "reject",
+        "amend",
+        "approve"
+      ]
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "severity",
+          "title",
+          "recommendation"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": [
+              "p0",
+              "p1",
+              "p2",
+              "note"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "recommendation": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "authority_note": {
+      "type": "string",
+      "const": "reviewer_output_is_evidence_only"
+    }
+  }
+}

--- a/schemas/intent_source_manifest_v1.json
+++ b/schemas/intent_source_manifest_v1.json
@@ -18,10 +18,7 @@
   "properties": {
     "schema_version": {
       "type": "string",
-      "enum": [
-        "intent_source_manifest.v1",
-        "intent_source_manifest_v1"
-      ]
+      "enum": ["intent_source_manifest.v1", "intent_source_manifest_v1"]
     },
     "work_item_id": {
       "type": "string",
@@ -37,12 +34,7 @@
     },
     "created_by": {
       "type": "string",
-      "enum": [
-        "conductor",
-        "worker",
-        "ea",
-        "tool"
-      ]
+      "enum": ["conductor", "worker", "ea", "tool"]
     },
     "source_discovery": {
       "type": "object",
@@ -84,12 +76,7 @@
         },
         "completeness_claimed_by": {
           "type": "string",
-          "enum": [
-            "conductor",
-            "worker",
-            "ea",
-            "tool"
-          ]
+          "enum": ["conductor", "worker", "ea", "tool"]
         }
       }
     },
@@ -141,10 +128,7 @@
           "$ref": "#/$defs/blocking_strength"
         },
         "guard_triggered": {
-          "type": [
-            "string",
-            "null"
-          ],
+          "type": ["string", "null"],
           "enum": [
             "negation",
             "historical",
@@ -236,11 +220,7 @@
     },
     "missing_source": {
       "type": "object",
-      "required": [
-        "expected_source",
-        "reason_missing",
-        "disposition"
-      ],
+      "required": ["expected_source", "reason_missing", "disposition"],
       "additionalProperties": false,
       "properties": {
         "expected_source": {
@@ -251,20 +231,13 @@
         },
         "disposition": {
           "type": "string",
-          "enum": [
-            "fail_closed",
-            "not_required"
-          ]
+          "enum": ["fail_closed", "not_required"]
         }
       }
     },
     "blocking_strength": {
       "type": "string",
-      "enum": [
-        "blocking",
-        "warning",
-        "requires_conductor_review"
-      ]
+      "enum": ["blocking", "warning", "requires_conductor_review"]
     }
   }
 }

--- a/schemas/intent_source_manifest_v1.json
+++ b/schemas/intent_source_manifest_v1.json
@@ -1,0 +1,270 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lifeos.local/schemas/intent_source_manifest_v1.json",
+  "title": "Intent Source Manifest v1",
+  "schema_version": "intent_source_manifest_v1",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "work_item_id",
+    "lexicon_version",
+    "created_at",
+    "created_by",
+    "source_discovery",
+    "sources",
+    "missing_sources"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "enum": [
+        "intent_source_manifest.v1",
+        "intent_source_manifest_v1"
+      ]
+    },
+    "work_item_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lexicon_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "created_by": {
+      "type": "string",
+      "enum": [
+        "conductor",
+        "worker",
+        "ea",
+        "tool"
+      ]
+    },
+    "source_discovery": {
+      "type": "object",
+      "required": [
+        "mode",
+        "commands_or_uris",
+        "command_output_hashes_sha256",
+        "cutoff_timestamp",
+        "completeness_claimed_by"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "github",
+            "local_file",
+            "google_doc",
+            "obsidian",
+            "chat",
+            "mixed"
+          ]
+        },
+        "commands_or_uris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "command_output_hashes_sha256": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/sha256"
+          }
+        },
+        "cutoff_timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "completeness_claimed_by": {
+          "type": "string",
+          "enum": [
+            "conductor",
+            "worker",
+            "ea",
+            "tool"
+          ]
+        }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/source"
+      }
+    },
+    "missing_sources": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/missing_source"
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "intent": {
+      "type": "object",
+      "required": [
+        "intent_class",
+        "phrase",
+        "line_or_offset",
+        "surrounding_context",
+        "blocking_strength"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "intent_class": {
+          "type": "string"
+        },
+        "phrase": {
+          "type": "string"
+        },
+        "source_id": {
+          "type": "string"
+        },
+        "line_or_offset": {
+          "type": "string"
+        },
+        "surrounding_context": {
+          "type": "string"
+        },
+        "blocking_strength": {
+          "$ref": "#/$defs/blocking_strength"
+        },
+        "guard_triggered": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "enum": [
+            "negation",
+            "historical",
+            "hypothetical",
+            "third_party_quote",
+            null
+          ]
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": [
+        "source_id",
+        "source_type",
+        "uri",
+        "retrieved_at",
+        "retrieval_method",
+        "content_hash_sha256",
+        "source_of_source_hash_sha256",
+        "authority_tier",
+        "extracted_intents"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "source_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_type": {
+          "type": "string",
+          "enum": [
+            "issue_body",
+            "issue_comment",
+            "pr_review",
+            "pr_comment",
+            "local_file",
+            "google_doc",
+            "obsidian_note",
+            "chat",
+            "plan",
+            "ratified_doc",
+            "transcript"
+          ]
+        },
+        "uri": {
+          "type": "string"
+        },
+        "retrieved_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "retrieval_method": {
+          "type": "string",
+          "minLength": 1
+        },
+        "content_hash_sha256": {
+          "$ref": "#/$defs/sha256"
+        },
+        "source_of_source_hash_sha256": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/sha256"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "authority_tier": {
+          "type": "string",
+          "enum": [
+            "current_ceo_instruction",
+            "acceptance_criteria",
+            "ratified_doc",
+            "plan",
+            "lesson",
+            "memory",
+            "other"
+          ]
+        },
+        "extracted_intents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/intent"
+          }
+        }
+      }
+    },
+    "missing_source": {
+      "type": "object",
+      "required": [
+        "expected_source",
+        "reason_missing",
+        "disposition"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "expected_source": {
+          "type": "string"
+        },
+        "reason_missing": {
+          "type": "string"
+        },
+        "disposition": {
+          "type": "string",
+          "enum": [
+            "fail_closed",
+            "not_required"
+          ]
+        }
+      }
+    },
+    "blocking_strength": {
+      "type": "string",
+      "enum": [
+        "blocking",
+        "warning",
+        "requires_conductor_review"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements the inert/dry-run v0.3 Founder Intent Fidelity Gate — an auditable pre-handoff gate proving that the brief handed to a worker/EA/build loop preserves active CEO intent.

Design artifacts (committed previously):
- [Spec v0.3](artifacts/specs/Founder_Intent_Fidelity_Gate_v0.3.md)
- [Implementation plan v0.3](artifacts/plans/2026-05-09-founder-intent-fidelity-gate-spec-and-plan-v0.3.md)
- [OpenClaw red-team review](artifacts/reviews/2026-05-09-founder-intent-fidelity-openclaw-redteam.md)
- [AA red-team review](artifacts/reviews/2026-05-09-founder-intent-fidelity-aa-redteam.md)

### What's built (Tasks 1-8)

| Task | Files | Status |
|------|-------|--------|
| 1. Fixture corpus | 9 fixture files under `runtime/tests/fixtures/intent_fidelity/` | Done |
| 2. Versioned lexicon | `runtime/data/intent_lexicon_v1.json` | Done |
| 3. JSON schemas | 5 schema files under `schemas/intent_*.json` | Done |
| 4. Intent extractor | `runtime/orchestration/intent_fidelity.py` (extract, guards, determinism) | Done |
| 5. Manifest builder | `runtime/orchestration/intent_fidelity.py` (manifest construction, fail-closed validation) | Done |
| 6. Fidelity checker | `runtime/orchestration/intent_fidelity.py` (v120 inversion detection, pass/fail/review decisions) | Done |
| 7. Conductor verification + bypass | `runtime/receipts/intent_fidelity.py` (verification artifact, bypass registry with 24h expiry) | Done |
| 8. CLI dry-run | `python3 -m lifeos intent-fidelity check --source --brief --brief-type --json` | Done |

### Key design decisions

- **Deterministic only within closed lexicon** — no LLM-based semantic matching in v0.3
- **9 intent classes**: absence, pause, approval_before_action, privacy, reversibility, automation_boundary, channel_authority, scope_minimisation, softening_inversion
- **False-positive guards**: negation, historical, hypothetical, third-party quote
- **Softening_inversion promoted to blocking** when absence/destructive intent exists in same source set
- **Bypass**: 24h max, single-use, cannot cover CEO-only classes without CEO approval
- **Conductor verification**: `implementation_authority_granted` always `False`, `handoff_candidate` requires separate session + independent confirmation
- **No runtime blocking** — inert/dry-run only per spec

### Test results

```
59 passed, 1 skipped in 1.37s
```

Quality gate: all blocking checks pass (ruff_check, ruff_format); mypy/biome advisory only (tool_unavailable_locally).

### Out of scope (deferred)

- Runtime handoff blocking
- Model-routing changes
- Compression quarantine implementation
- External/public writes
- Credentials or automation activation
- Governance doc ratification

Closes #111
