### PR TITLE
Refresh wiki after docs reconciliation

### DIFF
--- a/.context/wiki/_refresh_needed
+++ b/.context/wiki/_refresh_needed
@@ -1,7 +1,0 @@
-docs/audit/LIFEOS_AUTHORITY_AUDIT_RESULT_2026-04-27.md
-docs/03_runtime/memory/LIFEOS_MEMORY_KNOWLEDGE_ARCHITECTURE_v0.5.md
-docs/02_protocols/Work_Management_Framework_v0.1.md
-docs/11_admin/BACKLOG.md
-docs/INDEX.md
-docs/02_protocols/ARTEFACT_INDEX.json
-docs/LifeOS_Strategic_Corpus.md

--- a/.context/wiki/agent-roles.md
+++ b/.context/wiki/agent-roles.md
@@ -4,7 +4,7 @@ source_docs:
   - docs/00_foundations/LifeOS_Constitution_v2.0.md
   - docs/02_protocols/Intent_Routing_Rule_v1.1.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
-source_commit_max: c7df98632ed6dfee99daaada103cd613dc630501
+source_commit_max: 9eb65264ef948a4335892ab4b99d13e036019b23
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/backlog-task-system.md
+++ b/.context/wiki/backlog-task-system.md
@@ -4,7 +4,7 @@ source_docs:
   - docs/11_admin/BACKLOG.md
   - docs/02_protocols/Intent_Routing_Rule_v1.1.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
-source_commit_max: 8b2fa0d4c94ffca6229b86fb83ad98970d27be1f
+source_commit_max: 560164c7180b5ce4e0e4ed7f6a0fe47407554ff8
 authority: derived
 page_class: status
 concepts:
@@ -16,9 +16,7 @@ concepts:
 
 ## Summary
 
-The COO reviews the structured backlog and proposes tasks. CEO approves proposals, which
-become ExecutionOrders dispatched to sprint agents. `docs/11_admin/LIFEOS_STATE.md` is the
-canonical source for current phase, active WIP, and blockers.
+The COO reviews canonical backlog/state docs, proposes bounded tasks, and routes approved work to build or stewardship lanes. `docs/11_admin/LIFEOS_STATE.md` remains the canonical current-state surface; `docs/11_admin/BACKLOG.md` is the backlog summary view, not a replacement for live issue/PR readback.
 
 ## Key Relationships
 
@@ -31,24 +29,20 @@ canonical source for current phase, active WIP, and blockers.
 
 ## Authority Note
 
-Canonical sources: `docs/11_admin/LIFEOS_STATE.md` (current state) and
-`docs/11_admin/BACKLOG.md` (backlog). This page summarizes structure only; read those
-docs directly for current operational state.
+Canonical sources: `docs/11_admin/LIFEOS_STATE.md` for current operating state and `docs/11_admin/BACKLOG.md` for backlog orientation. This wiki page is derived and compact; it must not be used as completion, dispatch, or closure truth.
 
 ## Current Truth
 
 **Proposal flow:**
-1. COO reads backlog → proposes `task_proposal.v1` YAML via `lifeos coo propose`
-2. CEO approves → `ExecutionOrder` YAML created
-3. Sprint agent receives order + worktree → builds in isolation
-4. `close_build` gates (tests, quality, doc stewardship) → merged to main
+1. COO reads current state/backlog and GitHub issue evidence.
+2. CEO or governing policy approves the next bounded action when required.
+3. Build/stewardship work runs in isolated branches or worktrees.
+4. Completion requires PR/issue/check/readback evidence, not wiki text.
 
-**Auto-dispatch (L0):** `requires_approval=false` AND `risk=low` per `Intent_Routing_Rule_v1.1.md`.
+**Routing guard:** low-risk, reversible work may proceed under existing autonomy rules; CEO-level decisions still include canon promotion, financial/billing changes, external/public commitments, or irreversible operational changes.
 
-**Key files:** `docs/11_admin/LIFEOS_STATE.md` (current phase), `docs/11_admin/BACKLOG.md`
-(prioritized queue), `artifacts/active_branches.json` (in-flight builds).
+**Doc reconciliation note:** after issue #154, bus/hub/runtime documentation truth is split across LifeOS canonical docs, the operational bus issue/PR receipts, and hub accounting docs. The wiki only points to those sources.
 
 ## Open Questions
 
