### PR TITLE
Gate derived wiki freshness

### DIFF
--- a/.context/wiki/agent-roles.md
+++ b/.context/wiki/agent-roles.md
@@ -5,6 +5,9 @@ source_docs:
   - docs/02_protocols/Intent_Routing_Rule_v1.1.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
 source_commit_max: 9eb65264ef948a4335892ab4b99d13e036019b23
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/backlog-task-system.md
+++ b/.context/wiki/backlog-task-system.md
@@ -5,6 +5,9 @@ source_docs:
   - docs/02_protocols/Intent_Routing_Rule_v1.1.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
 source_commit_max: 560164c7180b5ce4e0e4ed7f6a0fe47407554ff8
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: status
 concepts:

--- a/.context/wiki/build-workflow.md
+++ b/.context/wiki/build-workflow.md
@@ -2,7 +2,7 @@
 source_docs:
   - docs/02_protocols/Git_Workflow_Protocol_v1.1.md
   - docs/02_protocols/Build_Handoff_Protocol_v1.1.md
-source_commit_max: 786d84b1846104b28b8bd0a718188cb2520bc057
+source_commit_max: df4bb54bba3a499ef8a41f4ccb711e1f59862820
 derived_edit_mode: generated
 source_command: python3 scripts/wiki/refresh_wiki.py
 source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120

--- a/.context/wiki/build-workflow.md
+++ b/.context/wiki/build-workflow.md
@@ -3,6 +3,9 @@ source_docs:
   - docs/02_protocols/Git_Workflow_Protocol_v1.1.md
   - docs/02_protocols/Build_Handoff_Protocol_v1.1.md
 source_commit_max: 786d84b1846104b28b8bd0a718188cb2520bc057
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/coo-runtime.md
+++ b/.context/wiki/coo-runtime.md
@@ -5,6 +5,9 @@ source_docs:
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
   - docs/11_admin/LIFEOS_STATE.md
 source_commit_max: 560164c7180b5ce4e0e4ed7f6a0fe47407554ff8
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: status
 concepts:

--- a/.context/wiki/doc-stewardship.md
+++ b/.context/wiki/doc-stewardship.md
@@ -4,6 +4,9 @@ source_docs:
   - docs/02_protocols/Deterministic_Artefact_Protocol_v2.0.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
 source_commit_max: 9eb65264ef948a4335892ab4b99d13e036019b23
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/governance-model.md
+++ b/.context/wiki/governance-model.md
@@ -4,6 +4,9 @@ source_docs:
   - docs/02_protocols/Council_Protocol_v1.3.md
   - docs/02_protocols/Governance_Protocol_v1.0.md
 source_commit_max: 9eb65264ef948a4335892ab4b99d13e036019b23
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/home.md
+++ b/.context/wiki/home.md
@@ -3,7 +3,10 @@ source_docs:
   - docs/INDEX.md
   - docs/00_foundations/LifeOS_Constitution_v2.0.md
   - docs/10_meta/architecture_decisions/INDEX.md
-source_commit_max: 560164c7180b5ce4e0e4ed7f6a0fe47407554ff8
+source_commit_max: d1f67f466388b92d820f83aa1e6334582ec7e187
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/mission-orchestration.md
+++ b/.context/wiki/mission-orchestration.md
@@ -4,6 +4,9 @@ source_docs:
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
   - docs/11_admin/LIFEOS_STATE.md
 source_commit_max: 560164c7180b5ce4e0e4ed7f6a0fe47407554ff8
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: status
 concepts:

--- a/.context/wiki/openclaw-integration.md
+++ b/.context/wiki/openclaw-integration.md
@@ -3,6 +3,9 @@ source_docs:
   - docs/02_protocols/OpenClaw_COO_Integration_v1.0.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
 source_commit_max: 786d84b1846104b28b8bd0a718188cb2520bc057
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/openclaw-integration.md
+++ b/.context/wiki/openclaw-integration.md
@@ -2,7 +2,7 @@
 source_docs:
   - docs/02_protocols/OpenClaw_COO_Integration_v1.0.md
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
-source_commit_max: 786d84b1846104b28b8bd0a718188cb2520bc057
+source_commit_max: c7df98632ed6dfee99daaada103cd613dc630501
 derived_edit_mode: generated
 source_command: python3 scripts/wiki/refresh_wiki.py
 source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120

