### PR TITLE
Add documentation authority registry validator

### DIFF
--- a/config/docs/authority_registry.yaml
+++ b/config/docs/authority_registry.yaml
@@ -92,7 +92,37 @@ doc_groups:
     paths:
       - docs/LifeOS_Strategic_Corpus.md
     source_paths:
-      - docs/**/*.md
+      - docs/00_foundations/*.md
+      - docs/00_foundations/**/*.md
+      - docs/01_governance/*.md
+      - docs/01_governance/**/*.md
+      - docs/02_protocols/*.md
+      - docs/02_protocols/**/*.md
+      - docs/03_runtime/*.md
+      - docs/03_runtime/**/*.md
+      - docs/04_project_builder/*.md
+      - docs/04_project_builder/**/*.md
+      - docs/05_agents/*.md
+      - docs/05_agents/**/*.md
+      - docs/06_user_surface/*.md
+      - docs/06_user_surface/**/*.md
+      - docs/08_manuals/*.md
+      - docs/08_manuals/**/*.md
+      - docs/09_prompts/*.md
+      - docs/09_prompts/**/*.md
+      - docs/10_meta/*.md
+      - docs/10_meta/**/*.md
+      - docs/11_admin/*.md
+      - docs/11_admin/**/*.md
+      - docs/12_productisation/*.md
+      - docs/12_productisation/**/*.md
+      - docs/INDEX.md
+    source_exclude_paths:
+      - docs/01_governance/_archive/**/*.md
+      - docs/02_protocols/archive/**/*.md
+      - docs/03_runtime/archive/**/*.md
+      - docs/10_meta/archive/**/*.md
+      - docs/11_admin/archive/**/*.md
     check_commands:
       - python3 docs/scripts/generate_strategic_context.py
   - id: discarded-archives

--- a/config/docs/authority_registry.yaml
+++ b/config/docs/authority_registry.yaml
@@ -1,0 +1,127 @@
+version: 1
+schema: config/schemas/doc_authority_registry_v1.json
+policy_source: https://github.com/marcusglee11/LifeOS/issues/117#issuecomment-4442005302
+notes:
+  - Central manifest is the machine authority for documentation authority class.
+  - Optional frontmatter is derivative/advisory and must match this manifest.
+  - Authority transitions use one authority_transitions record per changed path.
+baseline_lint_noise:
+  path: docs/11_admin/QUALITY_AUDIT_BASELINE_v1.0.md
+  status: advisory_for_later_work_packages
+valid_approval_evidence_types:
+  human: Human maintainer approval in GitHub issue/PR context.
+  aa: Architecture Authority review approval in GitHub issue/PR context.
+  ceo: CEO-level approval in GitHub issue/PR context.
+doc_groups:
+  - id: canonical-foundations
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/00_foundations/*.md
+      - docs/00_foundations/**/*.md
+    derived_surfaces:
+      - docs/LifeOS_Strategic_Corpus.md
+      - docs/INDEX.md
+  - id: canonical-governance
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/01_governance/*.md
+      - docs/01_governance/**/*.md
+    exclude_paths:
+      - docs/01_governance/_archive/**/*.md
+    derived_surfaces:
+      - docs/LifeOS_Strategic_Corpus.md
+      - docs/INDEX.md
+  - id: canonical-protocols
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+      - docs/02_protocols/**/*.md
+    exclude_paths:
+      - docs/02_protocols/archive/**/*.md
+    derived_surfaces:
+      - docs/LifeOS_Strategic_Corpus.md
+      - docs/INDEX.md
+  - id: canonical-runtime
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/03_runtime/*.md
+      - docs/03_runtime/**/*.md
+    exclude_paths:
+      - docs/03_runtime/archive/**/*.md
+    derived_surfaces:
+      - docs/LifeOS_Strategic_Corpus.md
+      - docs/INDEX.md
+  - id: canonical-builder-agents-surface-manuals-prompts-meta-admin-product
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/04_project_builder/*.md
+      - docs/04_project_builder/**/*.md
+      - docs/05_agents/*.md
+      - docs/05_agents/**/*.md
+      - docs/06_user_surface/*.md
+      - docs/06_user_surface/**/*.md
+      - docs/08_manuals/*.md
+      - docs/08_manuals/**/*.md
+      - docs/09_prompts/*.md
+      - docs/09_prompts/**/*.md
+      - docs/10_meta/*.md
+      - docs/10_meta/**/*.md
+      - docs/11_admin/*.md
+      - docs/11_admin/**/*.md
+      - docs/12_productisation/*.md
+      - docs/12_productisation/**/*.md
+    exclude_paths:
+      - docs/10_meta/archive/**/*.md
+      - docs/11_admin/archive/**/*.md
+    derived_surfaces:
+      - docs/LifeOS_Strategic_Corpus.md
+      - docs/INDEX.md
+  - id: canonical-root-navigation
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/INDEX.md
+  - id: derived-strategic-corpus
+    authority: derived
+    steward: Docs Steward
+    paths:
+      - docs/LifeOS_Strategic_Corpus.md
+    source_paths:
+      - docs/**/*.md
+    check_commands:
+      - python3 docs/scripts/generate_strategic_context.py
+  - id: discarded-archives
+    authority: discarded
+    steward: Docs Steward
+    paths:
+      - docs/99_archive/*.md
+      - docs/99_archive/**/*.md
+      - docs/01_governance/_archive/**/*.md
+      - docs/02_protocols/archive/**/*.md
+      - docs/03_runtime/archive/**/*.md
+      - docs/10_meta/archive/**/*.md
+      - docs/11_admin/archive/**/*.md
+  - id: proposal-and-working-material
+    authority: proposal-only
+    steward: Docs Steward
+    paths:
+      - docs/audit/*.md
+      - docs/audit/**/*.md
+      - docs/internal/*.md
+      - docs/internal/**/*.md
+      - docs/plans/*.md
+      - docs/plans/**/*.md
+      - docs/superpowers/plans/*.md
+      - docs/superpowers/plans/**/*.md
+      - docs/test/*.md
+      - docs/test/**/*.md
+      - docs/zz_scratch/*.md
+      - docs/zz_scratch/**/*.md
+      - docs/.pending_root_files/*.md
+      - docs/.pending_root_files/**/*.md
+authority_transitions: []

--- a/config/quality/manifest.yaml
+++ b/config/quality/manifest.yaml
@@ -79,6 +79,12 @@ tools:
     scopes: ["changed", "repo"]
     autofix_allowed: false
     failure_class: workstream_context_error