-For current active phase, blockers, and WIP, read `docs/11_admin/LIFEOS_STATE.md` directly —
-this page (page_class: status) only summarizes the structural flow, not current state values.
+For current active phase, blockers, and WIP, read `docs/11_admin/LIFEOS_STATE.md` and live GitHub issue/PR state directly.

--- a/.context/wiki/build-workflow.md
+++ b/.context/wiki/build-workflow.md
@@ -2,7 +2,7 @@
 source_docs:
   - docs/02_protocols/Git_Workflow_Protocol_v1.1.md
   - docs/02_protocols/Build_Handoff_Protocol_v1.1.md
-source_commit_max: df4bb54bba3a499ef8a41f4ccb711e1f59862820
+source_commit_max: 786d84b1846104b28b8bd0a718188cb2520bc057
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/coo-runtime.md
+++ b/.context/wiki/coo-runtime.md
@@ -4,7 +4,7 @@ source_docs:
   - docs/03_runtime/COO_Runtime_Core_Spec_v1.0.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
   - docs/11_admin/LIFEOS_STATE.md
-source_commit_max: 8b2fa0d4c94ffca6229b86fb83ad98970d27be1f
+source_commit_max: 560164c7180b5ce4e0e4ed7f6a0fe47407554ff8
 authority: derived
 page_class: status
 concepts:

--- a/.context/wiki/doc-stewardship.md
+++ b/.context/wiki/doc-stewardship.md
@@ -3,7 +3,7 @@ source_docs:
   - docs/02_protocols/Document_Steward_Protocol_v1.1.md
   - docs/02_protocols/Deterministic_Artefact_Protocol_v2.0.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
-source_commit_max: bf4d9ecd01e5124584e96a42b95f16c7f39e3fd2
+source_commit_max: 9eb65264ef948a4335892ab4b99d13e036019b23
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/governance-model.md
+++ b/.context/wiki/governance-model.md
@@ -3,7 +3,7 @@ source_docs:
   - docs/00_foundations/LifeOS_Constitution_v2.0.md
   - docs/02_protocols/Council_Protocol_v1.3.md
   - docs/02_protocols/Governance_Protocol_v1.0.md
-source_commit_max: e1a968bd4087d4cbe5000c04753f66b04a1594f7
+source_commit_max: 9eb65264ef948a4335892ab4b99d13e036019b23
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/home.md
+++ b/.context/wiki/home.md
@@ -3,7 +3,7 @@ source_docs:
   - docs/INDEX.md
   - docs/00_foundations/LifeOS_Constitution_v2.0.md
   - docs/10_meta/architecture_decisions/INDEX.md
-source_commit_max: ec9ba476765cf2c981f03bea46eb189f30698366
+source_commit_max: 560164c7180b5ce4e0e4ed7f6a0fe47407554ff8
 authority: derived
 page_class: evergreen
 concepts:
@@ -14,9 +14,7 @@ concepts:
 
 ## Summary
 
-Agent navigation landing page for the LifeOS wiki layer. Start here. The wiki is a
-**derived, non-authoritative** layer — canonical docs under `docs/**` always win.
-For current operational state, read `docs/11_admin/LIFEOS_STATE.md` directly.
+Agent navigation landing page for the LifeOS wiki layer. Start here, then verify substantive claims against canonical docs under `docs/**`. The wiki is **derived and non-authoritative**; canonical docs and live GitHub readback win.
 
 ## Key Relationships
 
@@ -24,7 +22,8 @@ For current operational state, read `docs/11_admin/LIFEOS_STATE.md` directly.
 - `docs/00_foundations/LifeOS_Constitution_v2.0.md` — supreme governing document
 - `docs/11_admin/LIFEOS_STATE.md` — current phase and WIP (volatile; read directly)
 - `docs/INDEX.md` — navigation index for all canonical docs