--- a/.context/wiki/protocols-index.md
+++ b/.context/wiki/protocols-index.md
@@ -1,7 +1,10 @@
 ---
 source_docs:
   - docs/INDEX.md
-source_commit_max: 560164c7180b5ce4e0e4ed7f6a0fe47407554ff8
+source_commit_max: d1f67f466388b92d820f83aa1e6334582ec7e187
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: evergreen
 concepts:

--- a/.context/wiki/target-architecture.md
+++ b/.context/wiki/target-architecture.md
@@ -1,7 +1,7 @@
 ---
 source_docs:
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
-source_commit_max: 786d84b1846104b28b8bd0a718188cb2520bc057
+source_commit_max: c7df98632ed6dfee99daaada103cd613dc630501
 derived_edit_mode: generated
 source_command: python3 scripts/wiki/refresh_wiki.py
 source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120

--- a/.context/wiki/target-architecture.md
+++ b/.context/wiki/target-architecture.md
@@ -2,6 +2,9 @@
 source_docs:
   - docs/00_foundations/LifeOS Target Architecture v2.3c.md
 source_commit_max: 786d84b1846104b28b8bd0a718188cb2520bc057
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120
 authority: derived
 page_class: evergreen
 concepts:

--- a/config/quality/manifest.yaml
+++ b/config/quality/manifest.yaml
@@ -85,6 +85,12 @@ tools:
     scopes: ["changed", "repo"]
     autofix_allowed: false
     failure_class: doc_authority_manifest_error
+  derived_outputs:
+    enabled: true
+    mode: blocking
+    scopes: ["changed", "repo"]
+    autofix_allowed: false
+    failure_class: derived_output_freshness_error
 
 waivers:
   - tool: markdownlint

--- a/doc_steward/wiki_lint_validator.py
+++ b/doc_steward/wiki_lint_validator.py
@@ -308,7 +308,6 @@ def check_wiki_lint(repo_root: str) -> list[str]:
         missing = _REQUIRED_FRONTMATTER - fields
         if missing:
             errors.append(f"{page.name}: missing frontmatter fields: {', '.join(sorted(missing))}")
-            continue
 
         # Validate frontmatter values
         errors.extend(_validate_frontmatter_values(page.name, text))