+  doc_authority_manifest:
+    enabled: true
+    mode: blocking
+    scopes: ["changed", "repo"]
+    autofix_allowed: false
+    failure_class: doc_authority_manifest_error
 
 waivers:
   - tool: markdownlint

--- a/config/schemas/doc_authority_registry_v1.json
+++ b/config/schemas/doc_authority_registry_v1.json
@@ -42,6 +42,10 @@
             "type": "array",
             "items": { "type": "string", "minLength": 1 }
           },
+          "source_exclude_paths": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
           "derived_surfaces": {
             "type": "array",
             "items": { "type": "string", "minLength": 1 }

--- a/config/schemas/doc_authority_registry_v1.json
+++ b/config/schemas/doc_authority_registry_v1.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lifeos.local/schemas/doc_authority_registry_v1.json",
+  "title": "LifeOS Documentation Authority Registry v1",
+  "type": "object",
+  "required": ["version", "doc_groups"],
+  "additionalProperties": true,
+  "properties": {
+    "version": { "const": 1 },
+    "schema": { "type": "string" },
+    "policy_source": { "type": "string" },
+    "baseline_lint_noise": { "type": "object" },
+    "valid_approval_evidence_types": { "type": "object" },
+    "doc_groups": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "authority", "steward", "paths"],
+        "additionalProperties": true,
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "authority": {
+            "enum": [
+              "canonical",
+              "derived",
+              "proposal-only",
+              "deferred",
+              "discarded"
+            ]
+          },
+          "steward": { "type": "string", "minLength": 1 },
+          "paths": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "exclude_paths": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "source_paths": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "derived_surfaces": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "check_commands": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "last_reviewed": { "type": "string" }
+        }
+      }
+    },
+    "authority_transitions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["changed_paths", "from", "to", "approval_evidence"],
+        "properties": {
+          "changed_paths": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": { "type": "string", "minLength": 1 }
+          },
+          "from": {
+            "enum": [
+              "canonical",
+              "derived",
+              "proposal-only",
+              "deferred",
+              "discarded"
+            ]
+          },
+          "to": {
+            "enum": [
+              "canonical",
+              "derived",
+              "proposal-only",
+              "deferred",
+              "discarded"
+            ]
+          },
+          "approval_evidence": {
+            "type": "object",
+            "required": ["type", "url", "verdict"],
+            "properties": {
+              "type": { "enum": ["human", "aa", "ceo"] },
+              "url": {
+                "type": "string",
+                "pattern": "^https://github\\.com/.+"
+              },
+              "verdict": { "const": "approved" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/doc_steward/cli.py
+++ b/doc_steward/cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: E501
 """
 doc_steward CLI — Stable command-line interface for documentation validators.
 
@@ -16,34 +17,36 @@ import argparse
 import sys
 from pathlib import Path
 
+from .admin_archive_link_ban_validator import check_admin_archive_link_ban
+from .admin_structure_validator import check_admin_structure
+from .archive_structure_validator import check_archive_structure
+from .artefact_index_validator import check_artefact_index
 from .dap_validator import check_dap_compliance
+from .doc_authority_manifest import check_doc_authority_manifest
+from .freshness_validator import check_freshness, get_freshness_mode
+from .global_archive_link_ban_validator import check_global_archive_link_ban
 from .index_checker import check_index
 from .link_checker import check_links
-from .admin_structure_validator import check_admin_structure
-from .admin_archive_link_ban_validator import check_admin_archive_link_ban
-from .freshness_validator import check_freshness, get_freshness_mode
 from .protocols_structure_validator import check_protocols_structure
 from .runtime_structure_validator import check_runtime_structure
-from .archive_structure_validator import check_archive_structure
-from .global_archive_link_ban_validator import check_global_archive_link_ban
 from .version_duplicate_detector import check_version_duplicates_with_lineage
-from .artefact_index_validator import check_artefact_index
 from .wiki_lint_validator import check_wiki_lint
+
 
 def cmd_opencode_validate(args: argparse.Namespace) -> int:
     """Run OpenCode artefact validation."""
     # args.doc_root is historically named, but here acts as repo_root or context root
     root = Path(args.doc_root).resolve()
     target = root / "artifacts" / "opencode"
-    
+
     if not target.exists():
         print(f"[FAILED] Missing required directory: {target}")
         return 1
-        
+
     if not target.is_dir():
         print(f"[FAILED] Target is not a directory: {target}")
         return 1
-        
+
     print(f"[PASSED] OpenCode artefact root exists: {target}")
     return 0
 
@@ -52,7 +55,7 @@ def cmd_dap_validate(args: argparse.Namespace) -> int:
     """Run DAP compliance validation."""
     doc_root = str(Path(args.doc_root).resolve())
     errors = check_dap_compliance(doc_root)
-    
+
     if errors:
         print(f"[FAILED] DAP validation failed ({len(errors)} errors):\n")
         for err in errors:
@@ -68,7 +71,7 @@ def cmd_index_check(args: argparse.Namespace) -> int:
     doc_root = str(Path(args.doc_root).resolve())
     index_path = str(Path(args.index_path).resolve())
     errors = check_index(doc_root, index_path)
-    
+
     if errors:
         print(f"[FAILED] Index check failed ({len(errors)} errors):\n")
         for err in errors:
@@ -219,7 +222,7 @@ def cmd_docs_archive_link_ban_check(args: argparse.Namespace) -> int:
 def cmd_artefact_index_check(args: argparse.Namespace) -> int:
     """Run artefact index validation."""
     repo_root = str(Path(args.repo_root).resolve())
-    directory = args.directory if hasattr(args, 'directory') else None
+    directory = args.directory if hasattr(args, "directory") else None
     errors = check_artefact_index(repo_root, directory)
 
     if errors:
@@ -259,24 +262,42 @@ def cmd_version_duplicate_scan(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_check_manifest(args: argparse.Namespace) -> int:
+    """Validate the central documentation authority manifest."""
+    repo_root = Path(args.repo_root).resolve()
+    errors = check_doc_authority_manifest(
+        repo_root,
+        manifest_path=args.manifest,
+        previous_manifest_path=args.previous_manifest,
+    )
+
+    if errors:
+        print(f"[FAILED] Documentation authority manifest check failed ({len(errors)} errors):\n")
+        for err in errors:
+            print(f"  * {err}")
+        return 1
+
+    print("[PASSED] Documentation authority manifest check passed.")
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
-        prog="doc_steward.cli",
-        description="LifeOS Documentation Steward CLI"
+        prog="doc_steward.cli", description="LifeOS Documentation Steward CLI"
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
-    
+
     # dap-validate
     p_dap = subparsers.add_parser("dap-validate", help="Check DAP naming compliance")
     p_dap.add_argument("doc_root", help="Root directory to validate")
     p_dap.set_defaults(func=cmd_dap_validate)
-    
+
     # index-check
     p_idx = subparsers.add_parser("index-check", help="Check index consistency")
     p_idx.add_argument("doc_root", help="Root directory of documentation")
     p_idx.add_argument("index_path", help="Path to INDEX.md file")
     p_idx.set_defaults(func=cmd_index_check)
-    
+
     # link-check
     p_link = subparsers.add_parser("link-check", help="Check for broken links")
     p_link.add_argument("doc_root", help="Root directory to validate")
@@ -288,14 +309,20 @@ def main() -> int:
     p_oc.set_defaults(func=cmd_opencode_validate)
 
     # admin-structure-check
-    p_admin_struct = subparsers.add_parser("admin-structure-check", help="Validate docs/11_admin/ structure")
+    p_admin_struct = subparsers.add_parser(
+        "admin-structure-check", help="Validate docs/11_admin/ structure"
+    )
     p_admin_struct.add_argument("repo_root", help="Repository root directory")
     p_admin_struct.set_defaults(func=cmd_admin_structure_check)
 
     # admin-archive-link-ban-check
-    p_admin_archive = subparsers.add_parser("admin-archive-link-ban-check", help="Check for links to archived docs")
+    p_admin_archive = subparsers.add_parser(
+        "admin-archive-link-ban-check", help="Check for links to archived docs"
+    )
     p_admin_archive.add_argument("repo_root", help="Repository root directory")
-    p_admin_archive.add_argument("--paths", nargs="+", default=None, help="Repo-relative paths to restrict scanning to")
+    p_admin_archive.add_argument(
+        "--paths", nargs="+", default=None, help="Repo-relative paths to restrict scanning to"
+    )
     p_admin_archive.set_defaults(func=cmd_admin_archive_link_ban_check)
 
     # freshness-check
@@ -304,30 +331,44 @@ def main() -> int:
     p_freshness.set_defaults(func=cmd_freshness_check)
 
     # protocols-structure-check
-    p_protocols = subparsers.add_parser("protocols-structure-check", help="Validate docs/02_protocols/ structure")
+    p_protocols = subparsers.add_parser(
+        "protocols-structure-check", help="Validate docs/02_protocols/ structure"
+    )
     p_protocols.add_argument("repo_root", help="Repository root directory")
     p_protocols.set_defaults(func=cmd_protocols_structure_check)
 
     # runtime-structure-check
-    p_runtime = subparsers.add_parser("runtime-structure-check", help="Validate docs/03_runtime/ structure")
+    p_runtime = subparsers.add_parser(
+        "runtime-structure-check", help="Validate docs/03_runtime/ structure"
+    )
     p_runtime.add_argument("repo_root", help="Repository root directory")
     p_runtime.set_defaults(func=cmd_runtime_structure_check)
 
     # archive-structure-check
-    p_archive = subparsers.add_parser("archive-structure-check", help="Validate docs/99_archive/ structure")
+    p_archive = subparsers.add_parser(
+        "archive-structure-check", help="Validate docs/99_archive/ structure"
+    )
     p_archive.add_argument("repo_root", help="Repository root directory")
     p_archive.set_defaults(func=cmd_archive_structure_check)
 
     # docs-archive-link-ban-check
-    p_link_ban = subparsers.add_parser("docs-archive-link-ban-check", help="Check for links to archived docs (global)")
+    p_link_ban = subparsers.add_parser(
+        "docs-archive-link-ban-check", help="Check for links to archived docs (global)"
+    )
     p_link_ban.add_argument("repo_root", help="Repository root directory")
-    p_link_ban.add_argument("--paths", nargs="+", default=None, help="Repo-relative paths to restrict scanning to")
+    p_link_ban.add_argument(
+        "--paths", nargs="+", default=None, help="Repo-relative paths to restrict scanning to"
+    )
     p_link_ban.set_defaults(func=cmd_docs_archive_link_ban_check)
 
     # artefact-index-check
-    p_artefact = subparsers.add_parser("artefact-index-check", help="Validate ARTEFACT_INDEX.json files")
+    p_artefact = subparsers.add_parser(
+        "artefact-index-check", help="Validate ARTEFACT_INDEX.json files"
+    )
     p_artefact.add_argument("repo_root", help="Repository root directory")
-    p_artefact.add_argument("--directory", help="Optional specific directory to check", default=None)
+    p_artefact.add_argument(
+        "--directory", help="Optional specific directory to check", default=None
+    )
     p_artefact.set_defaults(func=cmd_artefact_index_check)
 
     # wiki-lint
@@ -336,9 +377,28 @@ def main() -> int:
     p_wiki.set_defaults(func=cmd_wiki_lint)
 
     # version-duplicate-scan
-    p_version = subparsers.add_parser("version-duplicate-scan", help="Report version duplicates (warn-only)")
+    p_version = subparsers.add_parser(
+        "version-duplicate-scan", help="Report version duplicates (warn-only)"
+    )
     p_version.add_argument("repo_root", help="Repository root directory")
     p_version.set_defaults(func=cmd_version_duplicate_scan)
+
+    # check-manifest
+    p_manifest = subparsers.add_parser(
+        "check-manifest", help="Validate central docs authority manifest"
+    )
+    p_manifest.add_argument("repo_root", help="Repository root directory")
+    p_manifest.add_argument(
+        "--manifest",
+        default=None,
+        help="Optional manifest path; defaults to config/docs/authority_registry.yaml",
+    )
+    p_manifest.add_argument(
+        "--previous-manifest",
+        default=None,
+        help="Optional prior manifest path for protected transition checks; defaults to origin/main when available",
+    )
+    p_manifest.set_defaults(func=cmd_check_manifest)
 
     args = parser.parse_args()
     return args.func(args)

--- a/doc_steward/doc_authority_manifest.py
+++ b/doc_steward/doc_authority_manifest.py
@@ -1,0 +1,341 @@
+"""Documentation authority manifest validator.
+
+The central manifest is the machine authority for LifeOS documentation
+classification. Optional per-file frontmatter is derivative and must agree with
+this manifest.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ALLOWED_AUTHORITIES = {"canonical", "derived", "proposal-only", "deferred", "discarded"}
+ALLOWED_APPROVAL_TYPES = {"human", "aa", "ceo"}
+PROTECTED_TRANSITIONS = {
+    ("proposal-only", "canonical"),
+    ("deferred", "canonical"),
+    ("canonical", "derived"),
+    ("canonical", "proposal-only"),
+    ("canonical", "deferred"),
+    ("canonical", "discarded"),
+}
+DEFAULT_MANIFEST_PATH = Path("config/docs/authority_registry.yaml")
+DOC_PATH_RE = re.compile(r"^docs/.+\.md$")
+GITHUB_URL_RE = re.compile(r"^https://github\.com/[^/]+/[^/]+/(issues|pull)/\d+(#.*)?$")
+
+
+class AuthorityManifestError(ValueError):
+    """Raised when the manifest cannot be parsed as a mapping."""
+
+
+def check_doc_authority_manifest(
+    repo_root: str | Path,
+    manifest_path: str | Path | None = None,
+    previous_manifest_path: str | Path | None = None,
+) -> list[str]:
+    """Return validation errors for the documentation authority manifest."""
+    root = Path(repo_root).resolve()
+    rel_manifest = Path(manifest_path) if manifest_path else DEFAULT_MANIFEST_PATH
+    manifest_file = rel_manifest if rel_manifest.is_absolute() else root / rel_manifest
+    errors: list[str] = []
+
+    if not manifest_file.exists():
+        return [
+            f"{_rel(manifest_file, root)}: missing documentation authority manifest; "
+            f"create {DEFAULT_MANIFEST_PATH.as_posix()} and classify active docs."
+        ]
+
+    try:
+        payload = yaml.safe_load(manifest_file.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        return [f"{_rel(manifest_file, root)}: invalid YAML: {exc}"]
+
+    if not isinstance(payload, dict):
+        return [f"{_rel(manifest_file, root)}: manifest must be a YAML mapping"]
+
+    groups = payload.get("doc_groups", [])
+    if not isinstance(groups, list):
+        return [f"{_rel(manifest_file, root)}: doc_groups must be a list"]
+
+    coverage, authorities = _manifest_path_authorities(payload, root, errors)
+
+    previous_payload = _load_previous_manifest_payload(root, rel_manifest, previous_manifest_path)
+    if previous_payload is not None:
+        previous_errors: list[str] = []
+        _, previous_authorities = _manifest_path_authorities(
+            previous_payload, root, previous_errors
+        )
+        errors.extend(_check_manifest_authority_changes(previous_authorities, authorities, payload))
+
+    for rel_path in _active_doc_paths(root):
+        if rel_path not in coverage:
+            errors.append(
+                f"{rel_path}: missing authority classification; add it to "
+                f"{DEFAULT_MANIFEST_PATH.as_posix()} with authority, steward, and paths."
+            )
+        else:
+            frontmatter_authority = _frontmatter_authority(root / rel_path)
+            manifest_authority = authorities.get(rel_path)
+            if frontmatter_authority and frontmatter_authority != manifest_authority:
+                errors.append(
+                    f"{rel_path}: frontmatter authority '{frontmatter_authority}' "
+                    f"conflicts with manifest authority '{manifest_authority}'; update "
+                    "frontmatter or manifest so manifest wins."
+                )
+
+    errors.extend(_check_transitions(payload, root))
+    return errors
+
+
+def _manifest_path_authorities(
+    payload: dict[str, Any], root: Path, errors: list[str]
+) -> tuple[dict[str, str], dict[str, str]]:
+    coverage: dict[str, str] = {}
+    authorities: dict[str, str] = {}
+    groups = payload.get("doc_groups", [])
+    if not isinstance(groups, list):
+        return coverage, authorities
+
+    for index, group in enumerate(groups):
+        if not isinstance(group, dict):
+            errors.append(f"doc_groups[{index}]: group must be a mapping")
+            continue
+        group_id = str(group.get("id") or f"index-{index}")
+        authority = group.get("authority")
+        paths = group.get("paths", [])
+
+        if authority not in ALLOWED_AUTHORITIES:
+            errors.append(
+                f"doc_groups[{index}]/{group_id}: authority '{authority}' is invalid; "
+                f"use one of {', '.join(sorted(ALLOWED_AUTHORITIES))}."
+            )
+        if not group.get("steward"):
+            errors.append(
+                f"doc_groups[{index}]/{group_id}: missing steward; add steward owner/role."
+            )
+        if not isinstance(paths, list) or not paths:
+            errors.append(f"doc_groups[{index}]/{group_id}: paths must be a non-empty list.")
+            paths = []
+
+        if authority == "derived" and not group.get("source_paths"):
+            errors.append(
+                f"doc_groups[{index}]/{group_id}: derived group '{group_id}' must "
+                "declare source_paths; add canonical source path glob(s)."
+            )
+
+        exclude_paths = group.get("exclude_paths", []) or []
+        if not isinstance(exclude_paths, list):
+            errors.append(
+                f"doc_groups[{index}]/{group_id}: exclude_paths must be a list when present."
+            )
+            exclude_paths = []
+
+        for pattern in paths:
+            if not isinstance(pattern, str):
+                errors.append(f"doc_groups[{index}]/{group_id}: path pattern must be a string.")
+                continue
+            matched = _matching_docs(root, pattern, exclude_paths)
+            if not matched:
+                continue
+            for rel_path in matched:
+                previous = coverage.get(rel_path)
+                if previous and previous != group_id:
+                    errors.append(
+                        f"{rel_path}: classified by multiple groups ({previous}, {group_id}); "
+                        "keep exactly one authority classification."
+                    )
+                coverage[rel_path] = group_id
+                if isinstance(authority, str):
+                    authorities[rel_path] = authority
+
+    return coverage, authorities
+
+
+def _load_previous_manifest_payload(
+    root: Path, rel_manifest: Path, previous_manifest_path: str | Path | None
+) -> dict[str, Any] | None:
+    if previous_manifest_path:
+        previous_file = Path(previous_manifest_path)
+        if not previous_file.is_absolute():
+            previous_file = root / previous_file
+        if not previous_file.exists():
+            return None
+        payload = yaml.safe_load(previous_file.read_text(encoding="utf-8")) or {}
+        return payload if isinstance(payload, dict) else None
+
+    if rel_manifest.is_absolute():
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "show", f"origin/main:{rel_manifest.as_posix()}"],
+            cwd=root,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    payload = yaml.safe_load(result.stdout) or {}
+    return payload if isinstance(payload, dict) else None
+
+
+def _check_manifest_authority_changes(
+    previous_authorities: dict[str, str],
+    current_authorities: dict[str, str],
+    payload: dict[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    transition_index = _transition_index(payload)
+    for rel_path, previous_authority in sorted(previous_authorities.items()):
+        current_authority = current_authorities.get(rel_path)
+        if not current_authority or previous_authority == current_authority:
+            continue
+        if not _is_protected_transition(previous_authority, current_authority):
+            continue
+        record = transition_index.get(rel_path)
+        if record is None:
+            errors.append(
+                f"{rel_path}: authority changed from {previous_authority} to {current_authority}; "
+                "add one authority_transitions record for this path with approval_evidence."
+            )
+            continue
+        if record.get("from") != previous_authority or record.get("to") != current_authority:
+            errors.append(
+                f"{rel_path}: authority_transitions record must match manifest change "
+                f"from {previous_authority} to {current_authority}."
+            )
+    return errors
+
+
+def _transition_index(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    transitions = payload.get("authority_transitions", []) or []
+    if not isinstance(transitions, list):
+        return index
+    for record in transitions:
+        if not isinstance(record, dict):
+            continue
+        changed_paths = record.get("changed_paths", [])
+        if isinstance(changed_paths, list) and len(changed_paths) == 1:
+            index[str(changed_paths[0])] = record
+    return index
+
+
+def _check_transitions(payload: dict[str, Any], root: Path) -> list[str]:
+    errors: list[str] = []
+    transitions = payload.get("authority_transitions", []) or []
+    if not isinstance(transitions, list):
+        return ["authority_transitions: must be a list with one record per changed path."]
+
+    seen_paths: set[str] = set()
+    for index, record in enumerate(transitions):
+        if not isinstance(record, dict):
+            errors.append(f"authority_transitions[{index}]: record must be a mapping.")
+            continue
+        changed_paths = record.get("changed_paths", [])
+        from_class = record.get("from")
+        to_class = record.get("to")
+        evidence = record.get("approval_evidence") or {}
+
+        if not isinstance(changed_paths, list) or len(changed_paths) != 1:
+            errors.append(
+                f"authority_transitions[{index}]: changed_paths must contain exactly one path; "
+                "use one transition record per path."
+            )
+            paths = [f"authority_transitions[{index}]"]
+        else:
+            path = str(changed_paths[0])
+            paths = [path]
+            if path in seen_paths:
+                errors.append(
+                    f"authority transition for {path} is duplicated; keep exactly one "
+                    "authority_transitions record for this path."
+                )
+            seen_paths.add(path)
+
+        protected = _is_protected_transition(from_class, to_class)
+        if protected:
+            for rel_path in paths:
+                if evidence.get("type") not in ALLOWED_APPROVAL_TYPES:
+                    errors.append(
+                        f"authority transition for {rel_path} has invalid approval_evidence.type; "
+                        f"use one of {', '.join(sorted(ALLOWED_APPROVAL_TYPES))}."
+                    )
+                url = evidence.get("url")
+                if not isinstance(url, str) or not GITHUB_URL_RE.match(url):
+                    errors.append(
+                        f"authority transition for {rel_path} approval_evidence.url must "
+                        "be a GitHub URL to an issue/PR comment or review."
+                    )
+                if evidence.get("verdict") != "approved":
+                    errors.append(
+                        f"authority transition for {rel_path} approval_evidence.verdict "
+                        "must be approved."
+                    )
+    return errors
+
+
+def _is_protected_transition(from_class: Any, to_class: Any) -> bool:
+    if from_class == "discarded" and to_class in ALLOWED_AUTHORITIES - {"discarded"}:
+        return True
+    return (from_class, to_class) in PROTECTED_TRANSITIONS
+
+
+def _active_doc_paths(root: Path) -> list[str]:
+    docs = root / "docs"
+    if not docs.exists():
+        return []
+    return sorted(
+        path.relative_to(root).as_posix()
+        for path in docs.rglob("*.md")
+        if path.is_file() and not _is_generated_or_vendor_path(path.relative_to(root).as_posix())
+    )
+
+
+def _matching_docs(
+    root: Path, pattern: str, exclude_patterns: list[Any] | None = None
+) -> list[str]:
+    excludes = [str(item) for item in (exclude_patterns or []) if isinstance(item, str)]
+    return [
+        rel
+        for rel in _active_doc_paths(root)
+        if fnmatch.fnmatch(rel, pattern) and not any(fnmatch.fnmatch(rel, ex) for ex in excludes)
+    ]
+
+
+def _is_generated_or_vendor_path(rel_path: str) -> bool:
+    return rel_path.startswith("docs/LifeOS_Universal_Corpus.md")
+
+
+def _frontmatter_authority(path: Path) -> str | None:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return None
+    try:
+        frontmatter = yaml.safe_load(text[4:end]) or {}
+    except yaml.YAMLError:
+        return None
+    if isinstance(frontmatter, dict):
+        authority = frontmatter.get("authority")
+        if isinstance(authority, str):
+            return authority
+    return None
+
+
+def _rel(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.as_posix()

--- a/doc_steward/doc_authority_manifest.py
+++ b/doc_steward/doc_authority_manifest.py
@@ -7,13 +7,13 @@ this manifest.
 
 from __future__ import annotations
 
-import fnmatch
 import re
 import subprocess
 from pathlib import Path
 from typing import Any
 
 import yaml
+from jsonschema import Draft202012Validator
 
 ALLOWED_AUTHORITIES = {"canonical", "derived", "proposal-only", "deferred", "discarded"}
 ALLOWED_APPROVAL_TYPES = {"human", "aa", "ceo"}
@@ -64,6 +64,8 @@ def check_doc_authority_manifest(
         return [f"{_rel(manifest_file, root)}: doc_groups must be a list"]
 
     coverage, authorities = _manifest_path_authorities(payload, root, errors)
+    errors.extend(_check_schema(payload, root, manifest_file))
+    errors.extend(_check_derived_source_authority(payload, root, authorities))
 
     previous_payload = _load_previous_manifest_payload(root, rel_manifest, previous_manifest_path)
     if previous_payload is not None:
@@ -155,6 +157,59 @@ def _manifest_path_authorities(
                     authorities[rel_path] = authority
 
     return coverage, authorities
+
+
+def _check_schema(payload: dict[str, Any], root: Path, manifest_file: Path) -> list[str]:
+    schema_path = payload.get("schema")
+    if schema_path is None:
+        return []
+    if not isinstance(schema_path, str):
+        return [f"{_rel(manifest_file, root)}: schema must be a repo-relative path string."]
+    schema_file = root / schema_path
+    if not schema_file.exists():
+        return [f"{schema_path}: missing authority registry JSON schema; restore schema file."]
+    try:
+        schema = yaml.safe_load(schema_file.read_text(encoding="utf-8")) or {}
+        Draft202012Validator.check_schema(schema)
+        validator = Draft202012Validator(schema)
+        return [
+            f"{_rel(manifest_file, root)}: schema violation at "
+            f"{'.'.join(str(part) for part in error.absolute_path) or '<root>'}: {error.message}"
+            for error in sorted(validator.iter_errors(payload), key=str)
+        ]
+    except Exception as exc:
+        return [f"{schema_path}: invalid authority registry schema: {exc}"]
+
+
+def _check_derived_source_authority(
+    payload: dict[str, Any], root: Path, authorities: dict[str, str]
+) -> list[str]:
+    errors: list[str] = []
+    groups = payload.get("doc_groups", [])
+    if not isinstance(groups, list):
+        return errors
+    for index, group in enumerate(groups):
+        if not isinstance(group, dict) or group.get("authority") != "derived":
+            continue
+        group_id = str(group.get("id") or f"index-{index}")
+        source_paths = group.get("source_paths", []) or []
+        source_exclude_paths = group.get("source_exclude_paths", []) or []
+        if not isinstance(source_paths, list):
+            continue
+        if not isinstance(source_exclude_paths, list):
+            source_exclude_paths = []
+        for pattern in source_paths:
+            if not isinstance(pattern, str):
+                continue
+            for rel_path in _matching_docs(root, pattern, source_exclude_paths):
+                source_authority = authorities.get(rel_path)
+                if source_authority and source_authority != "canonical":
+                    errors.append(
+                        f"doc_groups[{index}]/{group_id}: source_paths pattern {pattern} "
+                        f"matches {rel_path} with authority {source_authority}; "
+                        "derived source_paths must resolve only to canonical docs."
+                    )
+    return errors
 
 
 def _load_previous_manifest_payload(
@@ -308,8 +363,29 @@ def _matching_docs(
     return [
         rel
         for rel in _active_doc_paths(root)
-        if fnmatch.fnmatch(rel, pattern) and not any(fnmatch.fnmatch(rel, ex) for ex in excludes)
+        if _path_matches(rel, pattern) and not any(_path_matches(rel, ex) for ex in excludes)
     ]
+
+
+def _path_matches(rel_path: str, pattern: str) -> bool:
+    regex = ""
+    index = 0
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "*":
+            if index + 1 < len(pattern) and pattern[index + 1] == "*":
+                regex += ".*"
+                index += 2
+            else:
+                regex += "[^/]*"
+                index += 1
+        elif char == "?":
+            regex += "[^/]"
+            index += 1
+        else:
+            regex += re.escape(char)
+            index += 1
+    return re.fullmatch(regex, rel_path) is not None
 
 
 def _is_generated_or_vendor_path(rel_path: str) -> bool:

--- a/runtime/tests/test_quality_gate.py
+++ b/runtime/tests/test_quality_gate.py
@@ -50,6 +50,11 @@ def test_route_quality_tools_doc_authority_manifest_change() -> None:
     assert routed["doc_authority_manifest"] == ["config/docs/authority_registry.yaml"]
 
 
+def test_route_quality_tools_doc_change_runs_doc_authority_manifest() -> None:
+    routed = route_quality_tools(Path("."), ["docs/02_protocols/example.md"], scope="changed")
+    assert routed["doc_authority_manifest"] == ["docs/02_protocols/example.md"]
+
+
 def test_route_quality_tools_wmf_workstreams_change_bypasses_artifacts_exclusion() -> None:
     routed = route_quality_tools(Path("."), ["artifacts/workstreams.yaml"], scope="changed")
     assert routed["wmf_validator"] == ["artifacts/workstreams.yaml"]

--- a/runtime/tests/test_quality_gate.py
+++ b/runtime/tests/test_quality_gate.py
@@ -43,6 +43,13 @@ def test_route_quality_tools_wmf_backlog_change() -> None:
     assert routed["wmf_validator"] == ["config/tasks/backlog.yaml"]
 
 
+def test_route_quality_tools_doc_authority_manifest_change() -> None:
+    routed = route_quality_tools(
+        Path("."), ["config/docs/authority_registry.yaml"], scope="changed"
+    )
+    assert routed["doc_authority_manifest"] == ["config/docs/authority_registry.yaml"]
+
+
 def test_route_quality_tools_wmf_workstreams_change_bypasses_artifacts_exclusion() -> None:
     routed = route_quality_tools(Path("."), ["artifacts/workstreams.yaml"], scope="changed")
     assert routed["wmf_validator"] == ["artifacts/workstreams.yaml"]

--- a/runtime/tools/workflow_pack.py
+++ b/runtime/tools/workflow_pack.py
@@ -341,7 +341,9 @@ def route_quality_tools(
             workstream_context_files.append(file_path)
             workstream_context_trigger = True
 
-        if file_path in QUALITY_DOC_AUTHORITY_MANIFEST_FILES:
+        if file_path in QUALITY_DOC_AUTHORITY_MANIFEST_FILES or (
+            suffix == ".md" and file_path.startswith("docs/")
+        ):
             doc_authority_manifest_files.append(file_path)
             doc_authority_manifest_trigger = True
 

--- a/runtime/tools/workflow_pack.py
+++ b/runtime/tools/workflow_pack.py
@@ -53,6 +53,7 @@ QUALITY_TOOL_EXECUTABLES = {
     "agent_control_plane_pin": "python3",
     "wmf_validator": "python3",
     "workstream_context": "python3",
+    "doc_authority_manifest": "python3",
 }
 QUALITY_PYTHON_CONFIG_FILES = {"pyproject.toml", "requirements.txt", "requirements-dev.txt"}
 QUALITY_BIOME_EXTENSIONS = {".js", ".jsx", ".ts", ".tsx", ".json", ".jsonc"}
@@ -83,6 +84,12 @@ QUALITY_WORKSTREAM_CONTEXT_PREFIXES = (
     "schemas/workstreams/",
     "runtime/tests/fixtures/workstreams/",
 )
+QUALITY_DOC_AUTHORITY_MANIFEST_FILES = {
+    "config/docs/authority_registry.yaml",
+    "config/schemas/doc_authority_registry_v1.json",
+    "doc_steward/doc_authority_manifest.py",
+    "tests_doc/test_doc_authority_manifest.py",
+}
 BACKLOG_METADATA_CONTINUATION_PATTERN = re.compile(
     r"^\s+[—-]+\s*(?:DoD|Why\s*Now|Owner|Context):",
     re.IGNORECASE,
@@ -286,6 +293,8 @@ def route_quality_tools(
     wmf_validator_trigger = False
     workstream_context_files: list[str] = []
     workstream_context_trigger = False
+    doc_authority_manifest_files: list[str] = []
+    doc_authority_manifest_trigger = False
 
     for file_path in files:
         path = Path(file_path)
@@ -332,6 +341,10 @@ def route_quality_tools(
             workstream_context_files.append(file_path)
             workstream_context_trigger = True
 
+        if file_path in QUALITY_DOC_AUTHORITY_MANIFEST_FILES:
+            doc_authority_manifest_files.append(file_path)
+            doc_authority_manifest_trigger = True
+
     if python_trigger:
         routed["ruff_check"] = _unique_ordered(python_files)
         routed["ruff_format"] = _unique_ordered(python_files)
@@ -350,6 +363,8 @@ def route_quality_tools(
         routed["wmf_validator"] = _unique_ordered(wmf_validator_files)
     if workstream_context_trigger and "workstream_context" in routed:
         routed["workstream_context"] = _unique_ordered(workstream_context_files)
+    if doc_authority_manifest_trigger and "doc_authority_manifest" in routed:
+        routed["doc_authority_manifest"] = _unique_ordered(doc_authority_manifest_files)
 
     return routed
 
@@ -536,6 +551,11 @@ def _build_quality_command(
         for state_path in state_paths:
             cmd.extend(["--state", state_path])
         return cmd
+
+    if tool_name == "doc_authority_manifest":
+        if scope != "repo" and not files:
+            return None
+        return ["python3", "-m", "doc_steward.cli", "check-manifest", "."]
 
     return None
 

--- a/tests_doc/test_doc_authority_manifest.py
+++ b/tests_doc/test_doc_authority_manifest.py
@@ -142,6 +142,66 @@ authority_transitions:
     )
 
 
+def test_derived_source_paths_must_resolve_to_canonical_docs(tmp_path):
+    _write(tmp_path / "docs" / "plans" / "Draft.md")
+    _write(tmp_path / "docs" / "LifeOS_Strategic_Corpus.md")
+    _manifest(
+        tmp_path,
+        """
+version: 1
+doc_groups:
+  - id: corpus
+    authority: derived
+    steward: Docs Steward
+    paths:
+      - docs/LifeOS_Strategic_Corpus.md
+    source_paths:
+      - docs/plans/*.md
+  - id: plans
+    authority: proposal-only
+    steward: Docs Steward
+    paths:
+      - docs/plans/*.md
+""",
+    )
+
+    errors = check_doc_authority_manifest(tmp_path)
+
+    assert any(
+        "source_paths pattern docs/plans/*.md matches docs/plans/Draft.md" in error
+        and "must resolve only to canonical docs" in error
+        for error in errors
+    )
+
+
+def test_manifest_schema_validation_fails_with_path(tmp_path):
+    _write(tmp_path / "docs" / "02_protocols" / "Runbook.md")
+    schema = tmp_path / "config" / "schemas" / "doc_authority_registry_v1.json"
+    schema.parent.mkdir(parents=True, exist_ok=True)
+    schema.write_text(
+        '{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"object",'
+        '"required":["version"],"properties":{"version":{"const":1}}}',
+        encoding="utf-8",
+    )
+    _manifest(
+        tmp_path,
+        """
+schema: config/schemas/doc_authority_registry_v1.json
+version: 2
+doc_groups:
+  - id: protocols
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+""",
+    )
+
+    errors = check_doc_authority_manifest(tmp_path)
+
+    assert any("schema violation at version" in error for error in errors)
+
+
 def test_duplicate_transition_records_for_same_path_fail(tmp_path):
     _write(tmp_path / "docs" / "02_protocols" / "Runbook.md")
     _manifest(

--- a/tests_doc/test_doc_authority_manifest.py
+++ b/tests_doc/test_doc_authority_manifest.py
@@ -1,0 +1,298 @@
+from pathlib import Path
+
+from doc_steward.doc_authority_manifest import check_doc_authority_manifest
+
+
+def _write(path: Path, content: str = "# Title\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _manifest(root: Path, body: str) -> Path:
+    path = root / "config" / "docs" / "authority_registry.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_unclassified_active_doc_fails_with_path_and_recovery(tmp_path):
+    _write(tmp_path / "docs" / "02_protocols" / "Runbook.md")
+    _manifest(
+        tmp_path,
+        """
+version: 1
+doc_groups: []
+""",
+    )
+
+    errors = check_doc_authority_manifest(tmp_path)
+
+    assert any("docs/02_protocols/Runbook.md" in error for error in errors)
+    assert any("add it to config/docs/authority_registry.yaml" in error for error in errors)
+
+
+def test_invalid_authority_class_fails(tmp_path):
+    _write(tmp_path / "docs" / "02_protocols" / "Runbook.md")
+    _manifest(
+        tmp_path,
+        """
+version: 1
+doc_groups:
+  - id: bad
+    authority: important
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+""",
+    )
+
+    errors = check_doc_authority_manifest(tmp_path)
+
+    assert any("authority 'important' is invalid" in error for error in errors)
+
+
+def test_derived_surface_requires_source_paths(tmp_path):
+    _write(tmp_path / "docs" / "LifeOS_Strategic_Corpus.md")
+    _manifest(
+        tmp_path,
+        """
+version: 1
+doc_groups:
+  - id: corpus
+    authority: derived
+    steward: Docs Steward
+    paths:
+      - docs/LifeOS_Strategic_Corpus.md
+    source_paths: []
+""",
+    )
+
+    errors = check_doc_authority_manifest(tmp_path)
+
+    assert any("derived group 'corpus' must declare source_paths" in error for error in errors)
+
+
+def test_frontmatter_conflict_fails_against_manifest(tmp_path):
+    _write(
+        tmp_path / "docs" / "02_protocols" / "Runbook.md",
+        """---
+authority: proposal-only
+---
+# Runbook
+""",
+    )
+    _manifest(
+        tmp_path,
+        """
+version: 1
+doc_groups:
+  - id: protocols
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+""",
+    )
+
+    errors = check_doc_authority_manifest(tmp_path)
+
+    assert any(
+        "frontmatter authority 'proposal-only' conflicts with manifest authority 'canonical'"
+        in error
+        for error in errors
+    )
+
+
+def test_protected_transition_requires_one_record_per_path_with_approval_url(tmp_path):
+    _write(tmp_path / "docs" / "02_protocols" / "Runbook.md")
+    _manifest(
+        tmp_path,
+        """
+version: 1
+doc_groups:
+  - id: protocols
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+authority_transitions:
+  - changed_paths:
+      - docs/02_protocols/Runbook.md
+    from: proposal-only
+    to: canonical
+    approval_evidence:
+      type: bot
+      url: not-a-url
+      verdict: approved
+""",
+    )
+
+    errors = check_doc_authority_manifest(tmp_path)
+
+    assert any(
+        "authority transition for docs/02_protocols/Runbook.md has invalid approval_evidence.type"
+        in error
+        for error in errors
+    )
+    assert any(
+        "authority transition for docs/02_protocols/Runbook.md approval_evidence.url" in error
+        and "must be a GitHub URL" in error
+        for error in errors
+    )
+
+
+def test_duplicate_transition_records_for_same_path_fail(tmp_path):
+    _write(tmp_path / "docs" / "02_protocols" / "Runbook.md")
+    _manifest(
+        tmp_path,
+        """
+version: 1
+doc_groups:
+  - id: protocols
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+authority_transitions:
+  - changed_paths:
+      - docs/02_protocols/Runbook.md
+    from: proposal-only
+    to: canonical
+    approval_evidence:
+      type: aa
+      url: https://github.com/marcusglee11/LifeOS/issues/117#issuecomment-1
+      verdict: approved
+  - changed_paths:
+      - docs/02_protocols/Runbook.md
+    from: deferred
+    to: canonical
+    approval_evidence:
+      type: aa
+      url: https://github.com/marcusglee11/LifeOS/issues/117#issuecomment-2
+      verdict: approved
+""",
+    )
+
+    errors = check_doc_authority_manifest(tmp_path)
+
+    assert any(
+        "authority transition for docs/02_protocols/Runbook.md is duplicated" in error
+        and "keep exactly one authority_transitions record" in error
+        for error in errors
+    )
+
+
+def test_protected_manifest_change_requires_transition_record(tmp_path):
+    _write(tmp_path / "docs" / "02_protocols" / "Runbook.md")
+    previous = tmp_path / "previous.yaml"
+    previous.write_text(
+        """
+version: 1
+doc_groups:
+  - id: protocols
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+""",
+        encoding="utf-8",
+    )
+    _manifest(
+        tmp_path,
+        """
+version: 1
+doc_groups:
+  - id: protocols
+    authority: derived
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+    source_paths:
+      - docs/01_strategy/*.md
+authority_transitions: []
+""",
+    )
+
+    errors = check_doc_authority_manifest(tmp_path, previous_manifest_path=previous)
+
+    assert any(
+        "docs/02_protocols/Runbook.md: authority changed from canonical to derived" in error
+        and "add one authority_transitions record" in error
+        for error in errors
+    )
+
+
+def test_protected_manifest_change_requires_matching_transition_record(tmp_path):
+    _write(tmp_path / "docs" / "02_protocols" / "Runbook.md")
+    previous = tmp_path / "previous.yaml"
+    previous.write_text(
+        """
+version: 1
+doc_groups:
+  - id: protocols
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+""",
+        encoding="utf-8",
+    )
+    _manifest(
+        tmp_path,
+        """
+version: 1
+doc_groups:
+  - id: protocols
+    authority: derived
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+    source_paths:
+      - docs/01_strategy/*.md
+authority_transitions:
+  - changed_paths:
+      - docs/02_protocols/Runbook.md
+    from: canonical
+    to: proposal-only
+    approval_evidence:
+      type: aa
+      url: https://github.com/marcusglee11/LifeOS/issues/117#issuecomment-1
+      verdict: approved
+""",
+    )
+
+    errors = check_doc_authority_manifest(tmp_path, previous_manifest_path=previous)
+
+    assert any(
+        "authority_transitions record must match manifest change from canonical to derived" in error
+        for error in errors
+    )
+
+
+def test_valid_manifest_passes(tmp_path):
+    _write(tmp_path / "docs" / "02_protocols" / "Runbook.md")
+    _write(tmp_path / "docs" / "LifeOS_Strategic_Corpus.md")
+    _manifest(
+        tmp_path,
+        """
+version: 1
+doc_groups:
+  - id: protocols
+    authority: canonical
+    steward: Docs Steward
+    paths:
+      - docs/02_protocols/*.md
+    derived_surfaces:
+      - docs/LifeOS_Strategic_Corpus.md
+  - id: corpus
+    authority: derived
+    steward: Docs Steward
+    paths:
+      - docs/LifeOS_Strategic_Corpus.md
+    source_paths:
+      - docs/02_protocols/*.md
+""",
+    )
+
+    assert check_doc_authority_manifest(tmp_path) == []


### PR DESCRIPTION
## Summary
- Add `config/docs/authority_registry.yaml` and JSON schema for central doc authority classification.
- Add `doc_steward check-manifest` validator for coverage, frontmatter conflicts, derived source paths, protected transitions, and one-record-per-path approval evidence.
- Route `doc_authority_manifest` as a blocking quality gate tool and cover it with tests.

## Review evidence
- OpenClaw quick review: APPROVE, blockers NONE.

## Test plan
- [x] `python3 -m ruff format doc_steward/doc_authority_manifest.py tests_doc/test_doc_authority_manifest.py doc_steward/cli.py`
- [x] `python3 -m ruff check doc_steward/doc_authority_manifest.py tests_doc/test_doc_authority_manifest.py doc_steward/cli.py`
- [x] `pytest tests_doc/test_doc_authority_manifest.py runtime/tests/test_quality_gate.py -q` (28 passed)
- [x] `python3 -m doc_steward.cli check-manifest .`
- [x] `python3 scripts/workflow/quality_gate.py check --scope changed --json` (0 blocking failures; local advisory tool-unavailable for mypy/biome/yamllint)
- [x] `pytest runtime/tests -q` (3356 passed, 7 skipped, 1 pre-existing unrelated failure: `runtime/tests/test_cli_skeleton.py::TestRepoRootDetection::test_detect_repo_root_no_marker_fails`)

Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)