-- `docs/10_meta/architecture_decisions/INDEX.md` — ratified architecture decision register (ADR-001 through ADR-004)
+- `docs/10_meta/ARCHITECTURE_SOURCE_OF_TRUTH.md` — architecture authority map, including bus/hub/runtime reconciliation
+- `docs/10_meta/architecture_decisions/INDEX.md` — ratified architecture decision register
 
 **Wiki pages:**
 - [target-architecture](target-architecture.md) — CEO→COO→EA control-plane design
@@ -40,16 +39,13 @@ For current operational state, read `docs/11_admin/LIFEOS_STATE.md` directly.
 
 ## Authority Note
 
-Canonical source: `docs/INDEX.md` and `docs/00_foundations/LifeOS_Constitution_v2.0.md`.
-This page is a navigation aid only. All substantive claims require canonical doc verification.
+Canonical source: `docs/INDEX.md` and `docs/00_foundations/LifeOS_Constitution_v2.0.md`. This page is a navigation aid only. All architecture, governance, and completion claims require canonical doc or GitHub readback.
 
 ## Current Truth
 
-`docs/INDEX.md` is the canonical navigation surface for the documentation corpus.
-Architecture decision records live in `docs/10_meta/architecture_decisions/INDEX.md`;
-ADR-004 (Drive / Workspace Canonical Role) ratified 2026-04-26 is the newest entry.
-For active phase, blockers, and current operational state, read `docs/11_admin/LIFEOS_STATE.md`
-directly. This page is a derived landing page only.
+`docs/INDEX.md` is the canonical navigation surface for the documentation corpus. Current bus/hub/runtime reconciliation is represented in canonical LifeOS meta/admin docs and linked review packets; generated corpora and wiki pages remain derived.
+
+Architecture decision records live in `docs/10_meta/architecture_decisions/INDEX.md`. For active phase, blockers, and current operational state, read `docs/11_admin/LIFEOS_STATE.md` directly.
 
 ## Open Questions
 

--- a/.context/wiki/mission-orchestration.md
+++ b/.context/wiki/mission-orchestration.md
@@ -3,7 +3,7 @@ source_docs:
   - docs/03_runtime/COO_Runtime_Core_Spec_v1.0.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
   - docs/11_admin/LIFEOS_STATE.md
-source_commit_max: 8b2fa0d4c94ffca6229b86fb83ad98970d27be1f
+source_commit_max: 560164c7180b5ce4e0e4ed7f6a0fe47407554ff8
 authority: derived
 page_class: status
 concepts:

--- a/.context/wiki/openclaw-integration.md
+++ b/.context/wiki/openclaw-integration.md
@@ -2,7 +2,7 @@
 source_docs:
   - docs/02_protocols/OpenClaw_COO_Integration_v1.0.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
-source_commit_max: c7df98632ed6dfee99daaada103cd613dc630501
+source_commit_max: 786d84b1846104b28b8bd0a718188cb2520bc057
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/protocols-index.md
+++ b/.context/wiki/protocols-index.md
@@ -1,7 +1,7 @@
 ---
 source_docs:
   - docs/INDEX.md
-source_commit_max: ec9ba476765cf2c981f03bea46eb189f30698366
+source_commit_max: 560164c7180b5ce4e0e4ed7f6a0fe47407554ff8
 authority: derived
 page_class: evergreen
 concepts:
@@ -12,47 +12,34 @@ concepts:
 
 ## Summary
 
-Navigation index of active protocols in `docs/02_protocols/`. This page is a navigation
-aid only — it does not duplicate protocol content. For full protocol text, read the source
-docs directly.
+Navigation index of active protocols and protocol-adjacent surfaces in `docs/02_protocols/` and related meta docs. This page is a compact pointer only; it does not duplicate protocol text.
 
 ## Key Relationships
 
 - [governance-model](governance-model.md) — constitutional authority for protocols
 - [doc-stewardship](doc-stewardship.md) — document stewardship protocol
 - [build-workflow](build-workflow.md) — Git and build protocols
+- [home](home.md) — wiki navigation and authority caveats
 - Source: `docs/INDEX.md` — authoritative protocol listing
 
 ## Authority Note
 
