### PR TITLE
fix(coo): correct telegram model prefix openai-codex to openai (#770)

### DIFF
--- a/config/coo/telegram_model.json
+++ b/config/coo/telegram_model.json
@@ -1,10 +1,10 @@
 {
-  "primary": "openai-codex/gpt-5.4",
+  "primary": "openai/gpt-5.4",
   "fallbacks": [
-    "openai-codex/gpt-5.3-codex",
-    "openai-codex/gpt-5.1",
-    "openai-codex/gpt-5.1-codex-max",
-    "github-copilot/gpt-5-mini",
-    "google-gemini-cli/gemini-3-flash-preview"
+    "openai/gpt-5.5",
+    "openai/gpt-5.4-mini",
+    "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-v4-pro",
+    "openrouter/auto"
   ]
 }


### PR DESCRIPTION
## Fix

Telegram bot failed to start because \`config/coo/telegram_model.json\` specified \`openai-codex/*\` models which are not in OpenClaw allowed models list.

## Changes
- Updated primary from \`openai-codex/gpt-5.4\` to \`openai/gpt-5.4\`
- Updated fallbacks to use models actually configured in OpenClaw (\`openai/*\`, \`deepseek/*\`, \`openrouter/auto\`)

## Verification
- Service restarted: \`systemctl --user restart lifeos-coo-telegram.service\`
- Status: \`active (running)\` — confirmed stable 15+ seconds
- No bootstrap errors in journal

Closes #770