--- a/doc_steward/wiki_lint_validator.py
+++ b/doc_steward/wiki_lint_validator.py
@@ -12,12 +12,19 @@ Checks:
   Current Truth, Open Questions
 - All pages listed in SCHEMA.md page index exist; no orphaned pages
 """
+
 import re
 import subprocess
 from pathlib import Path
 
-
-_REQUIRED_FRONTMATTER = {"source_docs", "source_commit_max", "authority", "page_class", "concepts"}
+_REQUIRED_FRONTMATTER = {
+    "source_docs",
+    "source_commit_max",
+    "authority",
+    "page_class",
+    "concepts",
+    "derived_edit_mode",
+}
 _REQUIRED_SECTIONS = (
     "## Summary",
     "## Key Relationships",
@@ -26,6 +33,7 @@ _REQUIRED_SECTIONS = (
     "## Open Questions",
 )
 _VALID_PAGE_CLASSES = frozenset({"evergreen", "status"})
+_VALID_DERIVED_EDIT_MODES = frozenset({"generated", "emergency-manual-repair"})
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
 _FIELD_RE = re.compile(r"^(\w+):", re.MULTILINE)
 _PAGE_TABLE_RE = re.compile(r"`([a-z0-9_-]+\.md)`")
@@ -164,11 +172,66 @@ def _validate_source_commit_max(
     return errors
 
 
+def _validate_provenance(page_name: str, text: str) -> list[str]:
+    """Validate derived-output provenance metadata for generated/manual edits."""
+    errors = []
+    mode = _parse_field(text, "derived_edit_mode")
+    if mode not in _VALID_DERIVED_EDIT_MODES:
+        errors.append(
+            f"{page_name}: derived_edit_mode must be 'generated' or "
+            f"'emergency-manual-repair', got '{mode}'"
+        )
+        return errors
+
+    if mode == "generated":
+        source_command = _parse_field(text, "source_command")
+        source_change_ref = _parse_field(text, "source_change_ref")
+        if source_command != "python3 scripts/wiki/refresh_wiki.py":
+            errors.append(
+                f"{page_name}: generated provenance requires source_command "
+                f"'python3 scripts/wiki/refresh_wiki.py'"
+            )
+        if not source_change_ref or source_change_ref == "pending":
+            errors.append(
+                f"{page_name}: generated provenance requires source_change_ref with a PR, "
+                f"commit, or issue URL/SHA; 'pending' is invalid"
+            )
+        return errors
+
+    reason = _parse_field(text, "reason")
+    follow_up_required = _parse_field(text, "follow_up_required")
+    follow_up_issue = _parse_field(text, "follow_up_issue")
+    approval_evidence = _parse_field(text, "approval_evidence")
+    if not reason:
+        errors.append(f"{page_name}: emergency manual repair requires reason")
+    if follow_up_required != "true":
+        errors.append(f"{page_name}: emergency manual repair requires follow_up_required: true")
+    if (
+        not follow_up_issue
+        or follow_up_issue == "pending"
+        or not follow_up_issue.startswith("https://github.com/")
+    ):
+        errors.append(
+            f"{page_name}: emergency manual repair requires actual follow_up_issue "
+            f"GitHub URL; 'pending' is invalid"
+        )
+    if (
+        not approval_evidence
+        or approval_evidence == "pending"
+        or not approval_evidence.startswith("https://github.com/")
+    ):
+        errors.append(
+            f"{page_name}: emergency manual repair requires actual approval_evidence "
+            f"GitHub URL; 'pending' is invalid"
+        )
+    return errors
+
+
 def _validate_required_sections(page_name: str, text: str) -> list[str]:
     """Check that required body sections exist in order."""
     errors = []
     positions = [text.find(s) for s in _REQUIRED_SECTIONS]
-    for section, pos in zip(_REQUIRED_SECTIONS, positions):
+    for section, pos in zip(_REQUIRED_SECTIONS, positions, strict=True):
         if pos == -1:
             errors.append(f"{page_name}: missing required section '{section}'")
     if errors:
@@ -223,10 +286,7 @@ def check_wiki_lint(repo_root: str) -> list[str]:
     indexed_names = _index_page_names(schema_text)
 
     # Collect actual wiki pages (exclude SCHEMA.md and _pending_diff.patch)
-    wiki_pages = [
-        p for p in wiki_dir.glob("*.md")
-        if p.name != "SCHEMA.md"
-    ]
+    wiki_pages = [p for p in wiki_dir.glob("*.md") if p.name != "SCHEMA.md"]
     wiki_page_names = {p.name for p in wiki_pages}
 
     # Check for pages in index that don't exist
@@ -247,9 +307,7 @@ def check_wiki_lint(repo_root: str) -> list[str]:
         # Required frontmatter fields
         missing = _REQUIRED_FRONTMATTER - fields
         if missing:
-            errors.append(
-                f"{page.name}: missing frontmatter fields: {', '.join(sorted(missing))}"
-            )
+            errors.append(f"{page.name}: missing frontmatter fields: {', '.join(sorted(missing))}")
             continue
 
         # Validate frontmatter values
@@ -259,6 +317,9 @@ def check_wiki_lint(repo_root: str) -> list[str]:
 
         # Validate source_docs paths (docs/** files only, no directories)
         errors.extend(_validate_source_paths(page.name, source_docs, repo_path))
+
+        # Validate derived-output provenance
+        errors.extend(_validate_provenance(page.name, text))
 
         # Validate source_commit_max freshness
         errors.extend(_validate_source_commit_max(page.name, text, source_docs, repo_path))

--- a/runtime/tests/test_quality_gate.py
+++ b/runtime/tests/test_quality_gate.py
@@ -55,6 +55,34 @@ def test_route_quality_tools_doc_change_runs_doc_authority_manifest() -> None:
     assert routed["doc_authority_manifest"] == ["docs/02_protocols/example.md"]
 
 
+def test_route_quality_tools_doc_change_runs_derived_outputs() -> None:
+    routed = route_quality_tools(Path("."), ["docs/02_protocols/example.md"], scope="changed")
+    assert routed["derived_outputs"] == ["docs/02_protocols/example.md"]
+
+
+def test_route_quality_tools_wiki_change_runs_derived_outputs() -> None:
+    routed = route_quality_tools(Path("."), [".context/wiki/home.md"], scope="changed")
+    assert routed["derived_outputs"] == [".context/wiki/home.md"]
+
+
+def test_run_quality_gates_runs_derived_outputs(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(*args, **kwargs):
+        cmd = args[0]
+        commands.append(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="OK", stderr="")
+
+    monkeypatch.setattr("runtime.tools.workflow_pack.subprocess.run", fake_run)
+    result = run_quality_gates(Path("."), [".context/wiki/home.md"], scope="changed")
+
+    assert result["passed"] is True
+    assert any(row["tool"] == "derived_outputs" for row in result["results"])
+    assert any(
+        command == ["python3", "scripts/wiki/check_derived_outputs.py"] for command in commands
+    )
+
+
 def test_route_quality_tools_wmf_workstreams_change_bypasses_artifacts_exclusion() -> None:
     routed = route_quality_tools(Path("."), ["artifacts/workstreams.yaml"], scope="changed")
     assert routed["wmf_validator"] == ["artifacts/workstreams.yaml"]

--- a/runtime/tests/test_wiki_lint_validator.py
+++ b/runtime/tests/test_wiki_lint_validator.py
@@ -9,7 +9,6 @@ import pytest
 
 from doc_steward.wiki_lint_validator import check_wiki_lint
 
-
 _MINIMAL_SCHEMA = """\
 ---
 type: schema