-Canonical source: `docs/INDEX.md`. That document wins on any conflict with this page.
-Protocol versions and existence are determined by `docs/INDEX.md` and the actual files
-present in `docs/02_protocols/` — not by this wiki page.
+Canonical source: `docs/INDEX.md`. That document wins on any conflict with this page. Protocol versions and existence are determined by `docs/INDEX.md` and the actual files present under `docs/**`, not this wiki page.
 
 ## Current Truth
 
-Key active protocols (see `docs/INDEX.md` for full list):
+Key active protocol families and adjacent navigation surfaces include:
 
-| Protocol | Concern |
+| Area | Canonical source |
 |----------|---------|
-| `Build_Handoff_Protocol_v1.1.md` | Agent-to-agent handoff messaging |
-| `Document_Steward_Protocol_v1.1.md` | Document creation, indexing, sync |
-| `Git_Workflow_Protocol_v1.1.md` | Branch, merge, and commit invariants |
-| `Council_Protocol_v1.3.md` | Council composition and rulings |
-| `Governance_Protocol_v1.0.md` | Governance procedures |
-| `Deterministic_Artefact_Protocol_v2.0.md` | DAP validation |
-| `Build_Artifact_Protocol_v1.0.md` | Formal schemas/templates for build artifacts |
-| `Intent_Routing_Rule_v1.1.md` | COO agent routing decisions |
-| `LifeOS_Design_Principles_Protocol_v1.1.md` | "Prove then Harden" development principles |
-| `Emergency_Declaration_Protocol_v1.0.md` | Emergency override and auto-revert |
-| `Test_Protocol_v2.0.md` | TDD and test design standards |
-| `EOL_Policy_v1.0.md` | End-of-life handling for docs |
-| `Project_Planning_Protocol_v1.0.md` | Build mission plan requirements and review |
-| `OpenClaw_COO_Integration_v1.0.md` | OpenClaw gateway invocation and constraints |
-| `Tier-2_API_Evolution_and_Versioning_Strategy_v1.0.md` | Tier-2 API versioning, deprecation, compatibility |
-| `Filesystem_Error_Boundary_Protocol_v1.0.md` | Fail-closed filesystem error boundaries (Draft) |
+| Build handoff, Git workflow, test discipline, and DAP | `docs/02_protocols/` |
+| Council, governance, emergency, intent routing, and planning rules | `docs/02_protocols/` |
+| OpenClaw COO integration and API/versioning boundaries | `docs/02_protocols/` |
+| Work-management and workstream context | `docs/02_protocols/Work_Management_Framework_v0.1.md`, `docs/02_protocols/workstream_context_v1.md` |
+| Architecture authority and reconciliation packets | `docs/10_meta/` |
+| Current operational state | `docs/11_admin/LIFEOS_STATE.md` |
 
-For packet schemas, templates, operational guides, and architecture decisions, see subdirectories under `docs/02_protocols/` and `docs/10_meta/`.
+For packet schemas, templates, operational guides, and architecture decisions, use `docs/INDEX.md` as the canonical navigation layer.
 
 ## Open Questions
 

--- a/.context/wiki/target-architecture.md
+++ b/.context/wiki/target-architecture.md
@@ -1,7 +1,7 @@
 ---
 source_docs:
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
-source_commit_max: c7df98632ed6dfee99daaada103cd613dc630501
+source_commit_max: 786d84b1846104b28b8bd0a718188cb2520bc057
 authority: derived
 page_class: evergreen
 concepts:


### PR DESCRIPTION
## Summary
- Refreshes the derived `.context/wiki` layer after #154 doc reconciliation.
- Updates the three affected wiki pages semantically: `backlog-task-system.md`, `home.md`, and `protocols-index.md`.
- Refreshes stale `source_commit_max` values across existing wiki pages and removes `_refresh_needed`.

## Verification
- `python3 -m doc_steward.cli wiki-lint .` — PASS
- `pytest -q runtime/tests/test_wiki_lint_validator.py` — PASS (`19 passed`)
- `git diff --check` — PASS

## Notes
- Wiki remains derived/non-authoritative; canonical docs and GitHub issue/PR readback still win.

Refs marcusglee11/lifeos-operational-bus#154