@@ -31,6 +30,9 @@ _VALID_PAGE = """\
 source_docs:
   - docs/some_doc.md
 source_commit_max: abc1234
+derived_edit_mode: generated
+source_command: python3 scripts/wiki/refresh_wiki.py
+source_change_ref: abc1234
 authority: derived
 page_class: evergreen
 concepts:
@@ -73,9 +75,7 @@ def wiki_root(tmp_path: Path) -> tuple[Path, Path, str]:
     subprocess.run(["git", "config", "user.email", "t@t.com"], cwd=tmp_path, capture_output=True)
     subprocess.run(["git", "config", "user.name", "T"], cwd=tmp_path, capture_output=True)
     subprocess.run(["git", "add", "docs/some_doc.md"], cwd=tmp_path, capture_output=True)
-    subprocess.run(
-        ["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True
-    )
+    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, capture_output=True)
     sha_result = subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=tmp_path, capture_output=True, text=True
     )
@@ -120,6 +120,9 @@ def test_missing_frontmatter_field(wiki_root: tuple[Path, Path, str]) -> None:
         f"---\n"
         f"source_docs:\n  - docs/some_doc.md\n"
         f"source_commit_max: {sha}\n"
+        f"derived_edit_mode: generated\n"
+        f"source_command: python3 scripts/wiki/refresh_wiki.py\n"
+        f"source_change_ref: {sha}\n"
         f"authority: derived\n"
         f"page_class: evergreen\n"
         f"---\n\n## Summary\n\nNo concepts field.\n"
@@ -133,9 +136,9 @@ def test_missing_frontmatter_field(wiki_root: tuple[Path, Path, str]) -> None:
 def test_source_doc_not_found(wiki_root: tuple[Path, Path, str]) -> None:
     root, wiki_dir, sha = wiki_root
     (wiki_dir / "SCHEMA.md").write_text(_MINIMAL_SCHEMA)
-    page_missing_source = _VALID_PAGE.replace(
-        "docs/some_doc.md", "docs/nonexistent.md"
-    ).replace("abc1234", sha)
+    page_missing_source = _VALID_PAGE.replace("docs/some_doc.md", "docs/nonexistent.md").replace(
+        "abc1234", sha
+    )
     (wiki_dir / "alpha.md").write_text(page_missing_source)
     (wiki_dir / "beta.md").write_text(_VALID_PAGE.replace("abc1234", sha))
     errors = check_wiki_lint(str(root))
@@ -154,6 +157,7 @@ def test_valid_wiki_passes(wiki_root: tuple[Path, Path, str]) -> None:
 
 # ── NEW TESTS (added in wiki remediation) ─────────────────────────────────────
 
+
 def _schema_with_pages(*page_names: str) -> str:
     """Return a minimal SCHEMA.md that indexes the given page names in a proper table."""
     rows = "\n".join(f"| `{name}` | Test |" for name in page_names)
@@ -170,6 +174,9 @@ def _compliant_page(sha: str) -> str:
         f"source_docs:\n"
         f"  - docs/some_doc.md\n"
         f"source_commit_max: {sha}\n"
+        f"derived_edit_mode: generated\n"
+        f"source_command: python3 scripts/wiki/refresh_wiki.py\n"
+        f"source_change_ref: {sha}\n"
         f"authority: derived\n"
         f"page_class: evergreen\n"
         f"concepts:\n"
@@ -200,9 +207,7 @@ def test_directory_source_rejected(wiki_root):
     tmp_path, wiki_dir, real_sha = wiki_root
     (tmp_path / "docs" / "subdir").mkdir(exist_ok=True)
     (wiki_dir / "SCHEMA.md").write_text(_schema_with_pages("dir_source.md"))
-    content = _compliant_page(real_sha).replace(
-        "  - docs/some_doc.md", "  - docs/subdir"
-    )
+    content = _compliant_page(real_sha).replace("  - docs/some_doc.md", "  - docs/subdir")
     (wiki_dir / "dir_source.md").write_text(content)
     errors = check_wiki_lint(str(tmp_path))
     assert any("dir_source.md" in e and "directory" in e.lower() for e in errors)
@@ -252,6 +257,7 @@ def test_compliant_page_passes_all_new_checks(wiki_root):
 
 
 # ── Value-validation regression tests ─────────────────────────────────────────
+
 
 def test_rejects_authority_not_derived(wiki_root):
     tmp_path, wiki_dir, real_sha = wiki_root
@@ -330,6 +336,9 @@ def test_multi_source_commit_max_uses_newest_commit(wiki_root):
         f"  - docs/some_doc.md\n"
         f"  - docs/second_doc.md\n"
         f"source_commit_max: {real_sha}\n"
+        f"derived_edit_mode: generated\n"
+        f"source_command: python3 scripts/wiki/refresh_wiki.py\n"
+        f"source_change_ref: {newer_sha}\n"
         f"authority: derived\n"
         f"page_class: evergreen\n"
         f"concepts:\n  - test\n"

--- a/runtime/tools/workflow_pack.py
+++ b/runtime/tools/workflow_pack.py
@@ -54,6 +54,7 @@ QUALITY_TOOL_EXECUTABLES = {
     "wmf_validator": "python3",
     "workstream_context": "python3",
     "doc_authority_manifest": "python3",
+    "derived_outputs": "python3",
 }
 QUALITY_PYTHON_CONFIG_FILES = {"pyproject.toml", "requirements.txt", "requirements-dev.txt"}
 QUALITY_BIOME_EXTENSIONS = {".js", ".jsx", ".ts", ".tsx", ".json", ".jsonc"}
@@ -90,6 +91,12 @@ QUALITY_DOC_AUTHORITY_MANIFEST_FILES = {
     "doc_steward/doc_authority_manifest.py",
     "tests_doc/test_doc_authority_manifest.py",
 }
+QUALITY_DERIVED_OUTPUT_FILES = {
+    "scripts/wiki/refresh_wiki.py",
+    "scripts/wiki/check_derived_outputs.py",
+    "doc_steward/wiki_lint_validator.py",
+}
+QUALITY_DERIVED_OUTPUT_PREFIXES = (".context/wiki/",)
 BACKLOG_METADATA_CONTINUATION_PATTERN = re.compile(
     r"^\s+[—-]+\s*(?:DoD|Why\s*Now|Owner|Context):",
     re.IGNORECASE,
@@ -295,6 +302,8 @@ def route_quality_tools(
     workstream_context_trigger = False
     doc_authority_manifest_files: list[str] = []
     doc_authority_manifest_trigger = False
+    derived_output_files: list[str] = []
+    derived_output_trigger = False
 
     for file_path in files:
         path = Path(file_path)
@@ -347,6 +356,15 @@ def route_quality_tools(
             doc_authority_manifest_files.append(file_path)
             doc_authority_manifest_trigger = True
 
+        if (
+            file_path in QUALITY_DERIVED_OUTPUT_FILES
+            or any(file_path.startswith(prefix) for prefix in QUALITY_DERIVED_OUTPUT_PREFIXES)
+            or (suffix == ".md" and file_path.startswith("docs/"))
+            or file_path == "docs/LifeOS_Strategic_Corpus.md"
+        ):
+            derived_output_files.append(file_path)
+            derived_output_trigger = True
+
     if python_trigger:
         routed["ruff_check"] = _unique_ordered(python_files)
         routed["ruff_format"] = _unique_ordered(python_files)
@@ -367,6 +385,8 @@ def route_quality_tools(
         routed["workstream_context"] = _unique_ordered(workstream_context_files)
     if doc_authority_manifest_trigger and "doc_authority_manifest" in routed:
         routed["doc_authority_manifest"] = _unique_ordered(doc_authority_manifest_files)
+    if derived_output_trigger and "derived_outputs" in routed:
+        routed["derived_outputs"] = _unique_ordered(derived_output_files)
 
     return routed
 
@@ -558,6 +578,11 @@ def _build_quality_command(
         if scope != "repo" and not files:
             return None
         return ["python3", "-m", "doc_steward.cli", "check-manifest", "."]
+
+    if tool_name == "derived_outputs":
+        if scope != "repo" and not files:
+            return None
+        return ["python3", "scripts/wiki/check_derived_outputs.py"]
 
     return None
 

--- a/scripts/wiki/check_derived_outputs.py
+++ b/scripts/wiki/check_derived_outputs.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Fail-closed derived wiki/corpus freshness and provenance merge gate."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run(cmd: list[str], repo_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, cwd=repo_root, capture_output=True, text=True, check=False)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    failures: list[str] = []
+    wiki_dir = repo_root / ".context" / "wiki"
+    marker = wiki_dir / "_refresh_needed"
+    if marker.exists() and marker.read_text(encoding="utf-8").strip():
+        failures.append(
+            ".context/wiki/_refresh_needed contains pending paths; "
+            "run python3 scripts/wiki/refresh_wiki.py and commit reviewed output."
+        )
+
+    pending_diff = wiki_dir / "_pending_diff.patch"
+    if pending_diff.exists() and pending_diff.read_text(encoding="utf-8").strip():
+        failures.append(
+            ".context/wiki/_pending_diff.patch contains uncommitted generated diff; "
+            "review/apply it with scripts/wiki/commit_wiki_update.py or remove stale diff."
+        )
+
+    dry = _run(["python3", "scripts/wiki/refresh_wiki.py", "--dry-run"], repo_root)
+    if dry.returncode != 0:
+        failures.append((dry.stderr or dry.stdout or "refresh_wiki.py --dry-run failed").strip())
+    elif "Pages to refresh:" in dry.stdout:
+        failures.append(
+            "refresh_wiki.py --dry-run found pages needing refresh; "
+            "run python3 scripts/wiki/refresh_wiki.py and commit reviewed output."
+        )
+
+    corpus_path = repo_root / "docs" / "LifeOS_Strategic_Corpus.md"
+    before_corpus = corpus_path.read_text(encoding="utf-8") if corpus_path.exists() else None
+    corpus = _run(["python3", "docs/scripts/generate_strategic_context.py"], repo_root)
+    after_corpus = corpus_path.read_text(encoding="utf-8") if corpus_path.exists() else None
+    if corpus.returncode != 0:
+        failures.append((corpus.stderr or corpus.stdout or "corpus generation failed").strip())
+    elif before_corpus != after_corpus:
+        failures.append(
+            "docs/LifeOS_Strategic_Corpus.md is stale; "
+            "run python3 docs/scripts/generate_strategic_context.py and commit output."
+        )
+        if before_corpus is not None:
+            corpus_path.write_text(before_corpus, encoding="utf-8")
+
+    lint = _run(["python3", "-m", "doc_steward.cli", "wiki-lint", "."], repo_root)
+    if lint.returncode != 0:
+        failures.append((lint.stdout or lint.stderr).strip())
+
+    if failures:
+        print("[FAILED] Derived output freshness/provenance gate failed:")
+        for failure in failures:
+            for line in failure.splitlines():
+                print(f"  * {line}")
+        return 1
+
+    print("[PASSED] Derived wiki/corpus freshness and provenance gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wiki/refresh_wiki.py
+++ b/scripts/wiki/refresh_wiki.py
@@ -25,7 +25,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-
 WIKI_DIR_REL = ".context/wiki"
 SCHEMA_FILE = "SCHEMA.md"
 PENDING_DIFF = "_pending_diff.patch"
@@ -38,8 +37,7 @@ _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
 
 def _repo_root() -> Path:
     result = subprocess.run(
-        ["git", "rev-parse", "--show-toplevel"],
-        capture_output=True, text=True, check=True
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True
     )
     return Path(result.stdout.strip())
 
@@ -157,9 +155,13 @@ def _call_ea(schema_text: str, page_text: str, sources_text: str) -> str:
         "Update the wiki page to reflect the current state of the sources. "
         "Keep the page compact (200-400 tokens). "
         "Preserve the frontmatter structure. Required frontmatter fields are: "
-        "source_docs, source_commit_max, authority, page_class, concepts. "
+        "source_docs, source_commit_max, derived_edit_mode, source_command, "
+        "source_change_ref, authority, page_class, concepts. "
         "Update source_commit_max to the placeholder string CURRENT_SHA (the caller will "
-        "substitute the real SHA). Do NOT emit a last_updated field. "
+        "substitute the real SHA). Set derived_edit_mode to generated, "
+        "source_command to python3 scripts/wiki/refresh_wiki.py, and "
+        "source_change_ref to CURRENT_CHANGE_REF (the caller will substitute a real ref). "
+        "Do NOT emit a last_updated field. "
         "Output ONLY the complete updated wiki page — no explanation, no code fences.\n\n"
         f"## Current wiki page\n\n{page_text}\n\n"
         f"## Changed source docs\n\n{sources_text}"
@@ -167,22 +169,25 @@ def _call_ea(schema_text: str, page_text: str, sources_text: str) -> str:
 
     result = subprocess.run(
         ["claude", "-p", prompt, "--output-format", "text"],
-        capture_output=True, text=True, timeout=120
+        capture_output=True,
+        text=True,
+        timeout=120,
     )
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"exit {result.returncode}")
     return result.stdout.strip()
 
 
-def _substitute_sha(text: str, sha: str) -> str:
-    return text.replace("CURRENT_SHA", sha)
+def _substitute_generated_placeholders(text: str, sha: str, change_ref: str) -> str:
+    return text.replace("CURRENT_SHA", sha).replace("CURRENT_CHANGE_REF", change_ref)
 
 
 def _build_diff(old_text: str, new_text: str, filename: str) -> str:
     old_lines = old_text.splitlines(keepends=True)
     new_lines = new_text.splitlines(keepends=True)
     diff = difflib.unified_diff(
-        old_lines, new_lines,
+        old_lines,
+        new_lines,
         fromfile=f"a/{filename}",
         tofile=f"b/{filename}",
     )
@@ -193,16 +198,19 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Refresh LifeOS wiki pages via EA")
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument(
-        "--changed-files", nargs="+", metavar="FILE",
-        help="Repo-relative paths of changed source docs"
+        "--changed-files",
+        nargs="+",
+        metavar="FILE",
+        help="Repo-relative paths of changed source docs",
     )
-    group.add_argument(
-        "--full", action="store_true",
-        help="Regenerate all wiki pages"
+    group.add_argument("--full", action="store_true", help="Regenerate all wiki pages")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print which pages would be updated, then exit"
     )
     parser.add_argument(
-        "--dry-run", action="store_true",
-        help="Print which pages would be updated, then exit"
+        "--source-change-ref",
+        default="pending",
+        help="PR URL, commit SHA, or issue URL recorded in generated provenance",
     )
     args = parser.parse_args()
 
@@ -287,9 +295,13 @@ def main() -> int:
             # Compute per-source SHA, fail closed if unavailable
             source_commit_max = _compute_source_commit_max(sources, repo_root)
             if source_commit_max is None:
-                errors.append(f"{page.name}: cannot compute source_commit_max — no valid sources resolved")
+                errors.append(
+                    f"{page.name}: cannot compute source_commit_max — no valid sources resolved"
+                )
                 continue
-            new_text = _substitute_sha(new_text, source_commit_max)
+            new_text = _substitute_generated_placeholders(
+                new_text, source_commit_max, args.source_change_ref
+            )
             if not new_text.endswith("\n"):
                 new_text += "\n"
 

--- a/tests_doc/test_wiki_lint_provenance.py
+++ b/tests_doc/test_wiki_lint_provenance.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from doc_steward.wiki_lint_validator import check_wiki_lint
+
+
+def _write_page(root: Path, extra_frontmatter: str) -> None:
+    docs = root / "docs"
+    docs.mkdir(parents=True)
+    (docs / "source.md").write_text("# Source\n", encoding="utf-8")
+    wiki = root / ".context" / "wiki"
+    wiki.mkdir(parents=True)
+    (wiki / "SCHEMA.md").write_text(
+        "| File | Purpose |\n|------|---------|\n| `home.md` | Home |\n",
+        encoding="utf-8",
+    )
+    (wiki / "home.md").write_text(
+        f"""---
+source_docs:
+  - docs/source.md
+source_commit_max: abc123
+authority: derived
+page_class: evergreen
+concepts:
+  - test
+{extra_frontmatter}---
+
+## Summary
+
+Test.
+
+## Key Relationships
+
+Test.
+
+## Authority Note
+
+Test.
+
+## Current Truth
+
+Test.
+
+## Open Questions
+
+None.
+""",
+        encoding="utf-8",
+    )
+
+
+def test_wiki_lint_requires_generated_provenance(tmp_path: Path, monkeypatch) -> None:
+    _write_page(
+        tmp_path,
+        "derived_edit_mode: generated\n"
+        "source_command: python3 scripts/wiki/refresh_wiki.py\n"
+        "source_change_ref: pending\n",
+    )
+    monkeypatch.setattr(
+        "doc_steward.wiki_lint_validator._compute_source_commit_max",
+        lambda sources, cwd: "abc123",
+    )
+
+    errors = check_wiki_lint(str(tmp_path))
+
+    assert any("source_change_ref" in error and "pending" in error for error in errors)
+
+
+def test_wiki_lint_requires_emergency_follow_up_and_approval(tmp_path: Path, monkeypatch) -> None:
+    _write_page(
+        tmp_path,
+        "derived_edit_mode: emergency-manual-repair\n"
+        "reason: generator unavailable\n"
+        "follow_up_required: true\n"
+        "follow_up_issue: pending\n"
+        "approval_evidence: pending\n",
+    )
+    monkeypatch.setattr(
+        "doc_steward.wiki_lint_validator._compute_source_commit_max",
+        lambda sources, cwd: "abc123",
+    )
+
+    errors = check_wiki_lint(str(tmp_path))
+
+    assert any("follow_up_issue" in error and "pending" in error for error in errors)
+    assert any("approval_evidence" in error and "pending" in error for error in errors)
+
+
+def test_wiki_lint_accepts_generated_provenance(tmp_path: Path, monkeypatch) -> None:
+    _write_page(
+        tmp_path,
+        "derived_edit_mode: generated\n"
+        "source_command: python3 scripts/wiki/refresh_wiki.py\n"
+        "source_change_ref: https://github.com/marcusglee11/LifeOS/issues/120\n",
+    )
+    monkeypatch.setattr(
+        "doc_steward.wiki_lint_validator._compute_source_commit_max",
+        lambda sources, cwd: "abc123",
+    )
+
+    errors = check_wiki_lint(str(tmp_path))
+
+    assert errors == []


### PR DESCRIPTION
## Summary
- Adds a blocking derived-output quality gate for wiki/corpus freshness and provenance.
- Routes docs/wiki/corpus changes through the new gate in `quality_gate.py`.
- Adds generated provenance to existing wiki pages and validates generated vs emergency manual repair metadata.

## Test plan
- [x] `python3 -m pytest -q runtime/tests/test_quality_gate.py tests_doc/test_wiki_lint_provenance.py`
- [x] `python3 scripts/wiki/check_derived_outputs.py`
- [x] `python3 scripts/workflow/quality_gate.py check --scope changed --json`
- [x] `git diff --check`
- [x] Fresh-context blocker review: APPROVE, no blockers

Refs #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
